### PR TITLE
Powercube chain offset fix

### DIFF
--- a/schunk_powercube_chain/common/include/schunk_powercube_chain/PowerCubeCtrl.h
+++ b/schunk_powercube_chain/common/include/schunk_powercube_chain/PowerCubeCtrl.h
@@ -250,6 +250,26 @@ public:
 
 	void updateVelocities(std::vector<double> pos_temp, double delta_t);
 
+	/*!
+	 * \brief Map an external position to an internal position.
+	 *
+	 * Apply the provided offset to the external position to get an internal position.
+	 * An external position is a position which is communicated through this class'
+	 * API. (e.g. from a ROS or OROCOS component). An internal position is a
+	 * position that is read from or written to the hardware module.
+	 */
+	double mapToInternalPosition(double external_pos, double offset);
+
+	/*!
+	 * \brief Map an internal position to an external position.
+	 *
+	 * Apply the provided offset to the internal position to get an external position.
+	 * An external position is a position which is communicated through this class'
+	 * API. (e.g. from a ROS or OROCOS component). An internal position is a
+	 * position that is read from or written to the hardware module.
+	 */
+	double mapToExternalPosition(double internal_pos, double offset);
+
 protected:
 	pthread_mutex_t m_mutex;
 

--- a/schunk_powercube_chain/common/src/PowerCubeCtrl.cpp
+++ b/schunk_powercube_chain/common/src/PowerCubeCtrl.cpp
@@ -1349,6 +1349,22 @@ bool PowerCubeCtrl::doHoming()
 }
 
 /*!
+ * \brief Map an external position to an internal position.
+ */
+double PowerCubeCtrl::mapToInternalPosition(double external_pos, double offset)
+{
+  return external_pos - offset;
+}
+
+/*!
+ * \brief Map an internal position to an external position.
+ */
+double PowerCubeCtrl::mapToExternalPosition(double internal_pos, double offset)
+{
+  return internal_pos + offset;
+}
+
+/*!
  * \brief Setup errors for diagnostics
  */
 bool m_TranslateError2Diagnosics(std::ostringstream* errorMsg)


### PR DESCRIPTION
We had the following issue with the tray: It was disconnected from the power supply for a longer time and lost its internal calibration. Therefore, we wanted to add the calibration offset in the calibration.urdf.xacro of COB3-1. Then however, the tray was not moving anymore, because the limits were not calculate correctly.

This pull request adds two helper functions, which allow the conversion between joint encoder values and ROS joint values, which are semantically easier to understand than adding or subtracting offsets. For our robot, this solves the issue which we had with the tray. The torso (without calibration offsets, but using the same code) is still working, though.
