### PR TITLE
/diagnostics as global topic

### DIFF
--- a/schunk_powercube_chain/ros/src/schunk_powercube_chain.cpp
+++ b/schunk_powercube_chain/ros/src/schunk_powercube_chain.cpp
@@ -139,7 +139,7 @@ public:
     /// implementation of topics to publish
     topicPub_JointState_ = n_.advertise<sensor_msgs::JointState> ("joint_states", 1);
     topicPub_ControllerState_ = n_.advertise<control_msgs::JointTrajectoryControllerState> ("state", 1);
-    topicPub_Diagnostic_ = n_.advertise<diagnostic_msgs::DiagnosticArray>("diagnostics", 1);
+    topicPub_Diagnostic_ = n_.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 1);
 
     /// implementation of topics to subscribe
     topicSub_CommandPos_ = n_.subscribe("command_pos", 1, &PowerCubeChainNode::topicCallback_CommandPos, this);

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -167,7 +167,7 @@ class SdhNode
 			nh_ = ros::NodeHandle ("~");
 			isError_ = false;
 			// diagnostics
-			topicPub_Diagnostics_ = nh_.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 1);
+			topicPub_Diagnostics_ = nh_.advertise<diagnostic_msgs::DiagnosticArray>("diagnostics", 1);
 
 		}
 


### PR DESCRIPTION
should not be  /diagnostics a global topic? Do we need a different /component_name/diagnostics topic per component?
