### PR TITLE
Format according to roscpp style guide, in line with ipa320 setup guideline

### DIFF
--- a/schunk_sdh/CMakeLists.txt
+++ b/schunk_sdh/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(schunk_sdh)
 
-find_package(catkin REQUIRED COMPONENTS actionlib cob_srvs control_msgs diagnostic_msgs libntcan libpcan message_generation roscpp sensor_msgs std_msgs std_srvs trajectory_msgs urdf)
+find_package(catkin REQUIRED COMPONENTS actionlib cob_srvs control_msgs diagnostic_msgs libntcan libpcan message_generation roscpp roslint sensor_msgs std_msgs std_srvs trajectory_msgs urdf)
 
 find_package(Boost REQUIRED)
 
@@ -67,3 +67,5 @@ install(TARGETS ${PROJECT_NAME} sdh_only dsa_only
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+### LINT ###
+roslint_cpp(ros/src/sdh.cpp ros/src/dsa_only.cpp ros/src/sdh_only.cpp)

--- a/schunk_sdh/common/include/schunk_sdh/basisdef.h
+++ b/schunk_sdh/common/include/schunk_sdh/basisdef.h
@@ -58,7 +58,7 @@ typedef unsigned __int32 UInt32;      //!< unsigned integer, size 4 Byte (32 Bit
 // using the typenames from stdint.h should work even on 64-Bit systems...
 #include <stdint.h>
 typedef int8_t           Int8;        //!< signed integer, size 1 Byte (8 Bit)
-typedef uint8_t          UInt8;	      //!< unsigned integer, size 1 Byte (8 Bit)
+typedef uint8_t          UInt8;       //!< unsigned integer, size 1 Byte (8 Bit)
 typedef int16_t          Int16;       //!< signed integer, size 2 Byte (16 Bit)
 typedef uint16_t         UInt16;      //!< unsigned integer, size 2 Byte (16 Bit)
 typedef int32_t          Int32;       //!< signed integer, size 4 Byte (32 Bit)

--- a/schunk_sdh/common/include/schunk_sdh/canserial-esd.h
+++ b/schunk_sdh/common/include/schunk_sdh/canserial-esd.h
@@ -75,9 +75,9 @@ class cCANSerial_ESD_Internal;
 class VCC_EXPORT cCANSerial_ESDException: public cSerialBaseException
 {
 public:
-    cCANSerial_ESDException( cMsg const & _msg )
-        : cSerialBaseException( "cCANSerial_ESDException", _msg )
-    {}
+  cCANSerial_ESDException(cMsg const & _msg)
+    : cSerialBaseException("cCANSerial_ESDException", _msg)
+  {}
 };
 //======================================================================
 
@@ -99,120 +99,120 @@ class VCC_EXPORT cCANSerial_ESD : public cSerialBase
 
 protected:
 
-    //! the ESD CAN net to use
-    int net;
+  //! the ESD CAN net to use
+  int net;
 
-    //! the baudrate to use in bit/s
-    unsigned long baudrate;
+  //! the baudrate to use in bit/s
+  unsigned long baudrate;
 
-    //! the CAN ID used for reading
-    int id_read;
+  //! the CAN ID used for reading
+  int id_read;
 
-    //! the CAN ID used for writing
-    int id_write;
+  //! the CAN ID used for writing
+  int id_write;
 
-    // ntcan_handle was removed from here, see class comment and GetHandle()
+  // ntcan_handle was removed from here, see class comment and GetHandle()
 
-    //! Translate a baudrate given as unsigned long into a baudrate code for struct termios
-    unsigned int BaudrateToBaudrateCode( unsigned long baudrate )
-        throw (cCANSerial_ESDException*);
+  //! Translate a baudrate given as unsigned long into a baudrate code for struct termios
+  unsigned int BaudrateToBaudrateCode(unsigned long baudrate)
+  throw (cCANSerial_ESDException*);
 
-    int status;
+  int status;
 
 private:
-    //! ptr to private, implementation specific members (using the 'Pimpl' (pointer to implementatino) design pattern)
-    cCANSerial_ESD_Internal* pimpl;
+  //! ptr to private, implementation specific members (using the 'Pimpl' (pointer to implementatino) design pattern)
+  cCANSerial_ESD_Internal* pimpl;
 
-    //! private copy constructor without implementation, since copying of cCANSerial_ESD objects makes no sense
-    cCANSerial_ESD( cCANSerial_ESD const& other );
+  //! private copy constructor without implementation, since copying of cCANSerial_ESD objects makes no sense
+  cCANSerial_ESD(cCANSerial_ESD const& other);
 
-    //! private copy assignment operator without implementation, since copying of cCANSerial_ESD objects makes no sense
-    cCANSerial_ESD& operator=( cCANSerial_ESD const& rhs );
+  //! private copy assignment operator without implementation, since copying of cCANSerial_ESD objects makes no sense
+  cCANSerial_ESD& operator=(cCANSerial_ESD const& rhs);
 
 public:
-    /*!
-      Constructor: constructs an object to communicate with an %SDH via CAN bus using an
-      ESD CAN card.
+  /*!
+    Constructor: constructs an object to communicate with an %SDH via CAN bus using an
+    ESD CAN card.
 
-      \param _net      - the ESD CAN net to use
-      \param _baudrate - the baudrate in bit/s. Only some bitrates are valid: (1000000,800000,500000,250000,125000,100000,50000,20000,10000)
-      \param _timeout  - the timeout in seconds (0 for no timeout = wait for ever)
-      \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID)
-      \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID)
-     */
-    cCANSerial_ESD( int _net, unsigned long _baudrate, double _timeout, int _id_read, int _id_write )
-        throw (cCANSerial_ESDException*);
+    \param _net      - the ESD CAN net to use
+    \param _baudrate - the baudrate in bit/s. Only some bitrates are valid: (1000000,800000,500000,250000,125000,100000,50000,20000,10000)
+    \param _timeout  - the timeout in seconds (0 for no timeout = wait for ever)
+    \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID)
+    \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID)
+   */
+  cCANSerial_ESD(int _net, unsigned long _baudrate, double _timeout, int _id_read, int _id_write)
+  throw (cCANSerial_ESDException*);
 
-    /*!
-      Constructor: constructs an object to communicate with an %SDH via CAN bus using an
-      ESD CAN card by reusing an already existing handle.
+  /*!
+    Constructor: constructs an object to communicate with an %SDH via CAN bus using an
+    ESD CAN card by reusing an already existing handle.
 
-      \param _ntcan_handle - the ESD CAN handle to reuse (please cast your NTCAN_HANDLE to tDeviceHandle! It is save to do that!)
-      \param _timeout  - the timeout in seconds (0 for no timeout = wait for ever)
-      \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID)
-      \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID)
-     */
-    cCANSerial_ESD( tDeviceHandle _ntcan_handle, double _timeout, int _id_read, int _id_write )
-        throw (cCANSerial_ESDException*);
+    \param _ntcan_handle - the ESD CAN handle to reuse (please cast your NTCAN_HANDLE to tDeviceHandle! It is save to do that!)
+    \param _timeout  - the timeout in seconds (0 for no timeout = wait for ever)
+    \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID)
+    \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID)
+   */
+  cCANSerial_ESD(tDeviceHandle _ntcan_handle, double _timeout, int _id_read, int _id_write)
+  throw (cCANSerial_ESDException*);
 
-    //! destructor: clean up
-    ~cCANSerial_ESD();
+  //! destructor: clean up
+  ~cCANSerial_ESD();
 
-    /*!
-      Open the device as configured by the parameters given to the constructor
-    */
-    void Open( void )
-        throw (cCANSerial_ESDException*);
+  /*!
+    Open the device as configured by the parameters given to the constructor
+  */
+  void Open(void)
+  throw (cCANSerial_ESDException*);
 
-    //! Return true if interface to CAN ESD is open
-    bool IsOpen( void )
-        throw();
+  //! Return true if interface to CAN ESD is open
+  bool IsOpen(void)
+  throw();
 
-    //! Close the previously opened CAN ESD interface port.
-    void Close( void )
-        throw (cCANSerial_ESDException*);
+  //! Close the previously opened CAN ESD interface port.
+  void Close(void)
+  throw (cCANSerial_ESDException*);
 
-    //! Write data to a previously opened port.
-    /*!
-      Write \a len bytes from \a *ptr to the CAN device
+  //! Write data to a previously opened port.
+  /*!
+    Write \a len bytes from \a *ptr to the CAN device
 
-      \param ptr - pointer the byte array to send in memory
-      \param len - number of bytes to send
+    \param ptr - pointer the byte array to send in memory
+    \param len - number of bytes to send
 
-      \return the number of bytes actually written
-    */
-    int write( char const *ptr, int len=0 )
-        throw (cCANSerial_ESDException*);
+    \return the number of bytes actually written
+  */
+  int write(char const *ptr, int len = 0)
+  throw (cCANSerial_ESDException*);
 
-    /*!
-      Read data from device. This function waits until \a max_time_us us passed or
-      the expected number of bytes are received via serial line.
-      if (\a return_on_less_data is true (default value), the number of bytes
-      that have been received are returned and the data is stored in \a data
-      If the \a return_on_less_data is false, data is only read from serial line, if at least
-      \a size bytes are available.
-    */
-    ssize_t Read( void *data, ssize_t size, long timeout_us, bool return_on_less_data )
-        throw (cCANSerial_ESDException*);
+  /*!
+    Read data from device. This function waits until \a max_time_us us passed or
+    the expected number of bytes are received via serial line.
+    if (\a return_on_less_data is true (default value), the number of bytes
+    that have been received are returned and the data is stored in \a data
+    If the \a return_on_less_data is false, data is only read from serial line, if at least
+    \a size bytes are available.
+  */
+  ssize_t Read(void *data, ssize_t size, long timeout_us, bool return_on_less_data)
+  throw (cCANSerial_ESDException*);
 
-    //! set the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
-    void SetTimeout( double _timeout )
-        throw (cSerialBaseException*);
+  //! set the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
+  void SetTimeout(double _timeout)
+  throw (cSerialBaseException*);
 
-    /*!
-     * Overloaded helper function that returns the last ESD error number.
-     */
-    virtual tErrorCode GetErrorNumber();
+  /*!
+   * Overloaded helper function that returns the last ESD error number.
+   */
+  virtual tErrorCode GetErrorNumber();
 
-    /*!
-     * Overloaded helper function that returns an ESD error message for ESD error code dw.
-     *
-     * \remark The string returned will be overwritten by the next call to the function
-     */
-    virtual char const* GetErrorMessage( tErrorCode dw );
+  /*!
+   * Overloaded helper function that returns an ESD error message for ESD error code dw.
+   *
+   * \remark The string returned will be overwritten by the next call to the function
+   */
+  virtual char const* GetErrorMessage(tErrorCode dw);
 
-    //! return the internally used NTCAN_HANDLE cast to a tDeviceHandle
-    tDeviceHandle GetHandle();
+  //! return the internally used NTCAN_HANDLE cast to a tDeviceHandle
+  tDeviceHandle GetHandle();
 };
 //======================================================================
 

--- a/schunk_sdh/common/include/schunk_sdh/canserial-peak.h
+++ b/schunk_sdh/common/include/schunk_sdh/canserial-peak.h
@@ -55,9 +55,9 @@ class cCANSerial_PEAK_Internal;
 class VCC_EXPORT cCANSerial_PEAKException: public cSerialBaseException
 {
 public:
-   cCANSerial_PEAKException( cMsg const & _msg )
-       : cSerialBaseException( "cCANSerial_PEAKException", _msg )
-   {}
+  cCANSerial_PEAKException(cMsg const & _msg)
+    : cSerialBaseException("cCANSerial_PEAKException", _msg)
+  {}
 };
 //======================================================================
 
@@ -80,123 +80,123 @@ class VCC_EXPORT cCANSerial_PEAK : public cSerialBase
 
 protected:
 
-    //! the baudrate to use in bit/s
-    unsigned long baudrate;
+  //! the baudrate to use in bit/s
+  unsigned long baudrate;
 
-    //! the CAN ID used for reading
-    int id_read;
+  //! the CAN ID used for reading
+  int id_read;
 
-    //! the CAN ID used for writing
-    int id_write;
+  //! the CAN ID used for writing
+  int id_write;
 
-    // handle was removed from here, see class comment and GetHandle()
+  // handle was removed from here, see class comment and GetHandle()
 
-    //! Translate a baudrate given as unsigned long into a baudrate code for struct termios
-    int BaudrateToBaudrateCode( unsigned long baudrate )
-    throw (cCANSerial_PEAKException*);
+  //! Translate a baudrate given as unsigned long into a baudrate code for struct termios
+  int BaudrateToBaudrateCode(unsigned long baudrate)
+  throw (cCANSerial_PEAKException*);
 
-    char m_device[64];
+  char m_device[64];
 
 private:
-    //! ptr to private, implementation specific members (using the 'Pimpl' (pointer to implementatino) design pattern)
-    cCANSerial_PEAK_Internal* pimpl;
+  //! ptr to private, implementation specific members (using the 'Pimpl' (pointer to implementatino) design pattern)
+  cCANSerial_PEAK_Internal* pimpl;
 
-    //! private copy constructor without implementation, since copying of cCANSerial_PEAK objects makes no sense
-    cCANSerial_PEAK( cCANSerial_PEAK const& other );
+  //! private copy constructor without implementation, since copying of cCANSerial_PEAK objects makes no sense
+  cCANSerial_PEAK(cCANSerial_PEAK const& other);
 
-    //! private copy assignment operator without implementation, since copying of cCANSerial_PEAK objects makes no sense
-    cCANSerial_PEAK& operator=( cCANSerial_PEAK const& rhs );
+  //! private copy assignment operator without implementation, since copying of cCANSerial_PEAK objects makes no sense
+  cCANSerial_PEAK& operator=(cCANSerial_PEAK const& rhs);
 
 public:
-    /*!
-    Constructor: constructs an object to communicate with an SDH via CAN bus using a
-    PEAK CAN card.
+  /*!
+  Constructor: constructs an object to communicate with an SDH via CAN bus using a
+  PEAK CAN card.
 
-    \param _baudrate - the baudrate in bit/s. Only some bitrates are valid: (1000000,800000,500000,250000,125000,100000,50000,20000,10000)
+  \param _baudrate - the baudrate in bit/s. Only some bitrates are valid: (1000000,800000,500000,250000,125000,100000,50000,20000,10000)
+  \param _timeout  - the timeout in seconds (0 for no timeout = wait for ever)
+  \param _id_read  - the CAN ID to use for reading (The SDH sends data on this ID)
+   \param _id_write - the CAN ID to use for writing (The SDH receives data on this ID)
+   \param device    - the name of the char device to communicate with the PEAD driver (Needed on Linux only!)
+  */
+  cCANSerial_PEAK(unsigned long _baudrate, double _timeout, int _id_read, int _id_write, const char *device = "/dev/pcanusb0")
+  throw (cCANSerial_PEAKException*);
+
+  /*!
+    Constructor: constructs an object to communicate with an SDH via CAN bus using a
+    PEAK CAN card by reusing an already existing handle (will work in Linux only).
+
+    \param _peak_handle   - the PEAK CAN handle to reuse (Works on Linux only!)
     \param _timeout  - the timeout in seconds (0 for no timeout = wait for ever)
     \param _id_read  - the CAN ID to use for reading (The SDH sends data on this ID)
-     \param _id_write - the CAN ID to use for writing (The SDH receives data on this ID)
-     \param device    - the name of the char device to communicate with the PEAD driver (Needed on Linux only!)
-    */
-   cCANSerial_PEAK( unsigned long _baudrate, double _timeout, int _id_read, int _id_write, const char *device="/dev/pcanusb0" )
-       throw (cCANSerial_PEAKException*);
-
-   /*!
-     Constructor: constructs an object to communicate with an SDH via CAN bus using a
-     PEAK CAN card by reusing an already existing handle (will work in Linux only).
-
-     \param _peak_handle   - the PEAK CAN handle to reuse (Works on Linux only!)
-     \param _timeout  - the timeout in seconds (0 for no timeout = wait for ever)
-     \param _id_read  - the CAN ID to use for reading (The SDH sends data on this ID)
-     \param _id_write - the CAN ID to use for writing (The SDH receives data on this ID)
-    */
-   cCANSerial_PEAK( tDeviceHandle _peak_handle, double _timeout, int _id_read, int _id_write )
-       throw (cCANSerial_PEAKException*);
-
-   //! destructor: clean up
-   ~cCANSerial_PEAK();
-
-   /*!
-    * Return the value of the HANDLE to the actual CAN device.
-    * Works on Linux only! Only returns a valid handle after a call to Open()!
-    *
-    * \remark The returned handle can be used to open a connection to a second SDH on the same CAN bus
-    * @return the handle to the actual CAN device
-    */
-   tDeviceHandle GetHandle();
-
-   /*!
-     Open the device as configured by the parameters given to the constructor
+    \param _id_write - the CAN ID to use for writing (The SDH receives data on this ID)
    */
-   void Open( void )
-       throw (cCANSerial_PEAKException*);
+  cCANSerial_PEAK(tDeviceHandle _peak_handle, double _timeout, int _id_read, int _id_write)
+  throw (cCANSerial_PEAKException*);
 
-   //! Return true if interface to CAN PEAK is open
-   bool IsOpen( void )
-       throw();
+  //! destructor: clean up
+  ~cCANSerial_PEAK();
 
-   //! Close the previously opened CAN PEAK interface port.
-   void Close( void )
-       throw (cCANSerial_PEAKException*);
-
-   //! Write data to a previously opened port.
-   /*!
-     Write \a len bytes from \a *ptr to the CAN device
-
-     \param ptr - pointer the byte array to send in memory
-     \param len - number of bytes to send
-
-     \return the number of bytes actually written
+  /*!
+   * Return the value of the HANDLE to the actual CAN device.
+   * Works on Linux only! Only returns a valid handle after a call to Open()!
+   *
+   * \remark The returned handle can be used to open a connection to a second SDH on the same CAN bus
+   * @return the handle to the actual CAN device
    */
-   int write( char const *ptr, int len=0 )
-       throw (cCANSerial_PEAKException*);
+  tDeviceHandle GetHandle();
 
-   /*!
-     Read data from device. This function waits until \a max_time_us us passed or
-     the expected number of bytes are received via serial line.
-     if (\a return_on_less_data is true (default value), the number of bytes
-     that have been received are returned and the data is stored in \a data
-     If the \a return_on_less_data is false, data is only read from serial line, if at least
-     \a size bytes are available.
+  /*!
+    Open the device as configured by the parameters given to the constructor
+  */
+  void Open(void)
+  throw (cCANSerial_PEAKException*);
+
+  //! Return true if interface to CAN PEAK is open
+  bool IsOpen(void)
+  throw();
+
+  //! Close the previously opened CAN PEAK interface port.
+  void Close(void)
+  throw (cCANSerial_PEAKException*);
+
+  //! Write data to a previously opened port.
+  /*!
+    Write \a len bytes from \a *ptr to the CAN device
+
+    \param ptr - pointer the byte array to send in memory
+    \param len - number of bytes to send
+
+    \return the number of bytes actually written
+  */
+  int write(char const *ptr, int len = 0)
+  throw (cCANSerial_PEAKException*);
+
+  /*!
+    Read data from device. This function waits until \a max_time_us us passed or
+    the expected number of bytes are received via serial line.
+    if (\a return_on_less_data is true (default value), the number of bytes
+    that have been received are returned and the data is stored in \a data
+    If the \a return_on_less_data is false, data is only read from serial line, if at least
+    \a size bytes are available.
+  */
+  ssize_t Read(void *data, ssize_t size, long timeout_us, bool return_on_less_data)
+  throw (cCANSerial_PEAKException*);
+
+  //! set the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
+  void SetTimeout(double _timeout)
+  throw (cSerialBaseException*);
+
+  /*!
+   * Overloaded helper function that returns the last Peak error number.
    */
-   ssize_t Read( void *data, ssize_t size, long timeout_us, bool return_on_less_data )
-       throw (cCANSerial_PEAKException*);
+  virtual tErrorCode GetErrorNumber();
 
-   //! set the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
-   void SetTimeout( double _timeout )
-       throw (cSerialBaseException*);
-
-   /*!
-    * Overloaded helper function that returns the last Peak error number.
-    */
-   virtual tErrorCode GetErrorNumber();
-
-   /*!
-    * Overloaded helper function that returns a PEAK error message for error code dw.
-    *
-    * \remark The string returned will be overwritten by the next call to the function
-    */
-   virtual char const* GetErrorMessage( tErrorCode dw );
+  /*!
+   * Overloaded helper function that returns a PEAK error message for error code dw.
+   *
+   * \remark The string returned will be overwritten by the next call to the function
+   */
+  virtual char const* GetErrorMessage(tErrorCode dw);
 
 };
 //======================================================================

--- a/schunk_sdh/common/include/schunk_sdh/crc.h
+++ b/schunk_sdh/common/include/schunk_sdh/crc.h
@@ -72,73 +72,73 @@ typedef UInt16 tCRCValue;   //!< the data type used to calculate and exchange CR
 // Class declarations
 //----------------------------------------------------------------------
 
- /*!
-     \brief Cyclic Redundancy Code checker class, used for protecting communication against transmission errors.
+/*!
+    \brief Cyclic Redundancy Code checker class, used for protecting communication against transmission errors.
 
-     Generic class to calculate a CRC using a given, precalculated table.
+    Generic class to calculate a CRC using a given, precalculated table.
 
-     Use derived classes like cCRC_DSACON32m with a specifically set CRC table.
- */
+    Use derived classes like cCRC_DSACON32m with a specifically set CRC table.
+*/
 class VCC_EXPORT cCRC
 {
- protected:
-    //! current value of the CRC checksum
-    tCRCValue current_crc;
+protected:
+  //! current value of the CRC checksum
+  tCRCValue current_crc;
 
-    //! initial value of the CRC checksum
-    tCRCValue initial_value;
+  //! initial value of the CRC checksum
+  tCRCValue initial_value;
 
-    //! table with precalculated CRC values
-    tCRCValue const* crc_table;
+  //! table with precalculated CRC values
+  tCRCValue const* crc_table;
 
- public:
-    //! constructor: create a new cCRC object and initialize the current value of the CRC checksum. \a crc_table is the CRC table to use.
-    cCRC( tCRCValue const* _crc_table, tCRCValue _initial_value )
-    {
-        crc_table     = _crc_table;
-        initial_value = _initial_value;
-        current_crc   = initial_value;
-    }
+public:
+  //! constructor: create a new cCRC object and initialize the current value of the CRC checksum. \a crc_table is the CRC table to use.
+  cCRC(tCRCValue const* _crc_table, tCRCValue _initial_value)
+  {
+    crc_table     = _crc_table;
+    initial_value = _initial_value;
+    current_crc   = initial_value;
+  }
 
-    //! insert byte into CRC calculation and return the new current CRC checksum
-    tCRCValue AddByte( unsigned char byte )
-    {
-        current_crc = ( (current_crc & 0xFF00) >> 8 ) ^ crc_table[ ( current_crc & 0x00FF ) ^ (byte & 0x00FF)];
-        return current_crc;
-    }
+  //! insert byte into CRC calculation and return the new current CRC checksum
+  tCRCValue AddByte(unsigned char byte)
+  {
+    current_crc = ((current_crc & 0xFF00) >> 8) ^ crc_table[(current_crc & 0x00FF) ^ (byte & 0x00FF)];
+    return current_crc;
+  }
 
-    //! insert \a nb_bytes from \a bytes into CRC calculation and return the new current CRC checksum
-    tCRCValue AddBytes( unsigned char* bytes, int nb_bytes )
-    {
-        for ( int i=0; i<nb_bytes; i++ )
-            current_crc = ( (current_crc & 0xFF00) >> 8 ) ^ crc_table[ ( current_crc & 0x00FF ) ^ (bytes[i] & 0x00FF)];
-        return current_crc;
-    }
+  //! insert \a nb_bytes from \a bytes into CRC calculation and return the new current CRC checksum
+  tCRCValue AddBytes(unsigned char* bytes, int nb_bytes)
+  {
+    for (int i = 0; i < nb_bytes; i++)
+      current_crc = ((current_crc & 0xFF00) >> 8) ^ crc_table[(current_crc & 0x00FF) ^ (bytes[i] & 0x00FF)];
+    return current_crc;
+  }
 
-    //! return the current CRC value
-    inline tCRCValue GetCRC()
-    {
-        return current_crc;
-    }
+  //! return the current CRC value
+  inline tCRCValue GetCRC()
+  {
+    return current_crc;
+  }
 
-    //! return the low byte of the current CRC value
-    inline UInt8 GetCRC_LB()
-    {
-        return current_crc & 0x00ff;
-    }
+  //! return the low byte of the current CRC value
+  inline UInt8 GetCRC_LB()
+  {
+    return current_crc & 0x00ff;
+  }
 
-    //! return the high byte of the current CRC value
-    inline UInt8 GetCRC_HB()
-    {
-        return (current_crc >> 8) & 0x00ff;
-    }
+  //! return the high byte of the current CRC value
+  inline UInt8 GetCRC_HB()
+  {
+    return (current_crc >> 8) & 0x00ff;
+  }
 
-    //! reset the current CRC value to its initial value and return it;
-    inline tCRCValue Reset()
-    {
-        current_crc = initial_value;
-        return current_crc;
-    }
+  //! reset the current CRC value to its initial value and return it;
+  inline tCRCValue Reset()
+  {
+    current_crc = initial_value;
+    return current_crc;
+  }
 };
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
@@ -146,17 +146,17 @@ class VCC_EXPORT cCRC
 //! A derived CRC class that uses a CRC table and initial value suitable for the Weiss Robotics DSACON32m controller
 class VCC_EXPORT cCRC_DSACON32m : public cCRC
 {
- protected:
-    //! the CRC table used by the DSACON32m controller
-    static tCRCValue const crc_table_dsacon32m[256];
+protected:
+  //! the CRC table used by the DSACON32m controller
+  static tCRCValue const crc_table_dsacon32m[256];
 
- public:
-    //! constructor to create a cCRC object suitable for checksumming the communication with a DSACON32m tactile sensor controller
-    inline cCRC_DSACON32m( void )
-        : cCRC( crc_table_dsacon32m, 0xffff )
-    {
-        // nothing more to do
-    }
+public:
+  //! constructor to create a cCRC object suitable for checksumming the communication with a DSACON32m tactile sensor controller
+  inline cCRC_DSACON32m(void)
+    : cCRC(crc_table_dsacon32m, 0xffff)
+  {
+    // nothing more to do
+  }
 };
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
@@ -169,13 +169,13 @@ class VCC_EXPORT cCRC_DSACON32m : public cCRC
  */
 class VCC_EXPORT cCRC_SDH : public cCRC_DSACON32m
 {
- public:
-    //! constructor to create a cCRC object suitable for checksumming the binary communication with SDH
-    inline cCRC_SDH( void )
-        : cCRC_DSACON32m()
-    {
-        // nothing more to do
-    }
+public:
+  //! constructor to create a cCRC object suitable for checksumming the binary communication with SDH
+  inline cCRC_SDH(void)
+    : cCRC_DSACON32m()
+  {
+    // nothing more to do
+  }
 };
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------

--- a/schunk_sdh/common/include/schunk_sdh/dbg.h
+++ b/schunk_sdh/common/include/schunk_sdh/dbg.h
@@ -113,214 +113,214 @@ NAMESPACE_SDH_START
 class VCC_EXPORT cDBG
 {
 protected:
-    char const*   debug_color;
-    char const*   normal_color;
-    std::ostream *output;
-    bool          debug_flag;
-    std::streamsize mywidth;
+  char const*   debug_color;
+  char const*   normal_color;
+  std::ostream *output;
+  bool          debug_flag;
+  std::streamsize mywidth;
 public:
 
-    /*!
-    * constructor: construct a cDBG object
-    *
-    * \param flag - the initial state of the flag, if true then messages sent
-    *               to the object are printed. Default is false. Can be changed with SetFlag()
-    * \param color - the name of the color to use, default is "red". Can be changed with SetColor()
-    * \param fd    - the ostream to use for output, default is stderr. Can be changed with SetOutput()
-    */
-    cDBG( bool flag=false, char const* color="red", std::ostream *fd=&std::cerr )
-    {
-        debug_flag     = flag;
-        SetColor( color );
-        output         = fd;
-        mywidth = output->width();
-    }
-    //---------------------
+  /*!
+  * constructor: construct a cDBG object
+  *
+  * \param flag - the initial state of the flag, if true then messages sent
+  *               to the object are printed. Default is false. Can be changed with SetFlag()
+  * \param color - the name of the color to use, default is "red". Can be changed with SetColor()
+  * \param fd    - the ostream to use for output, default is stderr. Can be changed with SetOutput()
+  */
+  cDBG(bool flag = false, char const* color = "red", std::ostream *fd = &std::cerr)
+  {
+    debug_flag     = flag;
+    SetColor(color);
+    output         = fd;
+    mywidth = output->width();
+  }
+  //---------------------
 
-    ~cDBG()
-    {
-        output->flush();
-    }
+  ~cDBG()
+  {
+    output->flush();
+  }
 
-    /*!
-    * Set debug_flag of this cDBG object to flag. After setting
-    * the flag to true debug messages are printed, else not.
-    */
-    void SetFlag( bool flag )
-    {
-        debug_flag  = flag;
-    }
+  /*!
+  * Set debug_flag of this cDBG object to flag. After setting
+  * the flag to true debug messages are printed, else not.
+  */
+  void SetFlag(bool flag)
+  {
+    debug_flag  = flag;
+  }
 
 
-    /*!
-    * Get debug_flag of this cDBG object.
-    */
-    bool GetFlag( void ) const
-    {
-        return debug_flag;
-    }
+  /*!
+  * Get debug_flag of this cDBG object.
+  */
+  bool GetFlag(void) const
+  {
+    return debug_flag;
+  }
 
-    /*!
-    * Set debug_color of this cDBG object to color.
-    * color is a string like "red", see util.py for valid names.
-    *
-    * \attention
-    * The string is \b NOT copied, just a pointer is stored
-    */
-    void SetColor( char const* color )
-    {
-        debug_color = GetColor( color );
-        if ( !strcmp( debug_color, "" ) )
-            // no debug color hence no normal color needed
-            normal_color = debug_color;
-        else
-            // the code to set color back to normal
-            normal_color = GetColor( "normal" );
-    }
-    //---------------------
+  /*!
+  * Set debug_color of this cDBG object to color.
+  * color is a string like "red", see util.py for valid names.
+  *
+  * \attention
+  * The string is \b NOT copied, just a pointer is stored
+  */
+  void SetColor(char const* color)
+  {
+    debug_color = GetColor(color);
+    if (!strcmp(debug_color, ""))
+      // no debug color hence no normal color needed
+      normal_color = debug_color;
+    else
+      // the code to set color back to normal
+      normal_color = GetColor("normal");
+  }
+  //---------------------
 
-    /*!
-    * Set output of this cDBG object to fd, which must be a file like object like sys.stderr
-    */
-    void SetOutput( std::ostream *fd )
-    {
-        output = fd;
-    }
-    //---------------------
+  /*!
+  * Set output of this cDBG object to fd, which must be a file like object like sys.stderr
+  */
+  void SetOutput(std::ostream *fd)
+  {
+    output = fd;
+  }
+  //---------------------
 
-    /*!
-    * Print debug messages of printf like fmt, ... in the color set
-    * with SetColor, but only if debug_flag is true.
-    */
-    void PDM( char const* fmt, ... ) SDH__attribute__ ((format (printf, 2, 3)))
-    /*
-    * Remark:
-    *   Since non-static C++ methods have an implicit `this' argument,
-    *   the arguments of such methods should be counted from two, not
-    *   one, when giving values for STRING-INDEX and FIRST-TO-CHECK
-    *   parameter of the format __attribute__.)
-    */
-    {
-        if (!debug_flag) return;
+  /*!
+  * Print debug messages of printf like fmt, ... in the color set
+  * with SetColor, but only if debug_flag is true.
+  */
+  void PDM(char const* fmt, ...) SDH__attribute__((format(printf, 2, 3)))
+  /*
+  * Remark:
+  *   Since non-static C++ methods have an implicit `this' argument,
+  *   the arguments of such methods should be counted from two, not
+  *   one, when giving values for STRING-INDEX and FIRST-TO-CHECK
+  *   parameter of the format __attribute__.)
+  */
+  {
+    if (!debug_flag) return;
 
-        char buffer[ 256 ];
+    char buffer[ 256 ];
 
-        va_list arglist;
-        va_start( arglist, fmt );
+    va_list arglist;
+    va_start(arglist, fmt);
 #if SDH_USE_VCC
-        vsnprintf_s( buffer, 256, 256, fmt, arglist );
+    vsnprintf_s(buffer, 256, 256, fmt, arglist);
 #else
-        vsnprintf( buffer, 256, fmt, arglist );
+    vsnprintf(buffer, 256, fmt, arglist);
 #endif
-        va_end( arglist );
+    va_end(arglist);
 
-        *output << debug_color << buffer << normal_color << std::flush;
-    }
-    //---------------------
+    *output << debug_color << buffer << normal_color << std::flush;
+  }
+  //---------------------
 
-    /*!
-    * return a string (terminal escape sequence) that when printed sets the
-    * color to \c c, where \c c must be in:
-    * - "normal", "bold", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "black" for normal color or
-    * - "black_back", "red_back", "green_back", "yellow_back", "blue_back", "cyan_back", "magenta_back", "white_back" for reverse color
-    *
-    * If the environment variable "SDH_NO_COLOR" is set then "" is returned.
-    * If the environment variable "OS" is WIN* or Win* and "OSTYPE" is not "cygwin"
-    * then "" is returned. (to prevent color output on windows consoles which cannot handle it).
-    * If the color is not found in the list of known colors then the string "" is returned.
-    */
-    char const* GetColor( char const* c )
-    {
-        char* sdh_no_color = getenv( "SDH_NO_COLOR" );
-        if ( sdh_no_color != NULL )
-            return "";
+  /*!
+  * return a string (terminal escape sequence) that when printed sets the
+  * color to \c c, where \c c must be in:
+  * - "normal", "bold", "red", "green", "yellow", "blue", "magenta", "cyan", "white", "black" for normal color or
+  * - "black_back", "red_back", "green_back", "yellow_back", "blue_back", "cyan_back", "magenta_back", "white_back" for reverse color
+  *
+  * If the environment variable "SDH_NO_COLOR" is set then "" is returned.
+  * If the environment variable "OS" is WIN* or Win* and "OSTYPE" is not "cygwin"
+  * then "" is returned. (to prevent color output on windows consoles which cannot handle it).
+  * If the color is not found in the list of known colors then the string "" is returned.
+  */
+  char const* GetColor(char const* c)
+  {
+    char* sdh_no_color = getenv("SDH_NO_COLOR");
+    if (sdh_no_color != NULL)
+      return "";
 
-        char* os = getenv( "OS" );
-        char* ostype = getenv( "OSTYPE" );
-        if ( os && (!strncmp( os, "WIN", 3 ) || !strncmp( os, "Win", 3 )) && (! ostype || (ostype && strcmp( ostype, "cygwin" ))) )
-            return "";
+    char* os = getenv("OS");
+    char* ostype = getenv("OSTYPE");
+    if (os && (!strncmp(os, "WIN", 3) || !strncmp(os, "Win", 3)) && (! ostype || (ostype && strcmp(ostype, "cygwin"))))
+      return "";
 
-        if ( !strcmp( c, "normal" ) )       return "\x1b[0m";
-        if ( !strcmp( c, "bold" ) )         return "\x1b[1m";
-        if ( !strcmp( c, "red" ) )          return "\x1b[31m";
-        if ( !strcmp( c, "green" ) )        return "\x1b[32m";
-        if ( !strcmp( c, "yellow" ) )       return "\x1b[33m";
-        if ( !strcmp( c, "blue" ) )         return "\x1b[34m";
-        if ( !strcmp( c, "magenta" ) )      return "\x1b[35m";
-        if ( !strcmp( c, "cyan" ) )         return "\x1b[36m";
-        if ( !strcmp( c, "white" ) )        return "\x1b[37m";
-        if ( !strcmp( c, "black" ) )        return "\x1b[39m";
-        if ( !strcmp( c, "black_back" ) )   return "\x1b[40m";
-        if ( !strcmp( c, "red_back" ) )     return "\x1b[41m";
-        if ( !strcmp( c, "green_back" ) )   return "\x1b[42m";
-        if ( !strcmp( c, "yellow_back" ) )  return "\x1b[43m";
-        if ( !strcmp( c, "blue_back" ) )    return "\x1b[44m";
-        if ( !strcmp( c, "cyan_back" ) )    return "\x1b[45m";
-        if ( !strcmp( c, "magenta_back" ) ) return "\x1b[46m";
-        if ( !strcmp( c, "white_back" ) )   return "\x1b[47m";
+    if (!strcmp(c, "normal"))       return "\x1b[0m";
+    if (!strcmp(c, "bold"))         return "\x1b[1m";
+    if (!strcmp(c, "red"))          return "\x1b[31m";
+    if (!strcmp(c, "green"))        return "\x1b[32m";
+    if (!strcmp(c, "yellow"))       return "\x1b[33m";
+    if (!strcmp(c, "blue"))         return "\x1b[34m";
+    if (!strcmp(c, "magenta"))      return "\x1b[35m";
+    if (!strcmp(c, "cyan"))         return "\x1b[36m";
+    if (!strcmp(c, "white"))        return "\x1b[37m";
+    if (!strcmp(c, "black"))        return "\x1b[39m";
+    if (!strcmp(c, "black_back"))   return "\x1b[40m";
+    if (!strcmp(c, "red_back"))     return "\x1b[41m";
+    if (!strcmp(c, "green_back"))   return "\x1b[42m";
+    if (!strcmp(c, "yellow_back"))  return "\x1b[43m";
+    if (!strcmp(c, "blue_back"))    return "\x1b[44m";
+    if (!strcmp(c, "cyan_back"))    return "\x1b[45m";
+    if (!strcmp(c, "magenta_back")) return "\x1b[46m";
+    if (!strcmp(c, "white_back"))   return "\x1b[47m";
 
-        // no coloring possible or unknown color: return ""
-        return "";
-    }
+    // no coloring possible or unknown color: return ""
+    return "";
+  }
 
-    /*!
-    * C++ stream like printing:
-    * \code
-    *   d = cDBG( true );
-    *   d << "bla" << "blu " << 42 << true << 0815;
-    * \endcode
-    */
-    template <typename T>
-    cDBG& operator<<( T const& v )
-    {
-        if (!debug_flag) return *this;
+  /*!
+  * C++ stream like printing:
+  * \code
+  *   d = cDBG( true );
+  *   d << "bla" << "blu " << 42 << true << 0815;
+  * \endcode
+  */
+  template <typename T>
+  cDBG& operator<<(T const& v)
+  {
+    if (!debug_flag) return *this;
 
-        output->width( 0 );
-        *output << debug_color;
-        output->width( mywidth );
-        *output << v;
-        mywidth = output->width();
-        output->width( 0 );
-        *output << normal_color << std::flush;
-        return *this;
-    }
-    //---------------------
+    output->width(0);
+    *output << debug_color;
+    output->width(mywidth);
+    *output << v;
+    mywidth = output->width();
+    output->width(0);
+    *output << normal_color << std::flush;
+    return *this;
+  }
+  //---------------------
 
-    std::ostream& flush()
-    {
-        return output->flush();
-    }
-    //---------------------
+  std::ostream& flush()
+  {
+    return output->flush();
+  }
+  //---------------------
 
 
-    /*!
-    * Print name and value of variable \a _var in output stream \a _d. This will
-    * print a "NAME='VALUE'" pair for variable _var
-    *
-    * \code
-    *   d = cDBG( true );
-    *   v = 42;
-    *   s = "test";
-    *   VAR( d, v );
-    *   VAR( d, s );
-    * \endcode
-    * Will print "v='42'" and "s='test'" on stderr
-    */
+  /*!
+  * Print name and value of variable \a _var in output stream \a _d. This will
+  * print a "NAME='VALUE'" pair for variable _var
+  *
+  * \code
+  *   d = cDBG( true );
+  *   v = 42;
+  *   s = "test";
+  *   VAR( d, v );
+  *   VAR( d, s );
+  * \endcode
+  * Will print "v='42'" and "s='test'" on stderr
+  */
 # define VAR( _d, _var )                        \
     (_d) << #_var << "='" << _var << "'\n"
 
-    /*!
-    * Insert name and value of the variable \a _var. This will
-    * insert a "NAME='VALUE' " in an output stream
-    *
-    * \code
-    *   d = cDBG( true );
-    *   v = 42;
-    *   s = "test";
-    *   d << VAL( v ) << "but " << VAL(s);
-    * \endcode
-    * Will print "v=42" and "s=test" on stderr
-    */
+  /*!
+  * Insert name and value of the variable \a _var. This will
+  * insert a "NAME='VALUE' " in an output stream
+  *
+  * \code
+  *   d = cDBG( true );
+  *   v = 42;
+  *   s = "test";
+  *   d << VAL( v ) << "but " << VAL(s);
+  * \endcode
+  * Will print "v=42" and "s=test" on stderr
+  */
 # define VAL( _var )                      \
     #_var << "='" << _var << "' "
 };
@@ -328,39 +328,39 @@ public:
 //! dummy class for (debug) stream output of bytes as list of hex values
 class VCC_EXPORT cHexByteString
 {
-    char const* bytes;
-    int         len;
+  char const* bytes;
+  int         len;
 public:
-    //! ctor: create a cHexByteString with \a _len bytes at \a _bytes
-    cHexByteString( char const* _bytes, int _len ) :
-        bytes(_bytes),
-        len(_len)
-        {};
+  //! ctor: create a cHexByteString with \a _len bytes at \a _bytes
+  cHexByteString(char const* _bytes, int _len) :
+    bytes(_bytes),
+    len(_len)
+  {};
 
-    friend VCC_EXPORT std::ostream &operator<<(std::ostream &stream, cHexByteString const &s);
+  friend VCC_EXPORT std::ostream &operator<<(std::ostream &stream, cHexByteString const &s);
 };
 
 //! output the bytes in \a s to \a stream as a list of space separated hex bytes (without 0x prefix)
 inline VCC_EXPORT std::ostream &operator<<(std::ostream &stream, cHexByteString const &s)
 {
-    //-----
-    // print all bytes as hex bytes:
-    bool is_all_printable_ascii = true;
-    for ( int i = 0; i < s.len; i++ )
-    {
-        stream << std::hex << std::setw(2) << std::setfill('0') << int( ((unsigned char const*)s.bytes)[i] ) << " ";
-        if ( s.bytes[i] < 0x20 || ((unsigned char) s.bytes[i]) >= 0x80 )
-            is_all_printable_ascii = false;
-    }
-    //-----
+  //-----
+  // print all bytes as hex bytes:
+  bool is_all_printable_ascii = true;
+  for (int i = 0; i < s.len; i++)
+  {
+    stream << std::hex << std::setw(2) << std::setfill('0') << int(((unsigned char const*)s.bytes)[i]) << " ";
+    if (s.bytes[i] < 0x20 || ((unsigned char) s.bytes[i]) >= 0x80)
+      is_all_printable_ascii = false;
+  }
+  //-----
 
-    //-----
-    // if the bytes were all printable ascii codes then print them as string as well:
-    if ( is_all_printable_ascii )
-        stream << "= \"" << std::string( s.bytes, s.len ) << "\"";
-    //-----
+  //-----
+  // if the bytes were all printable ascii codes then print them as string as well:
+  if (is_all_printable_ascii)
+    stream << "= \"" << std::string(s.bytes, s.len) << "\"";
+  //-----
 
-    return stream << std::dec;
+  return stream << std::dec;
 };
 
 NAMESPACE_SDH_END

--- a/schunk_sdh/common/include/schunk_sdh/dsa.h
+++ b/schunk_sdh/common/include/schunk_sdh/dsa.h
@@ -88,8 +88,8 @@ NAMESPACE_SDH_START
 class VCC_EXPORT cDSAException: public cSDHLibraryException
 {
 public:
-  cDSAException( cMsg const & _msg )
-    : cSDHLibraryException( "cDSAException", _msg )
+  cDSAException(cMsg const & _msg)
+    : cSDHLibraryException("cDSAException", _msg)
   {}
 };
 //======================================================================
@@ -110,595 +110,596 @@ public:
 */
 class VCC_EXPORT cDSA
 {
- public:
-    //! data type for a single 'texel' (tactile sensor element)
-    typedef UInt16 tTexel;
+public:
+  //! data type for a single 'texel' (tactile sensor element)
+  typedef UInt16 tTexel;
 
-    //! error codes returned by the remote DSACON32m tactile sensor controller
-    enum eDSAErrorCode
-    {
-        E_SUCCESS,
-        E_NOT_AVAILABLE,
-        E_NO_SENSOR,
-        E_NOT_INITIALIZED,
-        E_ALREADY_RUNNING,
-        E_FEATURE_NOT_SUPPORTED,
-        E_INCONSISTENT_DATA,
-        E_TIMEOUT,
-        E_READ_ERROR,
-        E_WRITE_ERROR,
-        E_INSUFFICIENT_RESOURCES,
-        E_CHECKSUM_ERROR,
-        E_CMD_NOT_ENOUGH_PARAMS,
-        E_CMD_UNKNOWN,
-        E_CMD_FORMAT_ERROR,
-        E_ACCESS_DENIED,
-        E_ALREADY_OPEN,
-        E_CMD_FAILED,
-        E_CMD_ABORTED,
-        E_INVALID_HANDLE,
-        E_DEVICE_NOT_FOUND,
-        E_DEVICE_NOT_OPENED,
-        E_IO_ERROR,
-        E_INVALID_PARAMETER,
-        E_INDEX_OUT_OF_BOUNDS,
-        E_CMD_PENDING,
-        E_OVERRUN,
-        E_RANGE_ERROR
-    };
+  //! error codes returned by the remote DSACON32m tactile sensor controller
+  enum eDSAErrorCode
+  {
+    E_SUCCESS,
+    E_NOT_AVAILABLE,
+    E_NO_SENSOR,
+    E_NOT_INITIALIZED,
+    E_ALREADY_RUNNING,
+    E_FEATURE_NOT_SUPPORTED,
+    E_INCONSISTENT_DATA,
+    E_TIMEOUT,
+    E_READ_ERROR,
+    E_WRITE_ERROR,
+    E_INSUFFICIENT_RESOURCES,
+    E_CHECKSUM_ERROR,
+    E_CMD_NOT_ENOUGH_PARAMS,
+    E_CMD_UNKNOWN,
+    E_CMD_FORMAT_ERROR,
+    E_ACCESS_DENIED,
+    E_ALREADY_OPEN,
+    E_CMD_FAILED,
+    E_CMD_ABORTED,
+    E_INVALID_HANDLE,
+    E_DEVICE_NOT_FOUND,
+    E_DEVICE_NOT_OPENED,
+    E_IO_ERROR,
+    E_INVALID_PARAMETER,
+    E_INDEX_OUT_OF_BOUNDS,
+    E_CMD_PENDING,
+    E_OVERRUN,
+    E_RANGE_ERROR
+  };
 
 
-    //! A data structure describing the controller info about the remote DSACON32m controller
+  //! A data structure describing the controller info about the remote DSACON32m controller
 #if SDH_USE_VCC
 #pragma pack(push,1)  // for VCC (MS Visual Studio) we have to set the necessary 1 byte packing with this pragma
 #endif
-    struct sControllerInfo
-    {
-        UInt16 error_code;
-        UInt32 serial_no;
-        UInt8  hw_version;
-        UInt16 sw_version;
-        UInt8  status_flags;
-        UInt8  feature_flags;
-        UInt8  senscon_type;
-        UInt8  active_interface;
-        UInt32 can_baudrate;
-        UInt16 can_id;
-    }   SDH__attribute__((__packed__)); // for gcc we have to set the necessary 1 byte packing with this attribute
+  struct sControllerInfo
+  {
+    UInt16 error_code;
+    UInt32 serial_no;
+    UInt8  hw_version;
+    UInt16 sw_version;
+    UInt8  status_flags;
+    UInt8  feature_flags;
+    UInt8  senscon_type;
+    UInt8  active_interface;
+    UInt32 can_baudrate;
+    UInt16 can_id;
+  }   SDH__attribute__((__packed__)); // for gcc we have to set the necessary 1 byte packing with this attribute
 
-    //! A data structure describing the sensor info about the remote DSACON32m controller
-    struct sSensorInfo
-    {
-        UInt16 error_code;
-        UInt16 nb_matrices;
-        UInt16 generated_by;
-        UInt8  hw_revision;
-        UInt32 serial_no;
-        UInt8  feature_flags;
-    } SDH__attribute__((__packed__)); // for gcc we have to set the necessary 1 byte packing with this attribute
+  //! A data structure describing the sensor info about the remote DSACON32m controller
+  struct sSensorInfo
+  {
+    UInt16 error_code;
+    UInt16 nb_matrices;
+    UInt16 generated_by;
+    UInt8  hw_revision;
+    UInt32 serial_no;
+    UInt8  feature_flags;
+  } SDH__attribute__((__packed__)); // for gcc we have to set the necessary 1 byte packing with this attribute
 
-    //! A data structure describing a single sensor matrix connected to the remote DSACON32m controller
-    struct sMatrixInfo
-    {
-        UInt16 error_code;
-        float  texel_width;
-        float  texel_height;
-        UInt16 cells_x;
-        UInt16 cells_y;
-        UInt8  uid[6];
-        UInt8  reserved[2];
-        UInt8  hw_revision;
+  //! A data structure describing a single sensor matrix connected to the remote DSACON32m controller
+  struct sMatrixInfo
+  {
+    UInt16 error_code;
+    float  texel_width;
+    float  texel_height;
+    UInt16 cells_x;
+    UInt16 cells_y;
+    UInt8  uid[6];
+    UInt8  reserved[2];
+    UInt8  hw_revision;
 
-        float  matrix_center_x;
-        float  matrix_center_y;
-        float  matrix_center_z;
+    float  matrix_center_x;
+    float  matrix_center_y;
+    float  matrix_center_z;
 
-        float  matrix_theta_x;
-        float  matrix_theta_y;
-        float  matrix_theta_z;
-        float  fullscale;
-        UInt8  feature_flags;
-    } SDH__attribute__((__packed__)); // for gcc we have to set the necessary 1 byte packing with this attribute
+    float  matrix_theta_x;
+    float  matrix_theta_y;
+    float  matrix_theta_z;
+    float  fullscale;
+    UInt8  feature_flags;
+  } SDH__attribute__((__packed__)); // for gcc we have to set the necessary 1 byte packing with this attribute
 
-    //! Structure to hold info about the sensitivity settings of one sensor patch
-    struct sSensitivityInfo
-    {
-        UInt16 error_code;  //!< 0000h, if successful, otherwise error code
-        UInt8  adj_flags;   //!< Bit vector indicating the sensitivity adjustment options:
-                            //!< - D7...2 reserved
-                            //!< - D1     1: user can change the sensitivity
-                            //!<          0: sensitivity cannot be changed by the user
-        float  cur_sens;    //!< Currently set sensitivity value. Floating point value.
-                            //!< 0 is minimum sensitivity, 1.0 is maximum sensitivity.
-        float  fact_sens;   //!< Sensitivity value that is used, if a factory restore command is
-                            //!< issued. Floating point value. 0 is minimum sensitivity, 1.0 is
-                            //!< maximum sensitivity.
-    } SDH__attribute__((__packed__)); // for gcc we have to set the necessary 1 byte packing with this attribute
+  //! Structure to hold info about the sensitivity settings of one sensor patch
+  struct sSensitivityInfo
+  {
+    UInt16 error_code;  //!< 0000h, if successful, otherwise error code
+    UInt8  adj_flags;   //!< Bit vector indicating the sensitivity adjustment options:
+    //!< - D7...2 reserved
+    //!< - D1     1: user can change the sensitivity
+    //!<          0: sensitivity cannot be changed by the user
+    float  cur_sens;    //!< Currently set sensitivity value. Floating point value.
+    //!< 0 is minimum sensitivity, 1.0 is maximum sensitivity.
+    float  fact_sens;   //!< Sensitivity value that is used, if a factory restore command is
+    //!< issued. Floating point value. 0 is minimum sensitivity, 1.0 is
+    //!< maximum sensitivity.
+  } SDH__attribute__((__packed__)); // for gcc we have to set the necessary 1 byte packing with this attribute
 
 #if SDH_USE_VCC
 #pragma pack(pop)   // for VCC (MS Visual Studio) restore normal packing
 #endif
 
 
-    /*!
-        \brief A data structure describing a full tactile sensor frame read from the remote DSACON32m controller
+  /*!
+      \brief A data structure describing a full tactile sensor frame read from the remote DSACON32m controller
 
-        \remark
-        - An object of this type is stored within the cDSA object
-        - You can get a reference to the #sTactileSensorFrame object with the
-          #GetFrame() function.
-        - The object must be updated manually (for now)
-          - by setting an appropriate framerate with #SetFramerate() once
-          - by calling #UpdateFrame() periodically
-        -
-    */
-    struct VCC_EXPORT sTactileSensorFrame
+      \remark
+      - An object of this type is stored within the cDSA object
+      - You can get a reference to the #sTactileSensorFrame object with the
+        #GetFrame() function.
+      - The object must be updated manually (for now)
+        - by setting an appropriate framerate with #SetFramerate() once
+        - by calling #UpdateFrame() periodically
+      -
+  */
+  struct VCC_EXPORT sTactileSensorFrame
+  {
+    UInt32  timestamp;  //!< the timestamp of the frame. Use #GetAgeOfFrame() to set this into relation with the time of the PC.
+    UInt8   flags;      //!< internal data
+    tTexel* texel;      //!< an 2D array of tTexel elements. Use #GetTexel() for easy access to specific individual elements.
+
+    //! constructor
+    sTactileSensorFrame(void)
     {
-        UInt32  timestamp;  //!< the timestamp of the frame. Use #GetAgeOfFrame() to set this into relation with the time of the PC.
-        UInt8   flags;      //!< internal data
-        tTexel* texel;      //!< an 2D array of tTexel elements. Use #GetTexel() for easy access to specific individual elements.
+      texel = NULL;
+    }
+  };
 
-        //! constructor
-        sTactileSensorFrame( void )
-        {
-            texel = NULL;
-        }
-    };
-
-    //! Structure to hold info about the contact of one sensor patch
-    struct sContactInfo
-    {
-        double force;  //!< accumulated force in N
-        double area;   //!< area of contact in mm*mm.
-        double cog_x;  //!< center of gravity of contact in x direction of sensor patch in mm
-        double cog_y;  //!< center of gravity of contact in y direction of sensor patch in mm
-    };
+  //! Structure to hold info about the contact of one sensor patch
+  struct sContactInfo
+  {
+    double force;  //!< accumulated force in N
+    double area;   //!< area of contact in mm*mm.
+    double cog_x;  //!< center of gravity of contact in x direction of sensor patch in mm
+    double cog_y;  //!< center of gravity of contact in y direction of sensor patch in mm
+  };
 
 
- protected:
+protected:
 
-    //! data structure for storing responses from the remote DSACON32m controller
+  //! data structure for storing responses from the remote DSACON32m controller
 #if SDH_USE_VCC
 #pragma pack(push,1)    // for VCC (MS Visual Studio) we have to set the necessary 1 byte packing with this pragma
 #endif
-     struct sResponse {
-        UInt8   packet_id;
-        UInt16  size;
-        UInt8*  payload;
-        Int32   max_payload_size;
+  struct sResponse
+  {
+    UInt8   packet_id;
+    UInt16  size;
+    UInt8*  payload;
+    Int32   max_payload_size;
 
-        //! constructor to init pointer and max size
-        sResponse( UInt8* _payload, int _max_payload_size )
-        {
-            payload = _payload;
-            max_payload_size = _max_payload_size;
-        }
-    } SDH__attribute__((__packed__));  // for gcc we have to set the necessary 1 byte packing with this attribute
+    //! constructor to init pointer and max size
+    sResponse(UInt8* _payload, int _max_payload_size)
+    {
+      payload = _payload;
+      max_payload_size = _max_payload_size;
+    }
+  } SDH__attribute__((__packed__));  // for gcc we have to set the necessary 1 byte packing with this attribute
 #if SDH_USE_VCC
 #pragma pack(pop)   // for VCC (MS Visual Studio) restore normal packing
 #endif
 
-    friend VCC_EXPORT std::ostream &operator<<(std::ostream &stream, cDSA::sResponse const &response );
+  friend VCC_EXPORT std::ostream &operator<<(std::ostream &stream, cDSA::sResponse const &response);
 
-    //! A stream object to print coloured debug messages
-    cDBG dbg;
+  //! A stream object to print coloured debug messages
+  cDBG dbg;
 
-    //! the serial RS232 communication interface to use
-    cRS232 comm_interface;
+  //! the serial RS232 communication interface to use
+  cRS232 comm_interface;
 
-    //! flag, true if data should be sent Run Length Encoded by the remote DSACON32m controller
-    bool do_RLE;
+  //! flag, true if data should be sent Run Length Encoded by the remote DSACON32m controller
+  bool do_RLE;
 
-    //! the controller info read from the remote DSACON32m controller
-    sControllerInfo controller_info;
+  //! the controller info read from the remote DSACON32m controller
+  sControllerInfo controller_info;
 
-    //! the sensor info read from the remote DSACON32m controller
-    sSensorInfo     sensor_info;
+  //! the sensor info read from the remote DSACON32m controller
+  sSensorInfo     sensor_info;
 
-    //! the matrix infos read from the remote DSACON32m controller
-    sMatrixInfo*    matrix_info;
+  //! the matrix infos read from the remote DSACON32m controller
+  sMatrixInfo*    matrix_info;
 
-    //! the latest frame received from the remote DSACON32m controller
-    sTactileSensorFrame frame;
+  //! the latest frame received from the remote DSACON32m controller
+  sTactileSensorFrame frame;
 
-    //! The total number of sensor cells
-    int nb_cells;
+  //! The total number of sensor cells
+  int nb_cells;
 
-    //! an array with the offsets of the first texel of all matrices into the whole frame
-    int* texel_offset;
+  //! an array with the offsets of the first texel of all matrices into the whole frame
+  int* texel_offset;
 
-    //! default timeout used for reading in us
-    long read_timeout_us;
+  //! default timeout used for reading in us
+  long read_timeout_us;
 
-    cSimpleTime start_pc;
-    UInt32      start_dsa;
+  cSimpleTime start_pc;
+  UInt32      start_dsa;
 
-    //! threshold of texel cell value for detecting contacts with GetContactArea
-    tTexel contact_area_cell_threshold;
+  //! threshold of texel cell value for detecting contacts with GetContactArea
+  tTexel contact_area_cell_threshold;
 
-    //! threshold of texel cell value for detecting forces with GetContactForce
-    tTexel contact_force_cell_threshold;
+  //! threshold of texel cell value for detecting forces with GetContactForce
+  tTexel contact_force_cell_threshold;
 
-    //! additional calibration factor for forces in GetContactForce
-    double force_factor;
+  //! additional calibration factor for forces in GetContactForce
+  double force_factor;
 
 
-    /*! For the voltage to pressure conversion in _VoltageToPressure()
-        enter one pressure/voltage measurement here (from demo-dsa.py --calibration):
-    */
-    double calib_pressure;  // N/(mm*mm)
-    //! see calib_pressure
-    double calib_voltage;   // "what the DSA reports:" ~mV
+  /*! For the voltage to pressure conversion in _VoltageToPressure()
+      enter one pressure/voltage measurement here (from demo-dsa.py --calibration):
+  */
+  double calib_pressure;  // N/(mm*mm)
+  //! see calib_pressure
+  double calib_voltage;   // "what the DSA reports:" ~mV
 
 
-    void WriteCommandWithPayload( UInt8 command, UInt8* payload, UInt16 payload_len )
-    throw (cDSAException*, cSDHErrorCommunication*);
+  void WriteCommandWithPayload(UInt8 command, UInt8* payload, UInt16 payload_len)
+  throw (cDSAException*, cSDHErrorCommunication*);
 
-    inline void WriteCommand( UInt8 command )
-    {
-        WriteCommandWithPayload( command, NULL, 0 );
-    }
-    //----------------------------------------------------------------------
+  inline void WriteCommand(UInt8 command)
+  {
+    WriteCommandWithPayload(command, NULL, 0);
+  }
+  //----------------------------------------------------------------------
 
-    /*!
-        Read any response from the remote DSACON32m, expect the \a command_id as command id
+  /*!
+      Read any response from the remote DSACON32m, expect the \a command_id as command id
 
-        - tries to find the preamble within the next at most DSA_MAX_PREAMBLE_SEARCH bytes from the device
-        - reads the packet id and size
-        - reads all data indicated by the size read
-        - if there is enough space in the payload of the response then the received data is stored there
-          if there is not enough space in the payload of the response then the data is received but forgotten (to keep the communication line clear)
-        - if sent, the CRC checksum is read and the data is checked. For invalid data an exception is thrown
-    */
-    void ReadResponse( sResponse* response, UInt8 command_id )
-    throw (cDSAException*, cSDHErrorCommunication*);
+      - tries to find the preamble within the next at most DSA_MAX_PREAMBLE_SEARCH bytes from the device
+      - reads the packet id and size
+      - reads all data indicated by the size read
+      - if there is enough space in the payload of the response then the received data is stored there
+        if there is not enough space in the payload of the response then the data is received but forgotten (to keep the communication line clear)
+      - if sent, the CRC checksum is read and the data is checked. For invalid data an exception is thrown
+  */
+  void ReadResponse(sResponse* response, UInt8 command_id)
+  throw (cDSAException*, cSDHErrorCommunication*);
 
-    /*!
-        Read and parse a controller info response from the remote DSA
-    */
-    void ReadControllerInfo( sControllerInfo* _controller_info )
-    throw (cDSAException*, cSDHErrorCommunication*);
+  /*!
+      Read and parse a controller info response from the remote DSA
+  */
+  void ReadControllerInfo(sControllerInfo* _controller_info)
+  throw (cDSAException*, cSDHErrorCommunication*);
 
 
-    /*!
-        Read and parse a sensor info response from the remote DSA
-    */
-    void ReadSensorInfo( sSensorInfo* _sensor_info )
-    throw (cDSAException*, cSDHErrorCommunication*);
+  /*!
+      Read and parse a sensor info response from the remote DSA
+  */
+  void ReadSensorInfo(sSensorInfo* _sensor_info)
+  throw (cDSAException*, cSDHErrorCommunication*);
 
 
-    /*!
-        Read and parse a matrix info response from the remote DSA
-    */
-    void ReadMatrixInfo( sMatrixInfo* _matrix_info  )
-    throw (cDSAException*, cSDHErrorCommunication*);
+  /*!
+      Read and parse a matrix info response from the remote DSA
+  */
+  void ReadMatrixInfo(sMatrixInfo* _matrix_info)
+  throw (cDSAException*, cSDHErrorCommunication*);
 
 
-    /*!
-        read and parse a full frame response from remote DSA
-    */
-    void ReadFrame( sTactileSensorFrame* frame_p  )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
-    /*!
-        Send command to resquest controller info from remote DSACON32m.
-        Read and parse the response from the remote DSACON32m.
-    */
-    void QueryControllerInfo( sControllerInfo* _controller_info  )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
-    /*!
-        Send command to request sensor info from remote DSACON32m.
-        Read and parse the response from the remote DSACON32m.
-    */
-    void QuerySensorInfo( sSensorInfo* _sensor_info )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
-    /*!
-        Send command to request matrix info from remote DSACON32m.
-        Read and parse the response from the remote DSACON32m.
-    */
-    void QueryMatrixInfo( sMatrixInfo* _matrix_info, int matrix_no )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
-    /*!
-      Query all matrix infos
-    */
-    void QueryMatrixInfos( void )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
-    /*!
-        Parse a full frame response from remote DSA
-    */
-    void ParseFrame( sResponse* response, sTactileSensorFrame* frame_p )
-    throw (cDSAException*);
-
-
- public:
-    /*!
-        Constructor for cDSA. This constructs a cDSA object to communicate with
-        the remote DSACON32m controller within the %SDH.
-
-        The connection is opened and established, and the sensor, controller and
-        matrix info is queried from the remote DSACON32m controller.
-        This initialization may take up to 9 seconds, since the
-        DSACON32m controller needs > 8 seconds for "booting". If the %SDH is already powered
-        for some time then this will be much quicker.
-
-        \param debug_level - the level of debug messages to be printed:
-                             - if > 0 (1,2,3...) then debug messages of cDSA itself are printed
-                             - if > 1 (2,3,...) then debug messages of the low level communication interface object are printed too
-        \param port - the RS232 port to use for communication. (port 0 = ttyS0 = COM1, port 1 = ttyS1 = COM2, ...)
-        \param device_format_string - a format string (C string) for generating the device name, like "/dev/ttyS%d" (default) or "/dev/ttyUSB%d".
-                                      Must contain a %d where the port number should be inserted.
-                                      This char array is duplicated on construction.
-                                      When compiled with VCC (MS-Visual C++) then this is not used.
-    */
-    cDSA( int debug_level=0, int port=1, char const* device_format_string="/dev/ttyS%d" );
-
-
-    //! Destructur: clean up and delete dynamically allocated memory
-    ~cDSA();
-
-
-    //! Return a reference to the sControllerInfo read from the remote DSACON32m controller
-    inline sControllerInfo const & GetControllerInfo( void ) const
-    {
-        return controller_info;
-    }
-    //-----------------------------------------------------------------
-
-    //! Return a reference to the sSensorInfo read from the remote DSACON32m controller
-    inline sSensorInfo const & GetSensorInfo( void ) const
-    {
-        return sensor_info;
-    }
-    //-----------------------------------------------------------------
-
-    //! Return a reference to the sMatrixInfo of matrix \a m read from the remote DSACON32m controller
-    inline sMatrixInfo const & GetMatrixInfo( int m ) const
-    {
-        assert( 0 <= m  &&  m <= (int ) sensor_info.nb_matrices );
-        return matrix_info[m];
-    }
-    //-----------------------------------------------------------------
-
-    //! return a reference to the latest tactile sensor frame without reading from remote DSACON32m
-    inline sTactileSensorFrame const & GetFrame() const
-    {
-        return frame;
-    }
-    //-----------------------------------------------------------------
-
-    //! read the tactile sensor frame from remote DSACON32m and return a reference to it. A command to query the frame (periodically) must have been sent before.
-    inline sTactileSensorFrame const & UpdateFrame()
-    {
-        ReadFrame( &frame );
-        return frame;
-    }
-    //-----------------------------------------------------------------
-
-    //! (Re-)open connection to DSACON32m controller, this is called by the constructor automatically, but is still usefull to call after a call to Close()
-    void Open(void)
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-    //! Set the framerate of the remote DSACON32m controller to 0 and close connection to it.
-    void Close(void)
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
-    /*!
-     * Set the \a framerate for querying full frames.
-     *
-     * @param framerate           - rate of frames.
-     * @param do_RLE              - flag, if true then use RLE (run length encoding) for sending frames
-     * @param do_data_acquisition - flag, enable or disable data acquisition. Must be true if you want to get new frames
-     *
-     * - Use \a framerate=0 and \a do_data_acquisition=false to make the remote DSACON32m in %SDH stop sending frames
-     * - Use \a framerate=0 and \a do_data_acquisition=true to read a single frame
-     * - Use \a framerate>0 and \a do_data_acquisition=true to make the remote DSACON32m in %SDH send frames at the
-     *   highest possible rate (for now: 30 FPS (frames per second)).
-     *
-     *  \bug SCHUNK-internal bugzilla ID: Bug 680<br>
-     *  With DSACON32m firmware R276 and after and SDHLibrary-C++ v0.0.1.15
-     *  and before stopping of the sending did not work.
-     *  <br><b>=> Resolved in SDHLibrary-C++ v0.0.1.16</b>
-     *
-     *  \bug SCHUNK-internal bugzilla ID: Bug 680<br>
-     *  With DSACON32m firmware before R276 and SDHLibrary-C++ v0.0.1.16
-     *  and before acquiring of single frames did not work
-     *  <br><b>=> Resolved in SDHLibrary-C++ v0.0.1.17</b>
-     *
-     *  \bug SCHUNK-internal bugzilla ID: Bug 703<br>
-     *  With DSACON32m firmware R288 and before and SDHLibrary-C++ v0.0.2.1 and before
-     *  tactile sensor frames could not be read reliably in single frame mode.
-     *  <br><b>=> Resolved in DSACON32m firmware 2.9.0.0</b>
-     *  <br><b>=> Resolved in SDHLibrary-C++ v0.0.2.1 with workaround for older DSACON32m firmwares</b>
-     */
-    void SetFramerate( UInt16 framerate, bool do_RLE=true, bool do_data_acquisition=true )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-    /*!
-     * Set the \a framerate for querying full frames.
-     *
-     * @param framerate - rate of frames. 0 will make the remote DSACON32m in
-     *                    %SDH stop sending frames, any value > 0 will make
-     *                    the remote DSACON32m in %SDH send frames at the
-     *                    highest possible rate (for now: 30 FPS (frames per second)).
-     * @param do_RLE              - flag, if true then use RLE (run length encoding) for sending frames
-     * @param do_data_acquisition - flag, enable or disable data acquisition. Must be true if you want to get new frames
-     * @param retries             - number of times the sending will be retried in case of an error (like timeout while waiting for response)
-     * @param ignore_exceptions   - flag, if true then exceptions are ignored in case of error. After \a retries tries the function just returns even in case of an error
-     */
-    void SetFramerateRetries( UInt16 framerate, bool do_RLE=true, bool do_data_acquisition=true, unsigned int retries=0, bool ignore_exceptions=false )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
-    /*!
-        Send command to get matrix sensitivity. Returns sensitivities of matrix no \a matrix_no.
-
-        A struct is returned containing the members
-        \a error_code - see DSACON32 Command Set Reference Manual
-        \a adj_flags  - see DSACON32 Command Set Reference Manual
-        \a cur_sens   - the currently set sensitivity as float [0.0 .. 1.0] (0.0 is minimum, 1.0 is maximum sensitivity)
-        \a fact_sens  - the factory sensitivity as float [0.0 .. 1.0] (0.0 is minimum, 1.0 is maximum sensitivity)
-
-        Raises a cDSAException in case of invalid responses from the remote DSACON32m controller.
-
-        \bug With DSACON32m firmware R218 and before this did not work, instead the factory default (0.5) was always reported
-        <br><b>=> Resolved in DSACON32m firmware R268</b>
-    */
-    sSensitivityInfo GetMatrixSensitivity( int matrix_no )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
-    /*!
-        Send command to set matrix sensitivity to \a sensitivity as float [0.0 .. 1.0] (0.0 is minimum, 1.0 is maximum sensitivity).
-        If \a do_all_matrices is true then the \a sensitivity is set for all matrices.
-        If \a do_reset is true then the sensitivity is reset to the factory default.
-        If \a do_persistent is true then the sensitivity is saved persistently to
-        configuration memory and will thus remain after the next power off/power on
-        cycle and will become the new factory default value. If \a do_persistent is
-        false (default) then the value will be reset to default on the next power
-        off/power on cycle
-        \warning PLEASE NOTE: the maximum write endurance of the configuration
-        memory is about 100.000 times!
-
-        Raises a cDSAException in case of invalid responses from the remote DSACON32m controller.
-
-        \remark Setting the matrix sensitivity persistently is only possible if the DSACON32m firmware is R268 or above.
-    */
-    void SetMatrixSensitivity( int matrix_no,
-                               double sensitivity,
-                               bool do_all_matrices=false,
-                               bool do_reset=false,
-                               bool do_persistent=false )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
-    /*!
-        Send command to set matrix threshold to \a threshold as integer [0 .. 4095] (0 is minimum, 4095 is maximum threshold).
-        If \a do_all_matrices is true then the \a threshold is set for all matrices.
-        If \a do_reset is true then the threshold is reset to the factory default.
-        If \a do_persistent is true then the threshold is saved persistently to
-        configuration memory and will thus remain after the next power off/power on
-        cycle and will become the new factory default value. If \a do_persistent is
-        false (default) then the value will be reset to default on the next power
-        off/power on cycle
-        \warning PLEASE NOTE: the maximum write endurance of the configuration
-        memory is about 100.000 times!
-
-        Raises a cDSAException in case of invalid responses from the remote DSACON32m controller.
-
-        \remark Getting the matrix threshold is only possible if the DSACON32m firmware is R268 or above.
-    */
-    void SetMatrixThreshold( int matrix_no,
-                             UInt16 threshold,
-                             bool do_all_matrices=false,
-                             bool do_reset=false,
-                             bool do_persistent=false )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-    /*!
-        Send command to get matrix threshold. Returns threshold of matrix no \a matrix_no.
-
-        \return threshold  - the currently set threshold as integer [0 .. 4095] (0 is minimum, 4095 is maximum threshold)
-
-        Raises a cDSAException in case of invalid responses from the remote DSACON32m controller.
-
-        \remark Getting the matrix threshold is only possible if the DSACON32m firmware is R268 or above.
-    */
-    UInt16 GetMatrixThreshold( int matrix_no )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-    /*!
-        Return texel value at column \a x row \a y of matrix \a m of the last frame
-    */
-    tTexel GetTexel( int m, int x, int y ) const;
-
-
-
-    /*!
-        return the matrix index of the sensor matrix attached to finger with index \a fi [1..3] and \a part [0,1] = [proximal,distal]
-    */
-    inline int GetMatrixIndex( int fi, int part )
-    {
-        return fi * 2 + part;
-    }
-
-
-    /*!
-        return age of frame in ms (time in ms from frame sampling until now)
-    */
-    inline unsigned long GetAgeOfFrame( sTactileSensorFrame* frame_p )
-    {
-        return ((unsigned long) (start_pc.Elapsed()*1000.0)) - (frame_p->timestamp - start_dsa);
-    }
-
-    double GetContactArea( int m );
-
- private:
-    double VoltageToPressure( double voltage );
-
-    void ReadAndCheckErrorResponse( char const* msg, UInt8 command_id )
-    throw (cDSAException*, cSDHErrorCommunication*);
-
-
- public:
-    sContactInfo GetContactInfo( int m );
-
-
-    /*!
-     * Return a short string description for \a error_code
-     *
-     * @param  error_code - error code as returned from the remote DSACON32m tactile sensor controller
-     * @return short string description for \a error_code
-     */
-    static char const* ErrorCodeToString( eDSAErrorCode error_code );
-    static char const* ErrorCodeToString( UInt16 error_code )
-    {
-        return ErrorCodeToString( (eDSAErrorCode) error_code );
-    }
-
- private:
-     //! flag, true if user requested acquiring of a single frame. Needed for DSACON32m firmware-bug workaround.
-     bool acquiring_single_frame;
-
-     /*!
-      * Cleanup communication line: read all available bytes
-      * with \a timeout_us_first timeout in us for first byte
-      * and \a timeout_us_subsequent timeoutin us for subsequent bytes
-      *
-      * @param timeout_us_first - timeout in us for first byte
-      * @param timeout_us_subsequent - timeout in us for subsequent bytes
-      *
-      * The push mode of the DSACON32m must be switched off on call since
-      * else the method will not return.
-      */
-     void FlushInput( long timeout_us_first, long timeout_us_subsequent );
+  /*!
+      read and parse a full frame response from remote DSA
+  */
+  void ReadFrame(sTactileSensorFrame* frame_p)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+  /*!
+      Send command to resquest controller info from remote DSACON32m.
+      Read and parse the response from the remote DSACON32m.
+  */
+  void QueryControllerInfo(sControllerInfo* _controller_info)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+  /*!
+      Send command to request sensor info from remote DSACON32m.
+      Read and parse the response from the remote DSACON32m.
+  */
+  void QuerySensorInfo(sSensorInfo* _sensor_info)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+  /*!
+      Send command to request matrix info from remote DSACON32m.
+      Read and parse the response from the remote DSACON32m.
+  */
+  void QueryMatrixInfo(sMatrixInfo* _matrix_info, int matrix_no)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+  /*!
+    Query all matrix infos
+  */
+  void QueryMatrixInfos(void)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+  /*!
+      Parse a full frame response from remote DSA
+  */
+  void ParseFrame(sResponse* response, sTactileSensorFrame* frame_p)
+  throw (cDSAException*);
+
+
+public:
+  /*!
+      Constructor for cDSA. This constructs a cDSA object to communicate with
+      the remote DSACON32m controller within the %SDH.
+
+      The connection is opened and established, and the sensor, controller and
+      matrix info is queried from the remote DSACON32m controller.
+      This initialization may take up to 9 seconds, since the
+      DSACON32m controller needs > 8 seconds for "booting". If the %SDH is already powered
+      for some time then this will be much quicker.
+
+      \param debug_level - the level of debug messages to be printed:
+                           - if > 0 (1,2,3...) then debug messages of cDSA itself are printed
+                           - if > 1 (2,3,...) then debug messages of the low level communication interface object are printed too
+      \param port - the RS232 port to use for communication. (port 0 = ttyS0 = COM1, port 1 = ttyS1 = COM2, ...)
+      \param device_format_string - a format string (C string) for generating the device name, like "/dev/ttyS%d" (default) or "/dev/ttyUSB%d".
+                                    Must contain a %d where the port number should be inserted.
+                                    This char array is duplicated on construction.
+                                    When compiled with VCC (MS-Visual C++) then this is not used.
+  */
+  cDSA(int debug_level = 0, int port = 1, char const* device_format_string = "/dev/ttyS%d");
+
+
+  //! Destructur: clean up and delete dynamically allocated memory
+  ~cDSA();
+
+
+  //! Return a reference to the sControllerInfo read from the remote DSACON32m controller
+  inline sControllerInfo const & GetControllerInfo(void) const
+  {
+    return controller_info;
+  }
+  //-----------------------------------------------------------------
+
+  //! Return a reference to the sSensorInfo read from the remote DSACON32m controller
+  inline sSensorInfo const & GetSensorInfo(void) const
+  {
+    return sensor_info;
+  }
+  //-----------------------------------------------------------------
+
+  //! Return a reference to the sMatrixInfo of matrix \a m read from the remote DSACON32m controller
+  inline sMatrixInfo const & GetMatrixInfo(int m) const
+  {
+    assert(0 <= m  &&  m <= (int) sensor_info.nb_matrices);
+    return matrix_info[m];
+  }
+  //-----------------------------------------------------------------
+
+  //! return a reference to the latest tactile sensor frame without reading from remote DSACON32m
+  inline sTactileSensorFrame const & GetFrame() const
+  {
+    return frame;
+  }
+  //-----------------------------------------------------------------
+
+  //! read the tactile sensor frame from remote DSACON32m and return a reference to it. A command to query the frame (periodically) must have been sent before.
+  inline sTactileSensorFrame const & UpdateFrame()
+  {
+    ReadFrame(&frame);
+    return frame;
+  }
+  //-----------------------------------------------------------------
+
+  //! (Re-)open connection to DSACON32m controller, this is called by the constructor automatically, but is still usefull to call after a call to Close()
+  void Open(void)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+  //! Set the framerate of the remote DSACON32m controller to 0 and close connection to it.
+  void Close(void)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+  /*!
+   * Set the \a framerate for querying full frames.
+   *
+   * @param framerate           - rate of frames.
+   * @param do_RLE              - flag, if true then use RLE (run length encoding) for sending frames
+   * @param do_data_acquisition - flag, enable or disable data acquisition. Must be true if you want to get new frames
+   *
+   * - Use \a framerate=0 and \a do_data_acquisition=false to make the remote DSACON32m in %SDH stop sending frames
+   * - Use \a framerate=0 and \a do_data_acquisition=true to read a single frame
+   * - Use \a framerate>0 and \a do_data_acquisition=true to make the remote DSACON32m in %SDH send frames at the
+   *   highest possible rate (for now: 30 FPS (frames per second)).
+   *
+   *  \bug SCHUNK-internal bugzilla ID: Bug 680<br>
+   *  With DSACON32m firmware R276 and after and SDHLibrary-C++ v0.0.1.15
+   *  and before stopping of the sending did not work.
+   *  <br><b>=> Resolved in SDHLibrary-C++ v0.0.1.16</b>
+   *
+   *  \bug SCHUNK-internal bugzilla ID: Bug 680<br>
+   *  With DSACON32m firmware before R276 and SDHLibrary-C++ v0.0.1.16
+   *  and before acquiring of single frames did not work
+   *  <br><b>=> Resolved in SDHLibrary-C++ v0.0.1.17</b>
+   *
+   *  \bug SCHUNK-internal bugzilla ID: Bug 703<br>
+   *  With DSACON32m firmware R288 and before and SDHLibrary-C++ v0.0.2.1 and before
+   *  tactile sensor frames could not be read reliably in single frame mode.
+   *  <br><b>=> Resolved in DSACON32m firmware 2.9.0.0</b>
+   *  <br><b>=> Resolved in SDHLibrary-C++ v0.0.2.1 with workaround for older DSACON32m firmwares</b>
+   */
+  void SetFramerate(UInt16 framerate, bool do_RLE = true, bool do_data_acquisition = true)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+  /*!
+   * Set the \a framerate for querying full frames.
+   *
+   * @param framerate - rate of frames. 0 will make the remote DSACON32m in
+   *                    %SDH stop sending frames, any value > 0 will make
+   *                    the remote DSACON32m in %SDH send frames at the
+   *                    highest possible rate (for now: 30 FPS (frames per second)).
+   * @param do_RLE              - flag, if true then use RLE (run length encoding) for sending frames
+   * @param do_data_acquisition - flag, enable or disable data acquisition. Must be true if you want to get new frames
+   * @param retries             - number of times the sending will be retried in case of an error (like timeout while waiting for response)
+   * @param ignore_exceptions   - flag, if true then exceptions are ignored in case of error. After \a retries tries the function just returns even in case of an error
+   */
+  void SetFramerateRetries(UInt16 framerate, bool do_RLE = true, bool do_data_acquisition = true, unsigned int retries = 0, bool ignore_exceptions = false)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+  /*!
+      Send command to get matrix sensitivity. Returns sensitivities of matrix no \a matrix_no.
+
+      A struct is returned containing the members
+      \a error_code - see DSACON32 Command Set Reference Manual
+      \a adj_flags  - see DSACON32 Command Set Reference Manual
+      \a cur_sens   - the currently set sensitivity as float [0.0 .. 1.0] (0.0 is minimum, 1.0 is maximum sensitivity)
+      \a fact_sens  - the factory sensitivity as float [0.0 .. 1.0] (0.0 is minimum, 1.0 is maximum sensitivity)
+
+      Raises a cDSAException in case of invalid responses from the remote DSACON32m controller.
+
+      \bug With DSACON32m firmware R218 and before this did not work, instead the factory default (0.5) was always reported
+      <br><b>=> Resolved in DSACON32m firmware R268</b>
+  */
+  sSensitivityInfo GetMatrixSensitivity(int matrix_no)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+  /*!
+      Send command to set matrix sensitivity to \a sensitivity as float [0.0 .. 1.0] (0.0 is minimum, 1.0 is maximum sensitivity).
+      If \a do_all_matrices is true then the \a sensitivity is set for all matrices.
+      If \a do_reset is true then the sensitivity is reset to the factory default.
+      If \a do_persistent is true then the sensitivity is saved persistently to
+      configuration memory and will thus remain after the next power off/power on
+      cycle and will become the new factory default value. If \a do_persistent is
+      false (default) then the value will be reset to default on the next power
+      off/power on cycle
+      \warning PLEASE NOTE: the maximum write endurance of the configuration
+      memory is about 100.000 times!
+
+      Raises a cDSAException in case of invalid responses from the remote DSACON32m controller.
+
+      \remark Setting the matrix sensitivity persistently is only possible if the DSACON32m firmware is R268 or above.
+  */
+  void SetMatrixSensitivity(int matrix_no,
+                            double sensitivity,
+                            bool do_all_matrices = false,
+                            bool do_reset = false,
+                            bool do_persistent = false)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+  /*!
+      Send command to set matrix threshold to \a threshold as integer [0 .. 4095] (0 is minimum, 4095 is maximum threshold).
+      If \a do_all_matrices is true then the \a threshold is set for all matrices.
+      If \a do_reset is true then the threshold is reset to the factory default.
+      If \a do_persistent is true then the threshold is saved persistently to
+      configuration memory and will thus remain after the next power off/power on
+      cycle and will become the new factory default value. If \a do_persistent is
+      false (default) then the value will be reset to default on the next power
+      off/power on cycle
+      \warning PLEASE NOTE: the maximum write endurance of the configuration
+      memory is about 100.000 times!
+
+      Raises a cDSAException in case of invalid responses from the remote DSACON32m controller.
+
+      \remark Getting the matrix threshold is only possible if the DSACON32m firmware is R268 or above.
+  */
+  void SetMatrixThreshold(int matrix_no,
+                          UInt16 threshold,
+                          bool do_all_matrices = false,
+                          bool do_reset = false,
+                          bool do_persistent = false)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+  /*!
+      Send command to get matrix threshold. Returns threshold of matrix no \a matrix_no.
+
+      \return threshold  - the currently set threshold as integer [0 .. 4095] (0 is minimum, 4095 is maximum threshold)
+
+      Raises a cDSAException in case of invalid responses from the remote DSACON32m controller.
+
+      \remark Getting the matrix threshold is only possible if the DSACON32m firmware is R268 or above.
+  */
+  UInt16 GetMatrixThreshold(int matrix_no)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+  /*!
+      Return texel value at column \a x row \a y of matrix \a m of the last frame
+  */
+  tTexel GetTexel(int m, int x, int y) const;
+
+
+
+  /*!
+      return the matrix index of the sensor matrix attached to finger with index \a fi [1..3] and \a part [0,1] = [proximal,distal]
+  */
+  inline int GetMatrixIndex(int fi, int part)
+  {
+    return fi * 2 + part;
+  }
+
+
+  /*!
+      return age of frame in ms (time in ms from frame sampling until now)
+  */
+  inline unsigned long GetAgeOfFrame(sTactileSensorFrame* frame_p)
+  {
+    return ((unsigned long)(start_pc.Elapsed() * 1000.0)) - (frame_p->timestamp - start_dsa);
+  }
+
+  double GetContactArea(int m);
+
+private:
+  double VoltageToPressure(double voltage);
+
+  void ReadAndCheckErrorResponse(char const* msg, UInt8 command_id)
+  throw (cDSAException*, cSDHErrorCommunication*);
+
+
+public:
+  sContactInfo GetContactInfo(int m);
+
+
+  /*!
+   * Return a short string description for \a error_code
+   *
+   * @param  error_code - error code as returned from the remote DSACON32m tactile sensor controller
+   * @return short string description for \a error_code
+   */
+  static char const* ErrorCodeToString(eDSAErrorCode error_code);
+  static char const* ErrorCodeToString(UInt16 error_code)
+  {
+    return ErrorCodeToString((eDSAErrorCode) error_code);
+  }
+
+private:
+  //! flag, true if user requested acquiring of a single frame. Needed for DSACON32m firmware-bug workaround.
+  bool acquiring_single_frame;
+
+  /*!
+   * Cleanup communication line: read all available bytes
+   * with \a timeout_us_first timeout in us for first byte
+   * and \a timeout_us_subsequent timeoutin us for subsequent bytes
+   *
+   * @param timeout_us_first - timeout in us for first byte
+   * @param timeout_us_subsequent - timeout in us for subsequent bytes
+   *
+   * The push mode of the DSACON32m must be switched off on call since
+   * else the method will not return.
+   */
+  void FlushInput(long timeout_us_first, long timeout_us_subsequent);
 }; // end of class cDSA
 //----------------------------------------------------------------------
 //----------------------------------------------------------------------
 
 
-VCC_EXPORT std::ostream &operator<<( std::ostream &stream,  cDSA::sControllerInfo const &controller_info );
+VCC_EXPORT std::ostream &operator<<(std::ostream &stream,  cDSA::sControllerInfo const &controller_info);
 
 
-VCC_EXPORT std::ostream &operator<<( std::ostream &stream,  cDSA::sSensorInfo const &sensor_info );
+VCC_EXPORT std::ostream &operator<<(std::ostream &stream,  cDSA::sSensorInfo const &sensor_info);
 
 
-VCC_EXPORT std::ostream &operator<<( std::ostream &stream,  cDSA::sMatrixInfo const &matrix_info );
+VCC_EXPORT std::ostream &operator<<(std::ostream &stream,  cDSA::sMatrixInfo const &matrix_info);
 
 
-VCC_EXPORT std::ostream &operator<<( std::ostream &stream,  cDSA::sResponse const &response );
+VCC_EXPORT std::ostream &operator<<(std::ostream &stream,  cDSA::sResponse const &response);
 
 
-VCC_EXPORT std::ostream &operator<<( std::ostream &stream,  cDSA const &dsa );
+VCC_EXPORT std::ostream &operator<<(std::ostream &stream,  cDSA const &dsa);
 
 
 NAMESPACE_SDH_END

--- a/schunk_sdh/common/include/schunk_sdh/rs232-cygwin.h
+++ b/schunk_sdh/common/include/schunk_sdh/rs232-cygwin.h
@@ -71,8 +71,8 @@ NAMESPACE_SDH_START
 class cRS232Exception: public cSerialBaseException
 {
 public:
-  cRS232Exception( cMsg const & _msg )
-    : cSerialBaseException( "cRS232Exception", _msg )
+  cRS232Exception(cMsg const & _msg)
+    : cSerialBaseException("cRS232Exception", _msg)
   {}
 };
 //======================================================================
@@ -85,38 +85,38 @@ class cRS232 : public cSerialBase
 {
 
 protected:
-    //! the RS232 portnumber to use
-    int port;
+  //! the RS232 portnumber to use
+  int port;
 
-    //! the sprintf format string to generate the device name from the port, see Constructor
-    std::string device_format_string;
+  //! the sprintf format string to generate the device name from the port, see Constructor
+  std::string device_format_string;
 
-    //! the baudrate in bit/s
-    unsigned long baudrate;
+  //! the baudrate in bit/s
+  unsigned long baudrate;
 
-    //! the file descriptor of the RS232 port
-    int fd;
+  //! the file descriptor of the RS232 port
+  int fd;
 
-    //! Translate a baudrate given as unsigned long into a baudrate code for struct termios
-    tcflag_t BaudrateToBaudrateCode( unsigned long baudrate )
-    throw (cRS232Exception*);
+  //! Translate a baudrate given as unsigned long into a baudrate code for struct termios
+  tcflag_t BaudrateToBaudrateCode(unsigned long baudrate)
+  throw (cRS232Exception*);
 
-    int status;
+  int status;
 
-    termios io_set_old;
+  termios io_set_old;
 
 public:
-    /*!
-      Constructor: constructs an object to communicate with an %SDH via RS232
+  /*!
+    Constructor: constructs an object to communicate with an %SDH via RS232
 
-      \param _port     - rs232 device number: 0='COM1'='/dev/ttyS0', 1='COM2'='/dev/ttyS1', ...
-      \param _baudrate - the baudrate in bit/s
-      \param _timeout  - the timeout in seconds
-      \param _device_format_string - a format string (C string) for generating the device name, like "/dev/ttyS%d" (default) or "/dev/ttyUSB%d".
-                                     Must contain a %d where the port number should be inserted.
-                                     This char array is duplicated on construction
-    */
-  cRS232( int _port, unsigned long _baudrate, double _timeout, char const* _device_format_string = "/dev/ttyS%d" );
+    \param _port     - rs232 device number: 0='COM1'='/dev/ttyS0', 1='COM2'='/dev/ttyS1', ...
+    \param _baudrate - the baudrate in bit/s
+    \param _timeout  - the timeout in seconds
+    \param _device_format_string - a format string (C string) for generating the device name, like "/dev/ttyS%d" (default) or "/dev/ttyUSB%d".
+                                   Must contain a %d where the port number should be inserted.
+                                   This char array is duplicated on construction
+  */
+  cRS232(int _port, unsigned long _baudrate, double _timeout, char const* _device_format_string = "/dev/ttyS%d");
 
   /*!
    *  Open the device as configured by the parameters given to the constructor
@@ -130,16 +130,16 @@ public:
    *   - #SDH_USE_BINARY_COMMUNICATION
    *   <br><b>=> Resolved in %SDHLibrary 0.0.2.2</b>
   */
-  void Open( void )
-      throw (cRS232Exception*);
+  void Open(void)
+  throw (cRS232Exception*);
 
   //! Return true if port to RS232 is open
-  bool IsOpen( void )
-      throw();
+  bool IsOpen(void)
+  throw();
 
   //! Close the previously opened rs232 port.
-  void Close( void )
-      throw (cRS232Exception*);
+  void Close(void)
+  throw (cRS232Exception*);
 
   //! Write data to a previously opened port.
   /*!
@@ -150,8 +150,8 @@ public:
 
       \return the number of bytes actually written
   */
-  int write( char const *ptr, int len=0 )
-      throw (cRS232Exception*);
+  int write(char const *ptr, int len = 0)
+  throw (cRS232Exception*);
 
   /*!
     Read data from device. This function waits until \a max_time_us us passed or
@@ -161,13 +161,13 @@ public:
     If the \a return_on_less_data is false, data is only read from serial line, if at least
     \a size bytes are available.
    */
-  ssize_t Read( void *data, ssize_t size, long timeout_us, bool return_on_less_data )
-      throw (cRS232Exception*);
+  ssize_t Read(void *data, ssize_t size, long timeout_us, bool return_on_less_data)
+  throw (cRS232Exception*);
 
   //! overloaded from cSerialBase::UseCRC16 since we want to use a CRC16 to protect binary RS232 communication
   virtual bool UseCRC16()
   {
-      return true;
+    return true;
   }
 
 };

--- a/schunk_sdh/common/include/schunk_sdh/rs232-vcc.h
+++ b/schunk_sdh/common/include/schunk_sdh/rs232-vcc.h
@@ -60,9 +60,9 @@ NAMESPACE_SDH_START
 class VCC_EXPORT cRS232Exception: public cSerialBaseException
 {
 public:
-    cRS232Exception( cMsg const & _msg )
-    : cSerialBaseException( "cRS232Exception", _msg )
-    {}
+  cRS232Exception(cMsg const & _msg)
+    : cSerialBaseException("cRS232Exception", _msg)
+  {}
 };
 
 /*!
@@ -72,71 +72,76 @@ class VCC_EXPORT cRS232 : public cSerialBase
 {
 private:
 #ifndef RS_232_TEST
-    HANDLE       _hCOM;
+  HANDLE       _hCOM;
 #endif
 #if SDH_RS232_VCC_ASYNC
-    OVERLAPPED   o;
+  OVERLAPPED   o;
 #endif
-    COMMTIMEOUTS comm_timeouts;
-    long         read_timeout_us; // for caching the read timeout in ms
+  COMMTIMEOUTS comm_timeouts;
+  long         read_timeout_us; // for caching the read timeout in ms
 
 protected:
-    //! the RS232 port number to use (port 0 is COM1)
-    int port;
+  //! the RS232 port number to use (port 0 is COM1)
+  int port;
 
-    //! the baudrate in bit/s
-    unsigned long baudrate;
+  //! the baudrate in bit/s
+  unsigned long baudrate;
 
 
 public:
-    /*!
-    * Constructor: constructs an object to communicate with an %SDH via RS232
+  /*!
+  * Constructor: constructs an object to communicate with an %SDH via RS232
 
-    * \param _port     - rs232 device number: 0='COM1'='/dev/ttyS0', 1='COM2'='/dev/ttyS1', ...
-    * \param _baudrate - the baudrate in bit/s
-    * \param _timeout  - the timeout in seconds
-    * \param _device_format_string - ignored for this VCC version
-    */
-    cRS232( int _port, unsigned long _baudrate, double _timeout, char const* _device_format_string = "" );
-    ~cRS232(void);
+  * \param _port     - rs232 device number: 0='COM1'='/dev/ttyS0', 1='COM2'='/dev/ttyS1', ...
+  * \param _baudrate - the baudrate in bit/s
+  * \param _timeout  - the timeout in seconds
+  * \param _device_format_string - ignored for this VCC version
+  */
+  cRS232(int _port, unsigned long _baudrate, double _timeout, char const* _device_format_string = "");
+  ~cRS232(void);
 
-    void Open( void )
-    throw (cRS232Exception*);
-    void Close( void )
-    throw (cRS232Exception*);
+  void Open(void)
+  throw (cRS232Exception*);
+  void Close(void)
+  throw (cRS232Exception*);
 
-    virtual void SetTimeout( double _timeout )
-        throw (cSerialBaseException*);
+  virtual void SetTimeout(double _timeout)
+  throw (cSerialBaseException*);
 
 #ifndef RS_232_TEST
-    bool IsOpen()
-    throw()
-    { return _hCOM != NULL; }
+  bool IsOpen()
+  throw()
+  {
+    return _hCOM != NULL;
+  }
 #else
-    bool IsOpen() { return true; }
+  bool IsOpen()
+  {
+    return true;
+  }
 #endif
-    int write( char const *ptr, int len=0 )
-    throw (cRS232Exception*);
+  int write(char const *ptr, int len = 0)
+  throw (cRS232Exception*);
 
-    /*!
-    * Read data from device. This function waits until \a max_time_us us passed or
-    * the expected number of bytes are received via serial line.
-    * if (\a return_on_less_data is true (default value), the number of bytes
-    * that have been received are returned and the data is stored in \a data
-    * If the \a return_on_less_data is false, data is only read from serial line, if at least
-    * \a size bytes are available.
-    */
-    ssize_t Read( void *data, ssize_t size, long timeout_us, bool return_on_less_data )
-    throw (cRS232Exception*);
+  /*!
+  * Read data from device. This function waits until \a max_time_us us passed or
+  * the expected number of bytes are received via serial line.
+  * if (\a return_on_less_data is true (default value), the number of bytes
+  * that have been received are returned and the data is stored in \a data
+  * If the \a return_on_less_data is false, data is only read from serial line, if at least
+  * \a size bytes are available.
+  */
+  ssize_t Read(void *data, ssize_t size, long timeout_us, bool return_on_less_data)
+  throw (cRS232Exception*);
 
-    char* readline(char* line, int size, char* eol, bool return_on_less_data)
-    throw (cRS232Exception*);
+  char* readline(char* line, int size, char* eol, bool return_on_less_data)
+  throw (cRS232Exception*);
 
-    //! overloaded from cSerialBase::UseCRC16 since we want to use a CRC16 to protect binary RS232 communication
-    virtual bool UseCRC16()
-    {
-        return true;
-    }
+  //! overloaded from cSerialBase::UseCRC16 since we want to use a CRC16 to protect binary RS232 communication
+  virtual bool UseCRC16()
+  {
+    return true;
+  }
 };
 
 NAMESPACE_SDH_END

--- a/schunk_sdh/common/include/schunk_sdh/sdh.h
+++ b/schunk_sdh/common/include/schunk_sdh/sdh.h
@@ -45,7 +45,7 @@ extern "C" {
 
 #include "basisdef.h"
 
-  //----------------------------------------------------------------------
+//----------------------------------------------------------------------
 // System Includes - include with <>
 //----------------------------------------------------------------------
 
@@ -102,16 +102,16 @@ NAMESPACE_SDH_START
 // and http://www.unknownroad.com/rtfm/VisualStudio/warningC4251.html
 //
 VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::allocator<int>;
-VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::vector<int,std::allocator<int> >;
+VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::vector<int, std::allocator<int> >;
 
 VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::allocator<std::vector<int> >;
-VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::vector<std::vector<int>,std::allocator<std::vector<int> > >;
+VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::vector<std::vector<int>, std::allocator<std::vector<int> > >;
 
 VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::allocator<double>;
-VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::vector<double,std::allocator<double> >;
+VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::vector<double, std::allocator<double> >;
 
 VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::allocator<std::vector<double> >;
-VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::vector<std::vector<double>,std::allocator<std::vector<double> > >;
+VCC_EXPORT_TEMPLATE template class VCC_EXPORT std::vector<std::vector<double>, std::allocator<std::vector<double> > >;
 #endif
 
 //======================================================================
@@ -173,3993 +173,3993 @@ class VCC_EXPORT cSDH : public cSDHBase
 {
 public:
 
-    //! the motor current can be set specifically for these modes:
-    enum eMotorCurrentMode
-    {
-        eMCM_MOVE=0, //!< The motor currents used while "moving" with a MoveHand() or MoveFinger() command
-        eMCM_GRIP=1, //!< The motor currents used while "gripping" with a GripHand() command
-        eMCM_HOLD=2, //!< The motor currents used after "gripping" with a GripHand() command (i.e. "holding")
+  //! the motor current can be set specifically for these modes:
+  enum eMotorCurrentMode
+  {
+    eMCM_MOVE = 0, //!< The motor currents used while "moving" with a MoveHand() or MoveFinger() command
+    eMCM_GRIP = 1, //!< The motor currents used while "gripping" with a GripHand() command
+    eMCM_HOLD = 2, //!< The motor currents used after "gripping" with a GripHand() command (i.e. "holding")
 
-        eMCM_DIMENSION //!< Endmarker and Dimension
-    };
-
-
-    //! The state of an axis (see TPOSCON_STATE in global.h of the %SDH firmware)
-    enum eAxisState
-    {
-        eAS_IDLE = 0,            //!< axis is idle
-        eAS_POSITIONING,         //!< the goal position has not been reached yet
-        eAS_SPEED_MODE,          //!< axis is in speed mode
-        eAS_NOT_INITIALIZED,     //!< axis is not initialized or doesn't exist
-        eAS_CW_BLOCKED,          //!< axis is blocked in counterwise direction
-        eAS_CCW_BLOCKED,         //!< axis is blocked is blocked in against counterwise direction
-        eAS_DISABLED,            //!< axis is disabled
-        eAS_LIMITS_REACHED,      //!< position limits reached and axis stopped
-
-        eAS_DIMENSION //!< Endmarker and Dimension
-    };
+    eMCM_DIMENSION //!< Endmarker and Dimension
+  };
 
 
-    //#######################################################################
-    /*!
-        \anchor sdhlibrary_cpp_sdh_h_unit_conversion_objects
-         \name   Predefined unit conversion objecs
+  //! The state of an axis (see TPOSCON_STATE in global.h of the %SDH firmware)
+  enum eAxisState
+  {
+    eAS_IDLE = 0,            //!< axis is idle
+    eAS_POSITIONING,         //!< the goal position has not been reached yet
+    eAS_SPEED_MODE,          //!< axis is in speed mode
+    eAS_NOT_INITIALIZED,     //!< axis is not initialized or doesn't exist
+    eAS_CW_BLOCKED,          //!< axis is blocked in counterwise direction
+    eAS_CCW_BLOCKED,         //!< axis is blocked is blocked in against counterwise direction
+    eAS_DISABLED,            //!< axis is disabled
+    eAS_LIMITS_REACHED,      //!< position limits reached and axis stopped
 
-         Some predefined cUnitConverter unit conversion objects to
-         convert values between different unit systems. These are static members since the converter objects do not
-         depend on the individiual cSDH object.
-
-         For every physical unit used in the cSDH class there is at
-         least one (most of the time more than one) predefined unit
-         converter. For example for angles there are \e radians and \e degrees.
-
-         @{
-    */
-
-    //! Default converter for angles (internal unit == external unit): degrees
-    static cUnitConverter const uc_angle_degrees;
-
-    //! Converter for angles: external unit = radians
-    static cUnitConverter const uc_angle_radians;
-
-    //! Default converter for times (internal unit == external unit): seconds
-    static cUnitConverter const uc_time_seconds;
-
-    //! Converter for times: external unit = milliseconds
-    static cUnitConverter const uc_time_milliseconds;
-
-    //! Default converter for temparatures (internal unit == external unit): degrees celsius
-    static cUnitConverter const uc_temperature_celsius;
-
-    //! Converter for temperatures: external unit = degrees fahrenheit
-    static cUnitConverter const uc_temperature_fahrenheit;
-
-    //! Default converter for angular velocities (internal unit == external unit): degrees / second
-    static cUnitConverter const uc_angular_velocity_degrees_per_second;
-
-    //! Converter for angular velocieties: external unit = radians/second
-    static cUnitConverter const uc_angular_velocity_radians_per_second;
-
-    //! Default converter for angular accelerations (internal unit == external unit): degrees / second
-    static cUnitConverter const uc_angular_acceleration_degrees_per_second_squared;
-
-    //! Converter for angular velocieties: external unit = radians/second
-    static cUnitConverter const uc_angular_acceleration_radians_per_second_squared;
-
-    //! Default converter for motor current (internal unit == external unit): Ampere
-    static cUnitConverter const uc_motor_current_ampere;
-
-    //! Converter for motor current: external unit = milli Ampere
-    static cUnitConverter const uc_motor_current_milliampere;
-
-    //! Default converter for position (internal unit == external unit): millimeter
-    static cUnitConverter const uc_position_millimeter;
-
-    //! Converter for position: external unit = meter
-    static cUnitConverter const uc_position_meter;
+    eAS_DIMENSION //!< Endmarker and Dimension
+  };
 
 
-    //  end of doxygen name group sdhlibrary_cpp_sdh_h_unit_conversion_objects
-    //! @}
+  //#######################################################################
+  /*!
+      \anchor sdhlibrary_cpp_sdh_h_unit_conversion_objects
+       \name   Predefined unit conversion objecs
+
+       Some predefined cUnitConverter unit conversion objects to
+       convert values between different unit systems. These are static members since the converter objects do not
+       depend on the individiual cSDH object.
+
+       For every physical unit used in the cSDH class there is at
+       least one (most of the time more than one) predefined unit
+       converter. For example for angles there are \e radians and \e degrees.
+
+       @{
+  */
+
+  //! Default converter for angles (internal unit == external unit): degrees
+  static cUnitConverter const uc_angle_degrees;
+
+  //! Converter for angles: external unit = radians
+  static cUnitConverter const uc_angle_radians;
+
+  //! Default converter for times (internal unit == external unit): seconds
+  static cUnitConverter const uc_time_seconds;
+
+  //! Converter for times: external unit = milliseconds
+  static cUnitConverter const uc_time_milliseconds;
+
+  //! Default converter for temparatures (internal unit == external unit): degrees celsius
+  static cUnitConverter const uc_temperature_celsius;
+
+  //! Converter for temperatures: external unit = degrees fahrenheit
+  static cUnitConverter const uc_temperature_fahrenheit;
+
+  //! Default converter for angular velocities (internal unit == external unit): degrees / second
+  static cUnitConverter const uc_angular_velocity_degrees_per_second;
+
+  //! Converter for angular velocieties: external unit = radians/second
+  static cUnitConverter const uc_angular_velocity_radians_per_second;
+
+  //! Default converter for angular accelerations (internal unit == external unit): degrees / second
+  static cUnitConverter const uc_angular_acceleration_degrees_per_second_squared;
+
+  //! Converter for angular velocieties: external unit = radians/second
+  static cUnitConverter const uc_angular_acceleration_radians_per_second_squared;
+
+  //! Default converter for motor current (internal unit == external unit): Ampere
+  static cUnitConverter const uc_motor_current_ampere;
+
+  //! Converter for motor current: external unit = milli Ampere
+  static cUnitConverter const uc_motor_current_milliampere;
+
+  //! Default converter for position (internal unit == external unit): millimeter
+  static cUnitConverter const uc_position_millimeter;
+
+  //! Converter for position: external unit = meter
+  static cUnitConverter const uc_position_meter;
+
+
+  //  end of doxygen name group sdhlibrary_cpp_sdh_h_unit_conversion_objects
+  //! @}
 
 protected:
-    //---------------------
-    // Misc member variables
+  //---------------------
+  // Misc member variables
 
-    //! The number of axis per finger (for finger 1 this includes the "virtual" base axis)
-    int NUMBER_OF_AXES_PER_FINGER;
-
-
-    //! The number of virtual axes
-    int NUMBER_OF_VIRTUAL_AXES;
-
-    //! The number of all axes including virtual axes
-    int nb_all_axes;
-
-    //! Mapping of finger index to number of real axes of fingers:
-    std::vector<int> finger_number_of_axes;
+  //! The number of axis per finger (for finger 1 this includes the "virtual" base axis)
+  int NUMBER_OF_AXES_PER_FINGER;
 
 
-    //! Mapping of finger index, finger axis index to axis index:
-    std::vector<std::vector<int> > finger_axis_index;
+  //! The number of virtual axes
+  int NUMBER_OF_VIRTUAL_AXES;
 
-    //! Vector of 3 epsilon values
-    //f_eps_v;
+  //! The number of all axes including virtual axes
+  int nb_all_axes;
 
-    //! Vector of 3 0.0 values
-    std::vector<double> f_zeros_v;
-
-    //! Vector of 3 1.0 values
-    std::vector<double> f_ones_v;
+  //! Mapping of finger index to number of real axes of fingers:
+  std::vector<int> finger_number_of_axes;
 
 
-    //! Vector of nb_all_axes 0.0 values
-    std::vector<double> zeros_v;
+  //! Mapping of finger index, finger axis index to axis index:
+  std::vector<std::vector<int> > finger_axis_index;
 
-    //! Vector of nb_all_axes 1.0 values
-    std::vector<double> ones_v;
+  //! Vector of 3 epsilon values
+  //f_eps_v;
 
+  //! Vector of 3 0.0 values
+  std::vector<double> f_zeros_v;
 
-    //! Minimum allowed motor currents (in internal units (Ampere)), including the virtual axis
-    std::vector<double> f_min_motor_current_v;
-
-    //! Maximum allowed motor currents (in internal units (Ampere)), including the virtual axis
-    std::vector<double> f_max_motor_current_v;
-
+  //! Vector of 3 1.0 values
+  std::vector<double> f_ones_v;
 
 
-    //! Minimum allowed axis angles (in internal units (degrees)), including the virtual axis
-    std::vector<double> f_min_angle_v;
+  //! Vector of nb_all_axes 0.0 values
+  std::vector<double> zeros_v;
 
-    //! Maximum allowed axis angles (in internal units (degrees)), including the virtual axis
-    std::vector<double> f_max_angle_v;
+  //! Vector of nb_all_axes 1.0 values
+  std::vector<double> ones_v;
 
-    //! Minimum allowed axis velocity (in internal units (degrees/second)), including the virtual axis
-    std::vector<double> f_min_velocity_v;
 
-    //! Maximum allowed axis velocity (in internal units (degrees/second)), including the virtual axis
-    std::vector<double> f_max_velocity_v;
+  //! Minimum allowed motor currents (in internal units (Ampere)), including the virtual axis
+  std::vector<double> f_min_motor_current_v;
 
-    //! Minimum allowed axis acceleration (in internal units (degrees/(second * second))), including the virtual axis
-    std::vector<double> f_min_acceleration_v;
+  //! Maximum allowed motor currents (in internal units (Ampere)), including the virtual axis
+  std::vector<double> f_max_motor_current_v;
 
-    //! Maximum allowed axis acceleration (in internal units (degrees/(second * second))), including the virtual axis
-    std::vector<double> f_max_acceleration_v;
 
-    //! Maximum allowed grip velocity (in internal units (degrees/second))
-    double grip_max_velocity;
 
-    /*!
-      \anchor sdhlibrary_cpp_sdh_h_kinematic_vars
-       \name   Kinematic parameters of the Hand
+  //! Minimum allowed axis angles (in internal units (degrees)), including the virtual axis
+  std::vector<double> f_min_angle_v;
 
-       @{
-    */
+  //! Maximum allowed axis angles (in internal units (degrees)), including the virtual axis
+  std::vector<double> f_max_angle_v;
 
-    //! length of limb 1 (proximal joint to distal joint) in mm
-    double l1;
+  //! Minimum allowed axis velocity (in internal units (degrees/second)), including the virtual axis
+  std::vector<double> f_min_velocity_v;
 
-    //! length of limb 2 (distal joint to fingertip) in mm
-    double l2;
+  //! Maximum allowed axis velocity (in internal units (degrees/second)), including the virtual axis
+  std::vector<double> f_max_velocity_v;
 
-    // distance between center points of base joints f0<->f1, f1<->f2, f0<->f2
-    double d;
+  //! Minimum allowed axis acceleration (in internal units (degrees/(second * second))), including the virtual axis
+  std::vector<double> f_min_acceleration_v;
 
-    // height of center of base joints above finger base plate
-    double h;
+  //! Maximum allowed axis acceleration (in internal units (degrees/(second * second))), including the virtual axis
+  std::vector<double> f_max_acceleration_v;
 
-    /*!
-        list of xyz-vectors for all fingers with offset from (0,0,0) of proximal joint in mm
+  //! Maximum allowed grip velocity (in internal units (degrees/second))
+  double grip_max_velocity;
 
-    */
-    std::vector<std::vector<double> > offset;
+  /*!
+    \anchor sdhlibrary_cpp_sdh_h_kinematic_vars
+     \name   Kinematic parameters of the Hand
 
-    cSerialBase* com;
+     @{
+  */
 
-    // !!! make this public for now (to access comm_interface->ref() / comm_interface->pos_save() for hands with missing absolute encoders)
+  //! length of limb 1 (proximal joint to distal joint) in mm
+  double l1;
+
+  //! length of limb 2 (distal joint to fingertip) in mm
+  double l2;
+
+  // distance between center points of base joints f0<->f1, f1<->f2, f0<->f2
+  double d;
+
+  // height of center of base joints above finger base plate
+  double h;
+
+  /*!
+      list of xyz-vectors for all fingers with offset from (0,0,0) of proximal joint in mm
+
+  */
+  std::vector<std::vector<double> > offset;
+
+  cSerialBase* com;
+
+  // !!! make this public for now (to access comm_interface->ref() / comm_interface->pos_save() for hands with missing absolute encoders)
 public:
-    //! The object to interface with the %SDH attached via serial RS232 or CAN or TCP.
-    cSDHSerial comm_interface;
+  //! The object to interface with the %SDH attached via serial RS232 or CAN or TCP.
+  cSDHSerial comm_interface;
 
-    //! change the stream to use for debug messages
-    virtual void SetDebugOutput( std::ostream* debuglog )
-    {
-        cSDHBase::SetDebugOutput( debuglog );
-        comm_interface.SetDebugOutput( debuglog );
-    }
+  //! change the stream to use for debug messages
+  virtual void SetDebugOutput(std::ostream* debuglog)
+  {
+    cSDHBase::SetDebugOutput(debuglog);
+    comm_interface.SetDebugOutput(debuglog);
+  }
 
 protected:
 
-    //######################################################################
-    /*!
-      \anchor sdhlibrary_cpp_sdh_h_csdh_internal
-       \name   Internal helper methods
+  //######################################################################
+  /*!
+    \anchor sdhlibrary_cpp_sdh_h_csdh_internal
+     \name   Internal helper methods
 
-       @{
-    */
+     @{
+  */
 
-    //----------------------------------------------------------------------
-    /*!
-        Generic set function: set some given axes to given values
+  //----------------------------------------------------------------------
+  /*!
+      Generic set function: set some given axes to given values
 
-        \param axes       - a vector of axis indices
-        \param values     - a vector of values
-        \param ll_set     - a pointer to the low level set function to use
-        \param ll_get     - a pointer to the low level get function to use (for those axes where the given value is NaN)
-        \param uc         - a pointer to the unit converter object to use before sending values to \a ll_set
-        \param min_values - a vector with the minimum allowed values
-        \param max_values - a vector with the maximum allowed values
-        \param name       - a string with the name of the values (for constructing error message)
+      \param axes       - a vector of axis indices
+      \param values     - a vector of values
+      \param ll_set     - a pointer to the low level set function to use
+      \param ll_get     - a pointer to the low level get function to use (for those axes where the given value is NaN)
+      \param uc         - a pointer to the unit converter object to use before sending values to \a ll_set
+      \param min_values - a vector with the minimum allowed values
+      \param max_values - a vector with the maximum allowed values
+      \param name       - a string with the name of the values (for constructing error message)
 
-        \return the values returned from the SDH will be returned
-           (for most commands ll_set/ll_get functions this will be the \a values, except
-            for the cSDHSerial::tvav and cSDHSerial::tpap functions)
+      \return the values returned from the SDH will be returned
+         (for most commands ll_set/ll_get functions this will be the \a values, except
+          for the cSDHSerial::tvav and cSDHSerial::tpap functions)
 
-        \remark
-        - The length of the \a axis and \a values vector must match.
-        - The indices can be given in any order, but the order of the
-          elements of \a axes and \a values must
-          match too. I.e. \c values[i] will be applied
-          to axis \c axes[i] (not axis \c i)
-        - The indices are checked if they are valid axis indices.
-        - The values are checked if they are in the allowed range
-          [\a min_values .. \a f_max_values], i.e. it is checked that \c
-          value[i], converted to the internal unit system by \a uc->ToInternal(),
-          is in [\a min_values[axes[i]] .. \a max_values[axes[i]]].
-        - If \b any index or value is invalid then \b none of the specified values is
-          sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter* exception is thrown.
+      \remark
+      - The length of the \a axis and \a values vector must match.
+      - The indices can be given in any order, but the order of the
+        elements of \a axes and \a values must
+        match too. I.e. \c values[i] will be applied
+        to axis \c axes[i] (not axis \c i)
+      - The indices are checked if they are valid axis indices.
+      - The values are checked if they are in the allowed range
+        [\a min_values .. \a f_max_values], i.e. it is checked that \c
+        value[i], converted to the internal unit system by \a uc->ToInternal(),
+        is in [\a min_values[axes[i]] .. \a max_values[axes[i]]].
+      - If \b any index or value is invalid then \b none of the specified values is
+        sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter* exception is thrown.
 
-                        // \bug: setting a single axis velocity only sets the velocities of all other axes to 0!
-                // So in order to address only some axes you must provide the desired velocity for all
-                // axes that you want to move in every call:
-        \bug
-          With %SDH firmware 0.0.2.16 and SDHLibrary-CPP 0.0.2.3 and binary
-          communication (see also #SDH_USE_BINARY_COMMUNICATION) setting of
-          single (more precisely: less-than-all) axis parameters (position,
-          velocity, acceleration) does not work as expected:
-          If a single parameter is to be set for a single axis then that
-          parameter is set to 0 for all other axes. <br>
-          \b Workaround:
-          If you want to access several different axes one after another
-          then you have to keep a vector of the parameter for all
-          your used axes in your application. You can then update single
-          values of the vector on demand, but you have to send the
-          complete vector to the SDHlibrary functions on every call.
-    */
-    std::vector<double> SetAxisValueVector( std::vector<int> const& axes,
-                                            std::vector<double> const& values,
-                                            pSetFunction ll_set,
-                                            pGetFunction ll_get,
-                                            cUnitConverter const* uc,
-                                            std::vector<double> const& min_values,
-                                            std::vector<double> const& max_values,
-                                            char const* name )
-                                            throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Generic get function: get some given axes values
-
-        \param axes   - a vector of axis indices
-        \param ll_get - a pointer to the low level get function to use
-        \param uc     - a pointer to the unit converter object to apply before returning values
-        \param name   - a string with the name of the values (for constructing error message)
-
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-        - A vector of the addressed values for the selected axes.
-        - The values are converted to external unit system using the
-          \a uc unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
-    */
-    std::vector<double> GetAxisValueVector( std::vector<int> const& axes,
-                                            pGetFunction ll_get,
-                                            cUnitConverter const* uc,
-                                            char const* name )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Internal helper function: return a vector of checked indices according to index.
-
-        \param index           - The index to vectorize or #All
-        \param all_replacement - a vector to return if \a index is #All
-        \param maxindex        - the \a index is checked if in [0..\ maxindex[ (i.e. not including \a maxindex)
-        \param name            - A name for the things index, used to report out of bounds errors
-
-        \return
-        - If \a index is #All then \a all_replacement is returned.
-        - If \a index is a single number >= 0 then it is checked if in
-          [0..\ maxindex[ and a vector of length 1 is returned containing
-          only \a index.
-        - In case \a index exceeds \a maxindex a (cSDHErrorInvalidParameter*) exception is thrown.
-    */
-    std::vector<int> ToIndexVector( int index, std::vector<int>& all_replacement, int maxindex, char const* name )
-        throw (cSDHLibraryException*);
+                      // \bug: setting a single axis velocity only sets the velocities of all other axes to 0!
+              // So in order to address only some axes you must provide the desired velocity for all
+              // axes that you want to move in every call:
+      \bug
+        With %SDH firmware 0.0.2.16 and SDHLibrary-CPP 0.0.2.3 and binary
+        communication (see also #SDH_USE_BINARY_COMMUNICATION) setting of
+        single (more precisely: less-than-all) axis parameters (position,
+        velocity, acceleration) does not work as expected:
+        If a single parameter is to be set for a single axis then that
+        parameter is set to 0 for all other axes. <br>
+        \b Workaround:
+        If you want to access several different axes one after another
+        then you have to keep a vector of the parameter for all
+        your used axes in your application. You can then update single
+        values of the vector on demand, but you have to send the
+        complete vector to the SDHlibrary functions on every call.
+  */
+  std::vector<double> SetAxisValueVector(std::vector<int> const& axes,
+                                         std::vector<double> const& values,
+                                         pSetFunction ll_set,
+                                         pGetFunction ll_get,
+                                         cUnitConverter const* uc,
+                                         std::vector<double> const& min_values,
+                                         std::vector<double> const& max_values,
+                                         char const* name)
+  throw (cSDHLibraryException*);
 
 
-    //-----------------------------------------------------------------
-    /*!
-        Internal helper function: return the get/set function of the
-        comm_interface object that is responsible for setting/getting
-        motor currents in \a mode.
-    */
-    pSetFunction GetMotorCurrentModeFunction( eMotorCurrentMode mode )
-        throw(cSDHLibraryException*);
+  //----------------------------------------------------------------------
+  /*!
+      Generic get function: get some given axes values
+
+      \param axes   - a vector of axis indices
+      \param ll_get - a pointer to the low level get function to use
+      \param uc     - a pointer to the unit converter object to apply before returning values
+      \param name   - a string with the name of the values (for constructing error message)
+
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \return
+      - A vector of the addressed values for the selected axes.
+      - The values are converted to external unit system using the
+        \a uc unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
+  */
+  std::vector<double> GetAxisValueVector(std::vector<int> const& axes,
+                                         pGetFunction ll_get,
+                                         cUnitConverter const* uc,
+                                         char const* name)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Internal helper function: return a vector of checked indices according to index.
+
+      \param index           - The index to vectorize or #All
+      \param all_replacement - a vector to return if \a index is #All
+      \param maxindex        - the \a index is checked if in [0..\ maxindex[ (i.e. not including \a maxindex)
+      \param name            - A name for the things index, used to report out of bounds errors
+
+      \return
+      - If \a index is #All then \a all_replacement is returned.
+      - If \a index is a single number >= 0 then it is checked if in
+        [0..\ maxindex[ and a vector of length 1 is returned containing
+        only \a index.
+      - In case \a index exceeds \a maxindex a (cSDHErrorInvalidParameter*) exception is thrown.
+  */
+  std::vector<int> ToIndexVector(int index, std::vector<int>& all_replacement, int maxindex, char const* name)
+  throw (cSDHLibraryException*);
 
 
-    //-----------------------------------------------------------------
-    /*!
-        return cartesian [x,y,z] position in mm of fingertip for finger fi at angles r_angles (rad)
-    */
-    std::vector<double> _GetFingerXYZ( int fi, std::vector<double> r_angles )
-        throw(cSDHLibraryException*);
+  //-----------------------------------------------------------------
+  /*!
+      Internal helper function: return the get/set function of the
+      comm_interface object that is responsible for setting/getting
+      motor currents in \a mode.
+  */
+  pSetFunction GetMotorCurrentModeFunction(eMotorCurrentMode mode)
+  throw(cSDHLibraryException*);
 
 
-    //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_internal
-    //! @}
-    //#####################################################################
+  //-----------------------------------------------------------------
+  /*!
+      return cartesian [x,y,z] position in mm of fingertip for finger fi at angles r_angles (rad)
+  */
+  std::vector<double> _GetFingerXYZ(int fi, std::vector<double> r_angles)
+  throw(cSDHLibraryException*);
+
+
+  //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_internal
+  //! @}
+  //#####################################################################
 
 
 public:
-    //----------------------------------------------------------------------
-    /*!
-        \anchor sdhlibrary_cpp_sdh_h_index_vectors
-        \name   Predefined index vector objects
-
-         @{
-    */
-
-    //! A vector with indices of all axes (in natural order), including the virtual axis.
-    std::vector<int> all_axes;
-
-    //! A vector with indices of all real axes (in natural order), excluding the virtual axis.
-    std::vector<int> all_real_axes;
-
-    //! A vector with indices of all fingers (in natural order)
-    std::vector<int> all_fingers;
-
-    //! A vector with indices of all temperature sensors
-    std::vector<int> all_temperature_sensors;
-
-    //  end of sdhlibrary_cpp_sdh_h_index_vectors
-    //! @}
-    //----------------------------------------------------------------------
-
-
-    //----------------------------------------------------------------------
-    /*!
-        \anchor sdhlibrary_cpp_sdh_h_unit_conversion_ptrs
-        \name   Predefined unit conversion objects
-
-         Pointers to the unit converter objects used by this cSDH object.
-
-         The refered objects convert values between different unit
-         systems. Example: convert angle values between \e degrees and
-         \e radians, temperatures between \e degrees \e celsius and \e degrees
-         \e fahrenheit or the like.
-
-         A cSDH object uses these converter objects to convert between external (user)
-         and internal (%SDH) units. The user can easily change the converter object
-         that is used for a certain kind of unit. This way a cSDH object
-         can easily report and accept parameters in the user or application
-         specific unit system.
-
-         Additionally, users can easily add conversion objects for their own,
-         even more user- or application-specific unit systems.
-
-         @{
-    */
-
-    //! unit convert for (axis) angles: default = #SDH::cSDH::uc_angle_degrees
-    const cUnitConverter* uc_angle;
-
-
-    //! unit convert for (axis) angular velocities: default = #SDH::cSDH::uc_angular_velocity_degrees_per_second
-    const cUnitConverter* uc_angular_velocity;
-
-
-    //! unit convert for (axis) angular accelerations: default = #SDH::cSDH::uc_angular_acceleration_degrees_per_second_squared
-    const cUnitConverter* uc_angular_acceleration;
-
-
-    //! unit convert for times: default = uc_time_seconds
-    const cUnitConverter* uc_time;
-
-
-    //! unit convert for temperatures: default = #SDH::cSDH::uc_temperature_celsius
-    const cUnitConverter* uc_temperature;
-
-
-    //! unit converter for motor curent: default = #SDH::cSDH::uc_motor_current_ampere
-    const cUnitConverter* uc_motor_current;
-
-
-    //! unit converter for position: default = #SDH::cSDH::uc_position_millimeter
-    const cUnitConverter* uc_position;
-    //---------------------
-
-    // end of sdhlibrary_cpp_sdh_h_unit_conversion_ptrs
-    //! @}
-    //----------------------------------------------------------------------
-
-
-    //-----------------------------------------------------------------
-    /*!
-      \brief Constructor of cSDH class.
-
-       Creates an new object of type cSDH. One such object is needed
-       for each %SDH that you want to control.  The constructor
-       initializes internal data structures. A connection the %SDH is
-       \b not yet established, see #OpenRS232() on how to do that.
-
-       After an object is created the user can adjust the unit systems
-       used to set/report parameters to/from %SDH. This is shown in the
-       example code below. The default units used (if not overwritten
-       by constructor parameters) are:
-       - \c degrees [deg] for (axis) angles
-       - \c degrees \c per \c second [deg/s] for (axis) angular velocities
-       - \c seconds [s] for times
-       - \c degrees \c celsius [deg C] for temperatures
-
-       \param _use_radians    : Flag, if true then use radians and radians/second
-                                to set/report (axis) angles and angular velocities
-                                instead of default degrees and degrees/s.
-       \param _use_fahrenheit : Flag, if true then use degrees fahrenheit
-                                to report temperatures instead of default degrees celsius.
-       \param _debug_level    : The level of debug messages to print
-                                - 0: (default) no messages
-                                - 1: messages of this cSDH instance
-                                - 2: like 1 plus messages of the inner cSDHSerial instance
-
-       \par Examples:
-
-       Common use:
-       \code
-         // Include the cSDH interface
-         #include <sdh.h>
-
-         // Create a cSDH object 'hand'.
-         cSDH hand();
-       \endcode
-
-       The mentioned change of a unit system can be done like this:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-
-         // override default unit converter for (axis) angles:
-         hand.uc_angle = &cSDH::uc_angle_radians;
-
-         // override default unit converter for (axis) angular velocities:
-         hand.uc_angular_velocity = &cSDH::uc_angular_velocity_radians_per_second;
-
-         // override default unit converter for (axis) angular accelerations:
-         hand.uc_angular_acceleration = &cSDH::uc_angular_acceleration_radians_per_second_squared;
-
-         // instead of the last 3 calls the following shortcut could be used:
-         hand.UseRadians();
-
-         // override default unit converter for times:
-         hand.uc_time  = &cSDH::uc_time_milliseconds;
-
-         // override default unit converter for temperatures:
-         hand.uc_temperature = &cSDH::uc_temperature_fahrenheit;
-
-         // override default unit converter for positions:
-         hand.uc_position = &cSDH::uc_position_meter;
-
-       \endcode
-
-
-       For convenience the most common settings can be specified as
-       bool parameters for the constructor, like in:
-
-       \code
-         // Include the cSDH interface
-         #include <sdh.h>
-
-         // Create a cSDH object 'hand' that uses
-         // - the non default radians and radians/s units,
-         // - the default temperature in degrees celsius,
-         // - A debug level of 2
-         cSDH hand( true, false, 2 );
-
-       \endcode
-
-       <hr>
-    */
-    cSDH( bool _use_radians=false, bool _use_fahrenheit=false, int _debug_level=0 );
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Virtual destructor to make compiler happy
-
-        If the connection to the %SDH hardware/firmware is still open
-        then the connection is closed, which will stop the axis
-        controllers (and thus prevent overheating).
-    */
-    virtual ~cSDH();
-
-
-    //######################################################################
-    /*!
-      \anchor sdhlibrary_cpp_sdh_h_csdh_misc
-       \name   Miscellaneous methods
+  //----------------------------------------------------------------------
+  /*!
+      \anchor sdhlibrary_cpp_sdh_h_index_vectors
+      \name   Predefined index vector objects
 
        @{
-    */
+  */
 
-    //----------------------------------------------------------------------
-    //! Return \c true if index \a iAxis refers to a virtual axis
-    bool IsVirtualAxis( int iAxis )
-        throw (cSDHLibraryException*);
+  //! A vector with indices of all axes (in natural order), including the virtual axis.
+  std::vector<int> all_axes;
 
-    //-----------------------------------------------------------------
-    /*!
-      Shortcut to set the unit system to radians.
+  //! A vector with indices of all real axes (in natural order), excluding the virtual axis.
+  std::vector<int> all_real_axes;
 
-       After calling this axis angles are set/reported in radians and
-       angular velocities are set/reported in radians/second
+  //! A vector with indices of all fingers (in natural order)
+  std::vector<int> all_fingers;
 
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
+  //! A vector with indices of all temperature sensors
+  std::vector<int> all_temperature_sensors;
 
-         // make hand object use radians and radians/second for angles and angular velocities
-         hand.UseRadians();
+  //  end of sdhlibrary_cpp_sdh_h_index_vectors
+  //! @}
+  //----------------------------------------------------------------------
 
-       \endcode
 
-       <hr>
-    */
-    void UseRadians( void );
+  //----------------------------------------------------------------------
+  /*!
+      \anchor sdhlibrary_cpp_sdh_h_unit_conversion_ptrs
+      \name   Predefined unit conversion objects
 
+       Pointers to the unit converter objects used by this cSDH object.
 
-    //-----------------------------------------------------------------
-    /*!
-      Shortcut to set the unit system to degrees.
+       The refered objects convert values between different unit
+       systems. Example: convert angle values between \e degrees and
+       \e radians, temperatures between \e degrees \e celsius and \e degrees
+       \e fahrenheit or the like.
 
-       After calling this (axis) angles are set/reported in degrees and
-       angular velocities are set/reported in degrees/second
+       A cSDH object uses these converter objects to convert between external (user)
+       and internal (%SDH) units. The user can easily change the converter object
+       that is used for a certain kind of unit. This way a cSDH object
+       can easily report and accept parameters in the user or application
+       specific unit system.
 
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-
-         // make hand object use degrees and degrees/second for angles and angular velocities
-         hand.UseDegrees();
-         // as degrees, degrees/second are the default this is needed only if the
-         // unit system was changed before
-
-       \endcode
-
-       <hr>
-    */
-    void UseDegrees( void );
-
-
-    //-----------------------------------------------------------------
-    /*!
-      Return the number of real axes of finger with index \a iFinger.
-
-       \param iFinger - index of finger in range [0..NUMBER_OF_FINGERS-1]
-
-       \return
-       - Number of real axes of finger with index \a iFinger
-       - If \a iFinger is invalid a (cSDHErrorInvalidParameter*) exception is thrown.
-
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-
-         cout << "The finger 0 has " << hand.GetFingerNumberOfAxes( 0 ) << " real axes\n";
-
-       \endcode
-
-       <hr>
-    */
-    int GetFingerNumberOfAxes( int iFinger )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-      Return axis index of \a iFingerAxis axis of finger with index iFinger
-
-       For \a iFinger=2, iFingerAxis=0 this will return the index of
-       the virtual base axis of the finger
-
-       \param iFinger     - index of finger in range [0..NUMBER_OF_FINGERS-1]
-       \param iFingerAxis - index of finger axis in range [0..NUMBER_OF_AXES_PER_FINGER-1]
-
-       \return
-       - Axis index of \a iFingerAxis-th axis of finger with index \a iFinger
-       - If \a iFinger or \a iFingerAxis is invalid a (cSDHErrorInvalidParameter*) exception is thrown.
-
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-
-         cout << "The 1st axis of finger 2 has real axis index " << hand.GetFingerNumberOfAxes( 2, 0 ) << "\n";
-
-       \endcode
-
-       <hr>
-    */
-    int GetFingerAxisIndex( int iFinger, int iFingerAxis )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-      Return the release name of the library (not the firmware of the %SDH) as string.
-
-
-       \par Examples:
-       \code
-         // static member function, so no cSDH object is needed for access:
-
-         cout << "The SDHLibrary reports release name " << cSDH::GetReleaseLibrary() << "\n";
-
-       \endcode
-
-       <hr>
-    */
-    static char const* GetLibraryRelease( void );
-
-
-    //-----------------------------------------------------------------
-    /*!
-      Return the name of the library as string.
-
-
-       \par Examples:
-       \code
-         // static member function, so no cSDH object is needed for access:
-
-         cout << "The SDHLibrary reports name " << cSDH::GetLibraryName() << "\n";
-
-       \endcode
-
-       <hr>
-    */
-    static char const* GetLibraryName( void );
-
-
-    //-----------------------------------------------------------------
-    /*!
-      Return the actual release name of the firmware of the %SDH (not the library) as string.
-
-      This will throw a (cSDHErrorCommunication*) exception if the
-      connection to the %SDH is not yet opened.
-
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-
-         cout << "The SDH firmware reports release " << hand.GetFirmwareRelease() << "\n";
-
-       \endcode
-
-       \see See GetFirmwareReleaseRecommended() to get the recommended SDH firmware release.
-       <hr>
-    */
-    char const* GetFirmwareRelease( void )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-      Return the recommended release of the firmware of the %SDH
-      by this library as string.
-
-       \par Examples:
-       \code
-         // static member function, so no cSDH object is needed for access:
-
-         cout << "This SDHLibrary recommends an SDH firmware release " << cSDH::GetFirmwareReleaseRecommended() << "\n";
-
-       \endcode
-
-       \see See GetFirmwareRelease() to get the actual release of the SDH firmware
-       <hr>
-    */
-    static char const* GetFirmwareReleaseRecommended( void );
-
-    //-----------------------------------------------------------------
-    /*!
-      Check the actual release of the firmware of the connected %SDH against the
-      recommended firmware release.
-      \return true - if the actual firmware is the recommended one
-              false - the actual firmware is NOT the recommended one (communication with the SDH might not work as expected)
-
-      This will throw a (cSDHErrorCommunication*) exception if the
-      connection to the %SDH is not yet opened.
-
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-
-         if ( hand.CheckFirmwareRelease() )
-         {
-             cout << "The firmware release of the connected SDH is the one recommended by this SDHLibrary\n";
-         }
-         else
-         {
-             cout << "The firmware release of the connected SDH is NOT the one recommended by this SDHLibrary\n";
-             cout << "  Actual SDH firmware release      " << hand.GetFirmwareRelease() << "\n";
-             cout << "  Recommended SDH firmware release " << hand.GetFirmwareReleaseRecommended() << "\n";
-         }
-
-       \endcode
-
-       \see See GetFirmwareReleaseRecommended() to get the recommended SDH firmware release.
-       <hr>
-    */
-    bool CheckFirmwareRelease( void )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*! Return info according to \a what
-    #
-    #  The following values are valid for \a what:
-    #  - "date-library"     : date of the SDHLibrary-python release
-    #  - "release-library"  : release name of the sdh.py python module
-    #  - "release-firmware" : release name of the %SDH firmware (requires
-    #                         an opened communication to the %SDH)
-    #  - "release-firmware-recommended" : recommended release name of the %SDH
-    #                         firmware
-    #  - "date-firmware"    : date of the %SDH firmware (requires
-    #                         an opened communication to the %SDH)
-    #  - "release-soc"      : release name of the %SDH SoC (requires
-    #                         an opened communication to the %SDH)
-    #  - "date-soc"         : date of the %SDH SoC (requires
-    #                         an opened communication to the %SDH)
-    #  - "id-sdh"           : ID of %SDH
-    #  - "sn-sdh"           : Serial number of %SDH
-    #
-    #  \par Examples:
-    #  \code
-    #    # Assuming 'hand' is a sdh.cSDH object ...
-    #
-    #    print "The SDH firmware reports release %s" % ( hand.GetInfo( "release-firmware" ) )
-    #
-    #  \endcode
-    #
-    #  <hr>
-    */
-    char const* GetInfo( char const* what )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Return temperature(s) measured within the %SDH.
-
-        \param sensors - A vector of indices of temperature sensors to access.
-                       - index 0 is sensor near motor of axis 0 (root)
-                       - index 1 is sensor near motor of axis 1 (proximal finger 1)
-                       - index 2 is sensor near motor of axis 2 (distal finger 1)
-                       - index 3 is sensor near motor of axis 3 (proximal finger 2)
-                       - index 4 is sensor near motor of axis 4 (distal finger 2)
-                       - index 5 is sensor near motor of axis 5 (proximal finger 3)
-                       - index 6 is sensor near motor of axis 6 (distal finger 3)
-                       - index 7 is FPGA temperature (controller chip)
-                       - index 8 is PCB temperature (Printed Circuit Board)
-
-        \remark
-        - The indices in \a sensors are checked if they are valid sensor indices.
-        - If \b any sensor index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        To access a single temperature sensor use #GetTemperature(int), see there.
-
-        \return
-          The temperatures of the selected sensors are returned as
-          std::vector<double> in the configured temperature unit system
-          #uc_temperature.
-
-
-        \par Examples:
-        \code
-          // Assuming 'hand' is a cSDH object ...
-
-          // Get measured values of all sensors
-          std::vector<double> temps = hand.GetTemperature( hand.all_temperature_sensors );
-          // Now temps is something like { 38.500,37.250,35.750,37.250,33.500,36.500,32.250,59.625,52.500 }
-
-          // Get controller temperature only:
-          double temp_controller = hand.GetTemperature( 0 );
-          // Now temp_controller is something like 40.5
-
-          // If we - for some obscure islandish reason - would want
-          // temperatures reported in degrees fahrenheit, the unit
-          // converter can be changed:
-          hand.uc_temperature = &cSDH::uc_temperature_fahrenheit;
-
-          // Get all temperaturs again:
-          temps = hand.GetTemperature( hand.all_temperature_sensors );
-          // Now temps is something like {100.0, 96.8, 92.3, 97.7, 91.8, 96.8, 90.1,  137.5,  125.2}
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetTemperature( std::vector<int> const& sensors )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetTemperature(std::vector<int>const&), just for one sensor
-        \a iSensor and returning a single temperature as double.
-    */
-    double GetTemperature( int iSensor )
-        throw (cSDHLibraryException*);
-
-
-    //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_common
-    //! @}
-    //#####################################################################
-
-
-    //######################################################################
-    /*!
-       \anchor sdhlibrary_cpp_sdh_h_csdh_communication
-       \name   Communication methods
+       Additionally, users can easily add conversion objects for their own,
+       even more user- or application-specific unit systems.
 
        @{
-    */
-
-    //-----------------------------------------------------------------
-    /*!
-      Open connection to %SDH via RS232.
-
-       \param _port    : The number of the serial port to use.
-                         The default value port=0 refers to 'COM1' in Windows and
-                         to the corresponding '/dev/ttyS0' in Linux.
-       \param _baudrate: the baudrate in bit/s, the default is 115200 which happens
-                         to be the default for the %SDH too
-       \param _timeout : The timeout to use:
-                         - -1 : wait forever
-                         - T  : wait for T seconds
-       \param _device_format_string : a format string (C string) for generating the device name, like "/dev/ttyS%d" (default) or "/dev/ttyUSB%d".
-                                     Must contain a %d where the port number should be inserted.
-                                     This char array is duplicated on construction
-                                     When compiled with VCC (MS-Visual C++) then this is not used.
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-
-         // Open connection to SDH via default port:
-         hand.OpenRS232();
-
-         // Use a different port 2 == COM3 == /dev/ttyS2 for a second hand "hand2":
-         cSDH hand2();
-         hand2.OpenRS232( 2 );
-
-         // Linux only: Use a different USB to RS232 device on port 3 /dev/ttyUSB3 for a third hand "hand3":
-         cSDH hand3();
-         hand2.OpenRS232( 3, 115200, -1, "/dev/ttyUSB%d" );
-
-       \endcode
-
-       <hr>
-    */
-    void OpenRS232(  int _port=0, unsigned long _baudrate = 115200, double _timeout=-1, char const* _device_format_string="/dev/ttyS%d" )
-        throw (cSDHLibraryException*);
-
-
-    /*!
-      Open connection to %SDH via CAN using an ESD CAN card.
-      If the library was compiled without ESD CAN support then this will just throw an
-      exception. See setting for WITH_ESD_CAN in the top level makefile.
-
-       \param _net     : The ESD CAN net number of the CAN port to use. (default: 0)
-       \param _baudrate : the CAN baudrate in bit/s. Only some bitrates are valid: (1000000 (default),800000,500000,250000,125000,100000,50000,20000,10000)
-       \param _timeout : The timeout to use:
-                         - <= 0 : wait forever (default)
-                         - T  : wait for T seconds
-       \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID, default=43=0x02b)
-       \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID, default=42=0x02a)
-
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-
-         // use default parameters for net, baudrate, timeout and IDs
-         hand.OpenCAN_ESD( );
-
-         // use non default settings:
-         // net=1, baudrate=500000, timeout=1.0, id_read=0x143, id_write=0x142
-         hand.OpenCAN_ESD( 1, 500000, 1.0, 0x143, 0x142 );
-       \endcode
-
-       <hr>
-    */
-    void OpenCAN_ESD(  int _net=0,  unsigned long _baudrate=1000000, double _timeout=0.0, Int32 _id_read=43, Int32 _id_write=42 )
-        throw (cSDHLibraryException*);
-
-
-    /*!
-      Open connection to %SDH via CAN using an ESD CAN card using an existing handle.
-      If the library was compiled without ESD CAN support then this will just throw an
-      exception. See setting for WITH_ESD_CAN in the top level makefile.
-
-       \param _ntcan_handle : the ESD CAN handle to reuse (please cast your NTCAN_HANDLE to tDeviceHandle! It is save to do that!)
-       \param _timeout : The timeout to use:
-                         - <= 0 : wait forever (default)
-                         - T  : wait for T seconds
-       \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID, default=43=0x2a)
-       \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID, default=42=0x2a)
-
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-         // and 'handle' is a valid NTCAN_HANDLE for the ESD device
-
-         // use default parameters for timeout and IDs
-         hand.OpenCAN_ESD( tDeviceHandle(handle) );
-
-         // or use non default settings:
-         // timeout=1.0, id_read=0x143, id_write=0x142
-         hand.OpenCAN_ESD( handle, 1.0, 0x143, 0x142 );
-
-       \endcode
-
-       <hr>
-    */
-    void OpenCAN_ESD(  tDeviceHandle _ntcan_handle, double _timeout=0.0, Int32 _id_read=43, Int32 _id_write=42 )
-        throw (cSDHLibraryException*);
-
-
-    /*!
-      Open connection to %SDH via CAN using an PEAK CAN card.
-      If the library was compiled without PEAK CAN support then this will just throw an
-      exception. See setting for WITH_PEAK_CAN in the top level makefile.
-
-       \param _baudrate : the CAN baudrate in bit/s. Only some bitrates are valid: (1000000 (default),800000,500000,250000,125000,100000,50000,20000,10000)
-       \param _timeout : The timeout to use:
-                         - <= 0 : wait forever (default)
-                         - T  : wait for T seconds
-       \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID, default=43=0x02b)
-       \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID, default=42=0x02a)
-       \param _device   - the PEAK device name. Used for the Linux char dev driver only. default="/dev/pcanusb0"
-
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-
-         // use default parameters for baudrate, timeout, IDs and device
-         hand.OpenCAN_PEAK( );
-
-         // use non default settings:
-         // baudrate=500000, timeout=1.0, id_read=0x143, id_write=0x142, , const char *device="/dev/pcanusb1"
-         hand.OpenCAN_PEAK( 500000, 1.0, 0x143, 0x142, "/dev/pcanusb1" );
-       \endcode
-
-       <hr>
-    */
-    void OpenCAN_PEAK( unsigned long _baudrate=1000000, double _timeout=0.0, Int32 _id_read=43, Int32 _id_write=42, const char *_device="/dev/pcanusb0" )
-        throw (cSDHLibraryException*);
-
-
-    /*!
-      Open connection to %SDH via CAN using an PEAK CAN card using an existing handle.
-      If the library was compiled without PEAK CAN support then this will just throw an
-      exception. See setting for WITH_PEAK_CAN in the top level makefile.
-
-       \param _handle : The PEAK CAN handle to reuse to connect to the PEAK CAN driver (please cast your PEAK_HANDLE to tDeviceHandle! It is save to do that!)
-       \param _timeout : The timeout to use:
-                         - <= 0 : wait forever (default)
-                         - T  : wait for T seconds
-       \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID, default=43=0x2a)
-       \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID, default=42=0x2a)
-
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
-         // and 'handle' is a valid HANDLE for the PEAK device
+  */
 
-         // use default parameters for timeout and IDs
-         hand.OpenCAN_PEAK( tDeviceHandle(handle) );
+  //! unit convert for (axis) angles: default = #SDH::cSDH::uc_angle_degrees
+  const cUnitConverter* uc_angle;
 
-         // or use non default settings:
-         // timeout=1.0, id_read=0x143, id_write=0x142
-         hand.OpenCAN_PEAK( handle, 1.0, 0x143, 0x142 );
 
-       \endcode
+  //! unit convert for (axis) angular velocities: default = #SDH::cSDH::uc_angular_velocity_degrees_per_second
+  const cUnitConverter* uc_angular_velocity;
 
-       <hr>
-    */
-    void OpenCAN_PEAK(  tDeviceHandle _handle, double _timeout=0.0, Int32 _id_read=43, Int32 _id_write=42 )
-        throw (cSDHLibraryException*);
 
-    /*!
-      Open connection to %SDH via TCP using TCP/IP address \a _tcp_adr and \a _tcp_port.
+  //! unit convert for (axis) angular accelerations: default = #SDH::cSDH::uc_angular_acceleration_degrees_per_second_squared
+  const cUnitConverter* uc_angular_acceleration;
 
-       \param _tcp_adr : The tcp host address of the SDH. Either a numeric IP as string or a hostname
-       \param _tcp_port : the tcp port number on the SDH to connect to
-       \param _timeout : The timeout to use:
-                         - <= 0 : wait forever (default)
-                         - T  : wait for T seconds
 
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
+  //! unit convert for times: default = uc_time_seconds
+  const cUnitConverter* uc_time;
 
-         // IP-address 192.168.1.1, port 23, timeout=0.0
-         hand.OpenTCP( "192.168.1.1.", 23, 0.0 );
-       \endcode
 
-       <hr>
-    */
-    void OpenTCP( char const* _tcp_adr="192.168.1.1", int _tcp_port=23, double _timeout=0.0 )
-        throw (cSDHLibraryException*);
+  //! unit convert for temperatures: default = #SDH::cSDH::uc_temperature_celsius
+  const cUnitConverter* uc_temperature;
 
-    //-----------------------------------------------------------------
-    /*!
-       Close connection to %SDH.
 
-       The default behaviour is to \b not leave the controllers of the
-       %SDH enabled (to prevent overheating). To keep the controllers
-       enabled (e.g. to keep the finger axes actively in position) set
-       \a leave_enabled to \c true. Only already enabled axes will be
-       left enabled.
+  //! unit converter for motor curent: default = #SDH::cSDH::uc_motor_current_ampere
+  const cUnitConverter* uc_motor_current;
 
-       \param leave_enabled - Flag: true to leave the controllers on,
-                              false (default) to disable the
-                              controllers (switch powerless)
 
-       This throws a (cSDHErrorCommunication*) exception if the
-       connection was not opened before.
+  //! unit converter for position: default = #SDH::cSDH::uc_position_millimeter
+  const cUnitConverter* uc_position;
+  //---------------------
 
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
+  // end of sdhlibrary_cpp_sdh_h_unit_conversion_ptrs
+  //! @}
+  //----------------------------------------------------------------------
 
-         // Close connection to SDH, power off controllers:
-         hand.Close();
 
-         // To leave the already enabled controllers enabled:
-         hand.Close( true );
+  //-----------------------------------------------------------------
+  /*!
+    \brief Constructor of cSDH class.
 
-       \endcode
+     Creates an new object of type cSDH. One such object is needed
+     for each %SDH that you want to control.  The constructor
+     initializes internal data structures. A connection the %SDH is
+     \b not yet established, see #OpenRS232() on how to do that.
 
-       <hr>
-    */
-    void Close( bool leave_enabled=false )
-        throw (cSDHLibraryException*);
+     After an object is created the user can adjust the unit systems
+     used to set/report parameters to/from %SDH. This is shown in the
+     example code below. The default units used (if not overwritten
+     by constructor parameters) are:
+     - \c degrees [deg] for (axis) angles
+     - \c degrees \c per \c second [deg/s] for (axis) angular velocities
+     - \c seconds [s] for times
+     - \c degrees \c celsius [deg C] for temperatures
 
-    //-----------------------------------------------------------------
-    /*!
-        Return true if connection to %SDH firmware/hardware is open.
-    */
-    virtual bool IsOpen( void )
-        throw ();
+     \param _use_radians    : Flag, if true then use radians and radians/second
+                              to set/report (axis) angles and angular velocities
+                              instead of default degrees and degrees/s.
+     \param _use_fahrenheit : Flag, if true then use degrees fahrenheit
+                              to report temperatures instead of default degrees celsius.
+     \param _debug_level    : The level of debug messages to print
+                              - 0: (default) no messages
+                              - 1: messages of this cSDH instance
+                              - 2: like 1 plus messages of the inner cSDHSerial instance
 
-
-    //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_communication
-    //! @}
-    //#####################################################################
-
-
-    //######################################################################
-    /*!
-      \anchor sdhlibrary_cpp_sdh_h_csdh_auxilliary
-       \name   Auxiliary movement methods
-
-       @{
-    */
-
-    //-----------------------------------------------------------------
-    /*!
-      Stop movement of all axes of the %SDH and switch off the controllers
-
-       This command will always be executed sequentially: it will return
-       only after the %SDH has confirmed the emergency stop.
-
-       \bug
-       For now this will \b NOT work while a GripHand() command is
-       executing, even if that was initiated non-sequentially!
-
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
+     \par Examples:
 
-         // Perform an emergency stop:
-         hand.EmergencyStop();
+     Common use:
+     \code
+       // Include the cSDH interface
+       #include <sdh.h>
 
-       \endcode
+       // Create a cSDH object 'hand'.
+       cSDH hand();
+     \endcode
 
-       <hr>
-    */
-    void EmergencyStop( void )
-        throw (cSDHLibraryException*);
+     The mentioned change of a unit system can be done like this:
+     \code
+       // Assuming 'hand' is a cSDH object ...
 
+       // override default unit converter for (axis) angles:
+       hand.uc_angle = &cSDH::uc_angle_radians;
 
-    //-----------------------------------------------------------------
-    /*!
-      Stop movement of all axes but keep controllers on
+       // override default unit converter for (axis) angular velocities:
+       hand.uc_angular_velocity = &cSDH::uc_angular_velocity_radians_per_second;
 
-       This command will always be executed sequentially: it will return
-       only after the %SDH has confirmed the stop
+       // override default unit converter for (axis) angular accelerations:
+       hand.uc_angular_acceleration = &cSDH::uc_angular_acceleration_radians_per_second_squared;
 
-       \bug
-       For now this will \b NOT work while a GripHand() command is
-       executing, even if that was initiated non-sequentially!
+       // instead of the last 3 calls the following shortcut could be used:
+       hand.UseRadians();
 
-       \bug
-       With %SDH firmware < 0.0.2.7 this made the axis jerk in eCT_POSE controller type.
-       This is resolved in %SDH firmware 0.0.2.7 for the eCT_POSE controller type with
-       velocity profile eVP_RAMP. For the eCT_POSE controller type with velocity profile
-       eVP_SIN_SQUARE changing target points/ velocities while moving will still make
-       the axes jerk.
-       <br><b>=> Partly resolved in %SDH firmware 0.0.2.7</b>
+       // override default unit converter for times:
+       hand.uc_time  = &cSDH::uc_time_milliseconds;
 
+       // override default unit converter for temperatures:
+       hand.uc_temperature = &cSDH::uc_temperature_fahrenheit;
 
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
+       // override default unit converter for positions:
+       hand.uc_position = &cSDH::uc_position_meter;
 
-         // Perform a stop:
-         hand.Stop();
+     \endcode
 
-       \endcode
 
-       <hr>
-    */
-    void Stop( void )
-        throw (cSDHLibraryException*);
+     For convenience the most common settings can be specified as
+     bool parameters for the constructor, like in:
 
+     \code
+       // Include the cSDH interface
+       #include <sdh.h>
 
-    //-----------------------------------------------------------------
-    //-----------------------------------------------------------------
-    // unimplemented from SAH:
-    // def GetEmergencyStop( int* piBrakeState)
+       // Create a cSDH object 'hand' that uses
+       // - the non default radians and radians/s units,
+       // - the default temperature in degrees celsius,
+       // - A debug level of 2
+       cSDH hand( true, false, 2 );
 
-    //-----------------------------------------------------------------
-    /*!
-       Set the type of axis controller to be used in the %SDH
+     \endcode
 
-       With %SDH firmware >= 0.0.2.7 this will automatically set valid
-       default values for all target velocities, accelerations and positions
-       in the %SDH firmware, according to the \a controller type:
-       - eCT_POSE:
-         - target velocities will be set to default (40 deg/s)
-         - target accelerations will be set to default (100 deg/(s*s))
-         - target positions will be set to default (0.0 deg)
-       - eCT_VELOCITY:
-         - target velocities will be set to default (0 deg/s)
-       - eCT_VELOCITY_ACCELERATION:
-         - target velocities will be set to default (0 deg/s)
-         - target accelerations will be set to default (100 deg/(s*s))
+     <hr>
+  */
+  cSDH(bool _use_radians = false, bool _use_fahrenheit = false, int _debug_level = 0);
 
-       This will also adjust the lower limits of the allowed velocities
-       here in the SDHLibrary, since the eCT_POSE controller allows only
-       positive velocities while the eCT_VELOCITY and
-       eCT_VELOCITY_ACCELERATION controllers require also negative
-       velocities.
 
-       \attention The availability of a controller type depends on the
-         %SDH firmware of the attached %SDH and is checked here.
-         - firmware <= 0.0.2.5: only eCT_POSE
-         - firmware >= 0.0.2.6: eCT_POSE, eCT_VELOCITY, eCT_VELOCITY_ACCELERATION
+  //----------------------------------------------------------------------
+  /*!
+      Virtual destructor to make compiler happy
 
-       \param controller - identifier of controller to set. Valid
-                           values are defined in eControllerType
+      If the connection to the %SDH hardware/firmware is still open
+      then the connection is closed, which will stop the axis
+      controllers (and thus prevent overheating).
+  */
+  virtual ~cSDH();
 
-       \par Examples:
-       \code
-         // Assuming 'hand' is a cSDH object ...
 
-         // Set the pose controller in the SDH
-         // (see e.g. demo-simple.cpp, demo-simple2.cpp, demo-simple3.cpp for further examples)
-         hand.SetController( hand.eCT_POSE );
+  //######################################################################
+  /*!
+    \anchor sdhlibrary_cpp_sdh_h_csdh_misc
+     \name   Miscellaneous methods
 
-         // Set the simple velocity controller in the SDH:
-         hand.SetController( hand.eCT_VELOCITY );
+     @{
+  */
 
-         // Set the velocity with acceleration ramp controller in the SDH:
-         // (see e.g. demo-velocity-acceleration.cpp for further examples)
-         hand.SetController( hand.eCT_VELOCITY_ACCELERATION );
+  //----------------------------------------------------------------------
+  //! Return \c true if index \a iAxis refers to a virtual axis
+  bool IsVirtualAxis(int iAxis)
+  throw (cSDHLibraryException*);
 
-       \endcode
+  //-----------------------------------------------------------------
+  /*!
+    Shortcut to set the unit system to radians.
 
-       <hr>
-    */
-    void SetController( cSDHBase::eControllerType controller )
-        throw( cSDHLibraryException* );
+     After calling this axis angles are set/reported in radians and
+     angular velocities are set/reported in radians/second
 
-    //-----------------------------------------------------------------
-    /*!
-      Get the type of axis controller used in the %SDH
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
 
-      The currently set controller type will be queried and returned
-      (One of eControllerType)
+       // make hand object use radians and radians/second for angles and angular velocities
+       hand.UseRadians();
 
-      \par Examples:
-      \code
-        // Assuming 'hand' is a sdh.cSDH object ...
+     \endcode
 
-        // Get the controller type of the attached SDH:
-        ct = hand.GetController();
+     <hr>
+  */
+  void UseRadians(void);
 
-        // Print result, numerically and symbolically
-        std::cout << "Currently the axis controller type is set to " << ct;
-        std::cout << "(" << GetStringFromControllerType(ct) << ")\n";
-      \endcode
 
-      <hr>
+  //-----------------------------------------------------------------
+  /*!
+    Shortcut to set the unit system to degrees.
 
-    */
-    eControllerType GetController( void  )
-        throw (cSDHLibraryException*);
+     After calling this (axis) angles are set/reported in degrees and
+     angular velocities are set/reported in degrees/second
 
-    //-----------------------------------------------------------------
-    /*!
-     Set the type of velocity profile to be used in the %SDH
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
 
-      \param velocity_profile - Name or number of velocity profile to set. Valid
-                                values are defined in eVelocityProfileType
+       // make hand object use degrees and degrees/second for angles and angular velocities
+       hand.UseDegrees();
+       // as degrees, degrees/second are the default this is needed only if the
+       // unit system was changed before
+
+     \endcode
+
+     <hr>
+  */
+  void UseDegrees(void);
+
+
+  //-----------------------------------------------------------------
+  /*!
+    Return the number of real axes of finger with index \a iFinger.
+
+     \param iFinger - index of finger in range [0..NUMBER_OF_FINGERS-1]
+
+     \return
+     - Number of real axes of finger with index \a iFinger
+     - If \a iFinger is invalid a (cSDHErrorInvalidParameter*) exception is thrown.
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       cout << "The finger 0 has " << hand.GetFingerNumberOfAxes( 0 ) << " real axes\n";
+
+     \endcode
+
+     <hr>
+  */
+  int GetFingerNumberOfAxes(int iFinger)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+    Return axis index of \a iFingerAxis axis of finger with index iFinger
+
+     For \a iFinger=2, iFingerAxis=0 this will return the index of
+     the virtual base axis of the finger
+
+     \param iFinger     - index of finger in range [0..NUMBER_OF_FINGERS-1]
+     \param iFingerAxis - index of finger axis in range [0..NUMBER_OF_AXES_PER_FINGER-1]
+
+     \return
+     - Axis index of \a iFingerAxis-th axis of finger with index \a iFinger
+     - If \a iFinger or \a iFingerAxis is invalid a (cSDHErrorInvalidParameter*) exception is thrown.
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       cout << "The 1st axis of finger 2 has real axis index " << hand.GetFingerNumberOfAxes( 2, 0 ) << "\n";
+
+     \endcode
+
+     <hr>
+  */
+  int GetFingerAxisIndex(int iFinger, int iFingerAxis)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+    Return the release name of the library (not the firmware of the %SDH) as string.
+
+
+     \par Examples:
+     \code
+       // static member function, so no cSDH object is needed for access:
+
+       cout << "The SDHLibrary reports release name " << cSDH::GetReleaseLibrary() << "\n";
+
+     \endcode
+
+     <hr>
+  */
+  static char const* GetLibraryRelease(void);
+
+
+  //-----------------------------------------------------------------
+  /*!
+    Return the name of the library as string.
+
+
+     \par Examples:
+     \code
+       // static member function, so no cSDH object is needed for access:
+
+       cout << "The SDHLibrary reports name " << cSDH::GetLibraryName() << "\n";
+
+     \endcode
+
+     <hr>
+  */
+  static char const* GetLibraryName(void);
+
+
+  //-----------------------------------------------------------------
+  /*!
+    Return the actual release name of the firmware of the %SDH (not the library) as string.
+
+    This will throw a (cSDHErrorCommunication*) exception if the
+    connection to the %SDH is not yet opened.
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       cout << "The SDH firmware reports release " << hand.GetFirmwareRelease() << "\n";
+
+     \endcode
+
+     \see See GetFirmwareReleaseRecommended() to get the recommended SDH firmware release.
+     <hr>
+  */
+  char const* GetFirmwareRelease(void)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+    Return the recommended release of the firmware of the %SDH
+    by this library as string.
+
+     \par Examples:
+     \code
+       // static member function, so no cSDH object is needed for access:
+
+       cout << "This SDHLibrary recommends an SDH firmware release " << cSDH::GetFirmwareReleaseRecommended() << "\n";
+
+     \endcode
+
+     \see See GetFirmwareRelease() to get the actual release of the SDH firmware
+     <hr>
+  */
+  static char const* GetFirmwareReleaseRecommended(void);
+
+  //-----------------------------------------------------------------
+  /*!
+    Check the actual release of the firmware of the connected %SDH against the
+    recommended firmware release.
+    \return true - if the actual firmware is the recommended one
+            false - the actual firmware is NOT the recommended one (communication with the SDH might not work as expected)
+
+    This will throw a (cSDHErrorCommunication*) exception if the
+    connection to the %SDH is not yet opened.
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       if ( hand.CheckFirmwareRelease() )
+       {
+           cout << "The firmware release of the connected SDH is the one recommended by this SDHLibrary\n";
+       }
+       else
+       {
+           cout << "The firmware release of the connected SDH is NOT the one recommended by this SDHLibrary\n";
+           cout << "  Actual SDH firmware release      " << hand.GetFirmwareRelease() << "\n";
+           cout << "  Recommended SDH firmware release " << hand.GetFirmwareReleaseRecommended() << "\n";
+       }
+
+     \endcode
+
+     \see See GetFirmwareReleaseRecommended() to get the recommended SDH firmware release.
+     <hr>
+  */
+  bool CheckFirmwareRelease(void)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*! Return info according to \a what
+  #
+  #  The following values are valid for \a what:
+  #  - "date-library"     : date of the SDHLibrary-python release
+  #  - "release-library"  : release name of the sdh.py python module
+  #  - "release-firmware" : release name of the %SDH firmware (requires
+  #                         an opened communication to the %SDH)
+  #  - "release-firmware-recommended" : recommended release name of the %SDH
+  #                         firmware
+  #  - "date-firmware"    : date of the %SDH firmware (requires
+  #                         an opened communication to the %SDH)
+  #  - "release-soc"      : release name of the %SDH SoC (requires
+  #                         an opened communication to the %SDH)
+  #  - "date-soc"         : date of the %SDH SoC (requires
+  #                         an opened communication to the %SDH)
+  #  - "id-sdh"           : ID of %SDH
+  #  - "sn-sdh"           : Serial number of %SDH
+  #
+  #  \par Examples:
+  #  \code
+  #    # Assuming 'hand' is a sdh.cSDH object ...
+  #
+  #    print "The SDH firmware reports release %s" % ( hand.GetInfo( "release-firmware" ) )
+  #
+  #  \endcode
+  #
+  #  <hr>
+  */
+  char const* GetInfo(char const* what)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Return temperature(s) measured within the %SDH.
+
+      \param sensors - A vector of indices of temperature sensors to access.
+                     - index 0 is sensor near motor of axis 0 (root)
+                     - index 1 is sensor near motor of axis 1 (proximal finger 1)
+                     - index 2 is sensor near motor of axis 2 (distal finger 1)
+                     - index 3 is sensor near motor of axis 3 (proximal finger 2)
+                     - index 4 is sensor near motor of axis 4 (distal finger 2)
+                     - index 5 is sensor near motor of axis 5 (proximal finger 3)
+                     - index 6 is sensor near motor of axis 6 (distal finger 3)
+                     - index 7 is FPGA temperature (controller chip)
+                     - index 8 is PCB temperature (Printed Circuit Board)
+
+      \remark
+      - The indices in \a sensors are checked if they are valid sensor indices.
+      - If \b any sensor index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      To access a single temperature sensor use #GetTemperature(int), see there.
+
+      \return
+        The temperatures of the selected sensors are returned as
+        std::vector<double> in the configured temperature unit system
+        #uc_temperature.
 
 
       \par Examples:
       \code
         // Assuming 'hand' is a cSDH object ...
 
-        // Set the sin square velocity profile in the SDH:
-        hand.SetVelocityProfile( hand.eVP_SIN_SQUARE );
+        // Get measured values of all sensors
+        std::vector<double> temps = hand.GetTemperature( hand.all_temperature_sensors );
+        // Now temps is something like { 38.500,37.250,35.750,37.250,33.500,36.500,32.250,59.625,52.500 }
 
-        // Or else set the ramp velocity profile in the SDH:
-        hand.SetVelocityProfile( hand.eVP_RAMP )
+        // Get controller temperature only:
+        double temp_controller = hand.GetTemperature( 0 );
+        // Now temp_controller is something like 40.5
+
+        // If we - for some obscure islandish reason - would want
+        // temperatures reported in degrees fahrenheit, the unit
+        // converter can be changed:
+        hand.uc_temperature = &cSDH::uc_temperature_fahrenheit;
+
+        // Get all temperaturs again:
+        temps = hand.GetTemperature( hand.all_temperature_sensors );
+        // Now temps is something like {100.0, 96.8, 92.3, 97.7, 91.8, 96.8, 90.1,  137.5,  125.2}
+
       \endcode
 
       <hr>
-    */
-    void SetVelocityProfile( eVelocityProfile velocity_profile )
-        throw (cSDHLibraryException*);
+  */
+  std::vector<double> GetTemperature(std::vector<int> const& sensors)
+  throw (cSDHLibraryException*);
 
 
-    //-----------------------------------------------------------------
-    /*!
-     Get the type of velocity profile used in the %SDH
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetTemperature(std::vector<int>const&), just for one sensor
+      \a iSensor and returning a single temperature as double.
+  */
+  double GetTemperature(int iSensor)
+  throw (cSDHLibraryException*);
 
-      \return the currently set velocity profile as integer, see eVelocityProfileType
+
+  //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_common
+  //! @}
+  //#####################################################################
+
+
+  //######################################################################
+  /*!
+     \anchor sdhlibrary_cpp_sdh_h_csdh_communication
+     \name   Communication methods
+
+     @{
+  */
+
+  //-----------------------------------------------------------------
+  /*!
+    Open connection to %SDH via RS232.
+
+     \param _port    : The number of the serial port to use.
+                       The default value port=0 refers to 'COM1' in Windows and
+                       to the corresponding '/dev/ttyS0' in Linux.
+     \param _baudrate: the baudrate in bit/s, the default is 115200 which happens
+                       to be the default for the %SDH too
+     \param _timeout : The timeout to use:
+                       - -1 : wait forever
+                       - T  : wait for T seconds
+     \param _device_format_string : a format string (C string) for generating the device name, like "/dev/ttyS%d" (default) or "/dev/ttyUSB%d".
+                                   Must contain a %d where the port number should be inserted.
+                                   This char array is duplicated on construction
+                                   When compiled with VCC (MS-Visual C++) then this is not used.
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       // Open connection to SDH via default port:
+       hand.OpenRS232();
+
+       // Use a different port 2 == COM3 == /dev/ttyS2 for a second hand "hand2":
+       cSDH hand2();
+       hand2.OpenRS232( 2 );
+
+       // Linux only: Use a different USB to RS232 device on port 3 /dev/ttyUSB3 for a third hand "hand3":
+       cSDH hand3();
+       hand2.OpenRS232( 3, 115200, -1, "/dev/ttyUSB%d" );
+
+     \endcode
+
+     <hr>
+  */
+  void OpenRS232(int _port = 0, unsigned long _baudrate = 115200, double _timeout = -1, char const* _device_format_string = "/dev/ttyS%d")
+  throw (cSDHLibraryException*);
+
+
+  /*!
+    Open connection to %SDH via CAN using an ESD CAN card.
+    If the library was compiled without ESD CAN support then this will just throw an
+    exception. See setting for WITH_ESD_CAN in the top level makefile.
+
+     \param _net     : The ESD CAN net number of the CAN port to use. (default: 0)
+     \param _baudrate : the CAN baudrate in bit/s. Only some bitrates are valid: (1000000 (default),800000,500000,250000,125000,100000,50000,20000,10000)
+     \param _timeout : The timeout to use:
+                       - <= 0 : wait forever (default)
+                       - T  : wait for T seconds
+     \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID, default=43=0x02b)
+     \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID, default=42=0x02a)
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       // use default parameters for net, baudrate, timeout and IDs
+       hand.OpenCAN_ESD( );
+
+       // use non default settings:
+       // net=1, baudrate=500000, timeout=1.0, id_read=0x143, id_write=0x142
+       hand.OpenCAN_ESD( 1, 500000, 1.0, 0x143, 0x142 );
+     \endcode
+
+     <hr>
+  */
+  void OpenCAN_ESD(int _net = 0,  unsigned long _baudrate = 1000000, double _timeout = 0.0, Int32 _id_read = 43, Int32 _id_write = 42)
+  throw (cSDHLibraryException*);
+
+
+  /*!
+    Open connection to %SDH via CAN using an ESD CAN card using an existing handle.
+    If the library was compiled without ESD CAN support then this will just throw an
+    exception. See setting for WITH_ESD_CAN in the top level makefile.
+
+     \param _ntcan_handle : the ESD CAN handle to reuse (please cast your NTCAN_HANDLE to tDeviceHandle! It is save to do that!)
+     \param _timeout : The timeout to use:
+                       - <= 0 : wait forever (default)
+                       - T  : wait for T seconds
+     \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID, default=43=0x2a)
+     \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID, default=42=0x2a)
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+       // and 'handle' is a valid NTCAN_HANDLE for the ESD device
+
+       // use default parameters for timeout and IDs
+       hand.OpenCAN_ESD( tDeviceHandle(handle) );
+
+       // or use non default settings:
+       // timeout=1.0, id_read=0x143, id_write=0x142
+       hand.OpenCAN_ESD( handle, 1.0, 0x143, 0x142 );
+
+     \endcode
+
+     <hr>
+  */
+  void OpenCAN_ESD(tDeviceHandle _ntcan_handle, double _timeout = 0.0, Int32 _id_read = 43, Int32 _id_write = 42)
+  throw (cSDHLibraryException*);
+
+
+  /*!
+    Open connection to %SDH via CAN using an PEAK CAN card.
+    If the library was compiled without PEAK CAN support then this will just throw an
+    exception. See setting for WITH_PEAK_CAN in the top level makefile.
+
+     \param _baudrate : the CAN baudrate in bit/s. Only some bitrates are valid: (1000000 (default),800000,500000,250000,125000,100000,50000,20000,10000)
+     \param _timeout : The timeout to use:
+                       - <= 0 : wait forever (default)
+                       - T  : wait for T seconds
+     \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID, default=43=0x02b)
+     \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID, default=42=0x02a)
+     \param _device   - the PEAK device name. Used for the Linux char dev driver only. default="/dev/pcanusb0"
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       // use default parameters for baudrate, timeout, IDs and device
+       hand.OpenCAN_PEAK( );
+
+       // use non default settings:
+       // baudrate=500000, timeout=1.0, id_read=0x143, id_write=0x142, , const char *device="/dev/pcanusb1"
+       hand.OpenCAN_PEAK( 500000, 1.0, 0x143, 0x142, "/dev/pcanusb1" );
+     \endcode
+
+     <hr>
+  */
+  void OpenCAN_PEAK(unsigned long _baudrate = 1000000, double _timeout = 0.0, Int32 _id_read = 43, Int32 _id_write = 42, const char *_device = "/dev/pcanusb0")
+  throw (cSDHLibraryException*);
+
+
+  /*!
+    Open connection to %SDH via CAN using an PEAK CAN card using an existing handle.
+    If the library was compiled without PEAK CAN support then this will just throw an
+    exception. See setting for WITH_PEAK_CAN in the top level makefile.
+
+     \param _handle : The PEAK CAN handle to reuse to connect to the PEAK CAN driver (please cast your PEAK_HANDLE to tDeviceHandle! It is save to do that!)
+     \param _timeout : The timeout to use:
+                       - <= 0 : wait forever (default)
+                       - T  : wait for T seconds
+     \param _id_read  - the CAN ID to use for reading (The %SDH sends data on this ID, default=43=0x2a)
+     \param _id_write - the CAN ID to use for writing (The %SDH receives data on this ID, default=42=0x2a)
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+       // and 'handle' is a valid HANDLE for the PEAK device
+
+       // use default parameters for timeout and IDs
+       hand.OpenCAN_PEAK( tDeviceHandle(handle) );
+
+       // or use non default settings:
+       // timeout=1.0, id_read=0x143, id_write=0x142
+       hand.OpenCAN_PEAK( handle, 1.0, 0x143, 0x142 );
+
+     \endcode
+
+     <hr>
+  */
+  void OpenCAN_PEAK(tDeviceHandle _handle, double _timeout = 0.0, Int32 _id_read = 43, Int32 _id_write = 42)
+  throw (cSDHLibraryException*);
+
+  /*!
+    Open connection to %SDH via TCP using TCP/IP address \a _tcp_adr and \a _tcp_port.
+
+     \param _tcp_adr : The tcp host address of the SDH. Either a numeric IP as string or a hostname
+     \param _tcp_port : the tcp port number on the SDH to connect to
+     \param _timeout : The timeout to use:
+                       - <= 0 : wait forever (default)
+                       - T  : wait for T seconds
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       // IP-address 192.168.1.1, port 23, timeout=0.0
+       hand.OpenTCP( "192.168.1.1.", 23, 0.0 );
+     \endcode
+
+     <hr>
+  */
+  void OpenTCP(char const* _tcp_adr = "192.168.1.1", int _tcp_port = 23, double _timeout = 0.0)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+     Close connection to %SDH.
+
+     The default behaviour is to \b not leave the controllers of the
+     %SDH enabled (to prevent overheating). To keep the controllers
+     enabled (e.g. to keep the finger axes actively in position) set
+     \a leave_enabled to \c true. Only already enabled axes will be
+     left enabled.
+
+     \param leave_enabled - Flag: true to leave the controllers on,
+                            false (default) to disable the
+                            controllers (switch powerless)
+
+     This throws a (cSDHErrorCommunication*) exception if the
+     connection was not opened before.
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       // Close connection to SDH, power off controllers:
+       hand.Close();
+
+       // To leave the already enabled controllers enabled:
+       hand.Close( true );
+
+     \endcode
+
+     <hr>
+  */
+  void Close(bool leave_enabled = false)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Return true if connection to %SDH firmware/hardware is open.
+  */
+  virtual bool IsOpen(void)
+  throw ();
+
+
+  //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_communication
+  //! @}
+  //#####################################################################
+
+
+  //######################################################################
+  /*!
+    \anchor sdhlibrary_cpp_sdh_h_csdh_auxilliary
+     \name   Auxiliary movement methods
+
+     @{
+  */
+
+  //-----------------------------------------------------------------
+  /*!
+    Stop movement of all axes of the %SDH and switch off the controllers
+
+     This command will always be executed sequentially: it will return
+     only after the %SDH has confirmed the emergency stop.
+
+     \bug
+     For now this will \b NOT work while a GripHand() command is
+     executing, even if that was initiated non-sequentially!
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       // Perform an emergency stop:
+       hand.EmergencyStop();
+
+     \endcode
+
+     <hr>
+  */
+  void EmergencyStop(void)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+    Stop movement of all axes but keep controllers on
+
+     This command will always be executed sequentially: it will return
+     only after the %SDH has confirmed the stop
+
+     \bug
+     For now this will \b NOT work while a GripHand() command is
+     executing, even if that was initiated non-sequentially!
+
+     \bug
+     With %SDH firmware < 0.0.2.7 this made the axis jerk in eCT_POSE controller type.
+     This is resolved in %SDH firmware 0.0.2.7 for the eCT_POSE controller type with
+     velocity profile eVP_RAMP. For the eCT_POSE controller type with velocity profile
+     eVP_SIN_SQUARE changing target points/ velocities while moving will still make
+     the axes jerk.
+     <br><b>=> Partly resolved in %SDH firmware 0.0.2.7</b>
+
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       // Perform a stop:
+       hand.Stop();
+
+     \endcode
+
+     <hr>
+  */
+  void Stop(void)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  //-----------------------------------------------------------------
+  // unimplemented from SAH:
+  // def GetEmergencyStop( int* piBrakeState)
+
+  //-----------------------------------------------------------------
+  /*!
+     Set the type of axis controller to be used in the %SDH
+
+     With %SDH firmware >= 0.0.2.7 this will automatically set valid
+     default values for all target velocities, accelerations and positions
+     in the %SDH firmware, according to the \a controller type:
+     - eCT_POSE:
+       - target velocities will be set to default (40 deg/s)
+       - target accelerations will be set to default (100 deg/(s*s))
+       - target positions will be set to default (0.0 deg)
+     - eCT_VELOCITY:
+       - target velocities will be set to default (0 deg/s)
+     - eCT_VELOCITY_ACCELERATION:
+       - target velocities will be set to default (0 deg/s)
+       - target accelerations will be set to default (100 deg/(s*s))
+
+     This will also adjust the lower limits of the allowed velocities
+     here in the SDHLibrary, since the eCT_POSE controller allows only
+     positive velocities while the eCT_VELOCITY and
+     eCT_VELOCITY_ACCELERATION controllers require also negative
+     velocities.
+
+     \attention The availability of a controller type depends on the
+       %SDH firmware of the attached %SDH and is checked here.
+       - firmware <= 0.0.2.5: only eCT_POSE
+       - firmware >= 0.0.2.6: eCT_POSE, eCT_VELOCITY, eCT_VELOCITY_ACCELERATION
+
+     \param controller - identifier of controller to set. Valid
+                         values are defined in eControllerType
+
+     \par Examples:
+     \code
+       // Assuming 'hand' is a cSDH object ...
+
+       // Set the pose controller in the SDH
+       // (see e.g. demo-simple.cpp, demo-simple2.cpp, demo-simple3.cpp for further examples)
+       hand.SetController( hand.eCT_POSE );
+
+       // Set the simple velocity controller in the SDH:
+       hand.SetController( hand.eCT_VELOCITY );
+
+       // Set the velocity with acceleration ramp controller in the SDH:
+       // (see e.g. demo-velocity-acceleration.cpp for further examples)
+       hand.SetController( hand.eCT_VELOCITY_ACCELERATION );
+
+     \endcode
+
+     <hr>
+  */
+  void SetController(cSDHBase::eControllerType controller)
+  throw(cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+    Get the type of axis controller used in the %SDH
+
+    The currently set controller type will be queried and returned
+    (One of eControllerType)
+
+    \par Examples:
+    \code
+      // Assuming 'hand' is a sdh.cSDH object ...
+
+      // Get the controller type of the attached SDH:
+      ct = hand.GetController();
+
+      // Print result, numerically and symbolically
+      std::cout << "Currently the axis controller type is set to " << ct;
+      std::cout << "(" << GetStringFromControllerType(ct) << ")\n";
+    \endcode
+
+    <hr>
+
+  */
+  eControllerType GetController(void)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+   Set the type of velocity profile to be used in the %SDH
+
+    \param velocity_profile - Name or number of velocity profile to set. Valid
+                              values are defined in eVelocityProfileType
+
+
+    \par Examples:
+    \code
+      // Assuming 'hand' is a cSDH object ...
+
+      // Set the sin square velocity profile in the SDH:
+      hand.SetVelocityProfile( hand.eVP_SIN_SQUARE );
+
+      // Or else set the ramp velocity profile in the SDH:
+      hand.SetVelocityProfile( hand.eVP_RAMP )
+    \endcode
+
+    <hr>
+  */
+  void SetVelocityProfile(eVelocityProfile velocity_profile)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+   Get the type of velocity profile used in the %SDH
+
+    \return the currently set velocity profile as integer, see eVelocityProfileType
+
+
+    \par Examples:
+    \code
+      // Assuming 'hand' is a cSDH object ...
+
+      // Get the velocity profile from the SDH:
+      velocity_profile = hand.GetVelocityProfile();
+      // now velocity_profile is something like eVP_SIN_SQUARE or eVP_RAMP
+
+    \endcode
+
+    <hr>
+  */
+  eVelocityProfile GetVelocityProfile(void)
+  throw (cSDHLibraryException*);
+
+
+  //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_auxilliary
+  //! @}
+  //#####################################################################
+
+
+  //######################################################################
+  /*!
+    \anchor sdhlibrary_cpp_sdh_h_csdh_axis
+     \name   Methods to access %SDH on axis-level
+
+     @{
+  */
+
+  //-----------------------------------------------------------------
+  /*!
+      Set the maximum allowed motor current(s) for axes.
+
+      The maximum allowed motor currents are sent to the %SDH.
+      The motor currents can be stored:
+      - axis specific
+      - mode specific (see #eMotorCurrentMode)
+
+      \param axes           - A vector of axis indices to access.
+      \param motor_currents - A vector of motor currents to set. If any of the numbers in the vector is \c NaN (Not a Number) then
+                              the currently set axis motor current will be kept for the corresponding axis.
+                              The value(s) are expected in the configured motor current unit system #uc_motor_current.
+      \param mode           - the mode to set the maximum motor current for. One of the #eMotorCurrentMode modes.
+
+      \remark
+      - The lengths of the \a axes and \a motor_currents vector must match.
+      - The indices can be given in any order, but the order of
+        their elements must match, i.e. \c motor_currents[i] will be applied
+        to axis \c axes[i] (not axis \c i).
+      - The indices are checked if they are valid axis indices.
+      - The motor currents are checked if they are in the allowed range
+        [0 .. #f_max_motor_current_v], i.e. it is checked that \c motor_currents[i],
+        converted to internal units, is in \c [0 .. \c f_max_motor_currents_v[axes[i]]].
+      - If \b any index or value is invalid then \b none of the specified
+        values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter* exception
+        is thrown.
+
+      See also #SetAxisMotorCurrent(int,double,eMotorCurrentMode)
+      for an overloaded variant to set a single axis motor current
+      or to set the same motor current for all axes.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Set maximum allowed motor current of all axes to the given values in mode "eMCM_MOVE"::
+        std::vector<double> all_motor_currents;
+        all_motor_currents.push_back( 0.0 );
+        all_motor_currents.push_back( 0.1 );
+        all_motor_currents.push_back( 0.2 );
+        all_motor_currents.push_back( 0.3 );
+        all_motor_currents.push_back( 0.4 );
+        all_motor_currents.push_back( 0.5 );
+        all_motor_currents.push_back( 0.6 );
+
+        hand.SetAxisMotorCurrent( hand.all_axes, all_motor_currents );
+
+
+        // Set maximum allowed motor current of all axes to 0.1 A in mode "eMCM_HOLD":
+        hand.SetAxisMotorCurrent( hand.All, 1.0, eMCM_HOLD );
+
+        // Set maximum allowed motor current of axis 3 to 0.75 A in mode "eMCM_MOVE":
+        hand.SetAxisMotorCurrent( 3, 0.75, eMCM_MOVE );
+
+        // Set maximum allowed motor current of for axis 0, 4 and 2 to 0.0 A,
+        // 0.4 A and 0.2 A respectively in mode "eMCM_GRIP"
+        std::vector<int> axes042;
+        axes042.push_back( 0 );
+        axes042.push_back( 4 );
+        axes042.push_back( 2 );
+        std::vector<double> motor_currents042;
+        motor_currents042.push_back( 0.0 );
+        motor_currents042.push_back( 0.4 );
+        motor_currents042.push_back( 0.2 );
+
+        hand.SetAxisMotorCurrent( axes042, states042, eMCM_GRIP );
+
+      \endcode
+
+      <hr>
+  */
+  void SetAxisMotorCurrent(std::vector<int> const& axes, std::vector<double> const& motor_currents, eMotorCurrentMode mode = eMCM_MOVE)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetAxisMotorCurrent(std::vector<int>const&,std::vector<double>const&,eMotorCurrentMode),
+      just for a single axis \a iAxis and a single motor current \a motor_current, see there.
+
+      If \a iAxis is #All then \a motor_current is set for all axes.
+  */
+  void SetAxisMotorCurrent(int iAxis, double motor_current, eMotorCurrentMode mode = eMCM_MOVE)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get the maximum allowed motor current(s) of axis(axes).
+
+      The maximum allowed motor currents are read from the %SDH.
+      The motor currents are stored:
+      - axis specific
+      - mode specific (see eMotorCurrentMode)
+
+      \param axes           - A vector of axis indices to access.
+      \param mode           - the mode to set the maximum motor current for. One of the #eMotorCurrentMode modes.
+
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \return
+      - A vector of the motor currents of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_motor_current unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
+
+      See also #GetAxisMotorCurrent(int,eMotorCurrentMode) for an
+      overloaded variant to access a single axis.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Get maximum allowed motor currents of all axes
+        std::vector<double> v = hand.GetAxisMotorCurrent( hand.all_axes );
+        // now v is something like {0.1, 0.2, 0.3, 0.4, 0.5, 0,6, 0.7}
+
+        // Get maximum allowed motor current of axis 3 in mode "eMCM_MOVE"
+        double mc3 = hand.GetAxisMotorCurrent( 3, eMCM_MOVE );
+        // mc3 is now something like 0.75
+
+        // Get maximum allowed motor current of axis 3 and 5 in mode "eMCM_GRIP"
+        std::vector<int> axes35;
+        axes35.push_back( 3 );
+        axes35.push_back( 5 );
+
+        v = hand.GetAxisMotorCurrent( axes35, eMCM_GRIP );
+        // now v is something like {0.5,0.5};
+
+      \endcode
+
+      <hr>
+  */
+  std::vector<double> GetAxisMotorCurrent(std::vector<int> const& axes, eMotorCurrentMode mode = eMCM_MOVE)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisMotorCurrent(std::vector<int>const&,eMotorCurrentMode),
+      just for a single axis, see there for details and examples.
+  */
+  double GetAxisMotorCurrent(int iAxis, eMotorCurrentMode mode = eMCM_MOVE)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Set enabled/disabled state of axis controller(s).
+
+      The controllers of the selected axes are enabled/disabled in
+      the %SDH. Disabled axes are not powered and thus might not
+      remain in their current pose due to gravity, inertia or
+      other external influences. But to prevent overheating the axis
+      controllers should be switched of when not needed.
+
+      \param axes   - A vector of axis indices to access.
+      \param states - A vector of enabled states (0 = disabled, !=0 = enabled) to set.
+                      If any of the numbers in the vector is \c NaN (Not a
+                      Number) then the currently set enabled state will be
+                      kept for the corresponding axis.
+
+      \remark
+      - The lengths of the \a axes and \a states vector must match.
+      - The indices can be given in any order, but the order of
+        their elements must match, i.e. \c state[i] will be applied
+        to axis \c axes[i] (not axis \c i).
+      - The indices are checked if they are valid axis indices.
+      - If \b any index is invalid then \b none of the specified
+        values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      See also #SetAxisEnable(int,double), #SetAxisEnable(int,bool)
+      for overloaded variants to set a single axis enabled/disabled
+      or to set the same state for all axes.  See further
+      #SetAxisEnable(std::vector<int>const&,std::vector<bool>const&) for a
+      variant that accepts a \c bool vector for the states to set.
 
 
       \par Examples:
       \code
         // Assuming 'hand' is a cSDH object ...
 
-        // Get the velocity profile from the SDH:
-        velocity_profile = hand.GetVelocityProfile();
-        // now velocity_profile is something like eVP_SIN_SQUARE or eVP_RAMP
+        // Enable all axes:
+        hand.SetAxisEnable( hand.all_axes, hand.ones_v );
+
+        // Disable all axes:
+        hand.SetAxisEnable( All, 0 );
+
+        // Enable axis 0 and 2 while disabling axis 4:
+        std::vector<int> axes042;
+        axes042.push_back( 0 );
+        axes042.push_back( 4 );
+        axes042.push_back( 2 );
+
+        std::vector<double> states042;
+        states042.push_back( 1.0 );
+        states042.push_back( 0.0 );
+        states042.push_back( 1.0 );
+
+        hand.SetAxisEnable( axes042, states042 );
+
+
+        // Disable axis 2
+        hand.SetAxisEnable( 2, false );
+      \endcode
+
+      <hr>
+  */
+  void SetAxisEnable(std::vector<int> const& axes, std::vector<double> const& states)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetAxisEnable(std::vector<int>const&,std::vector<double>const&),
+      just for a single axis \a iAxis and a single axis state \a state, see there.
+
+      If \a iAxis is #All then \a state is applied to all axes.
+  */
+  void SetAxisEnable(int iAxis = All, double state = 1.0)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetAxisEnable(std::vector<int>const&,std::vector<double>const&),
+      just accepting a vector of \c bool values as states, see there.
+  */
+  void SetAxisEnable(std::vector<int> const& axes, std::vector<bool> const& states)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetAxisEnable(std::vector<int>const&,std::vector<double>const&),
+      just for a single axis \a iAxis and a single axis state \a state, see there.
+
+      If \a iAxis is #All then \a state is applied to all axes.
+  */
+  void SetAxisEnable(int iAxis = All, bool state = true)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get enabled/disabled state of axis controller(s).
+
+      The enabled/disabled state of the controllers of the selected
+      axes is read from the %SDH.
+
+      \param axes - A vector of axis indices to access.
+
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \return
+      - A vector of enabled/disabled states as doubles (0=disabled,
+        1.0=enabled) of the selected axes.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
+
+      See also #GetAxisEnable(int) for an overloaded variant to
+      access a single axis.
+
+
+      \par Examples:
+      \code
+        // Assuming 'hand' is a cSDH object ...
+
+        // Get enabled state of all axes:
+        std::vector<double> v = hand.GetAxisEnable( hand.all_axes );
+        // now v is something like {0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0}
+
+        // Get enabled state of axis 3 and 5
+        std::vector<int> axes35;
+        axes35.push_back( 3 );
+        axes35.push_back( 5 );
+
+        v = hand.GetAxisEnable( axes35 );
+        // now v is something like {1.0, 0.0}
+
+
+        // Get enabled state of axis 3
+        double v3 = hand.GetAxisEnable( 3 );
+        // now v3 is something like 1.0
 
       \endcode
 
       <hr>
-    */
-    eVelocityProfile GetVelocityProfile( void )
-        throw (cSDHLibraryException*);
-
-
-    //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_auxilliary
-    //! @}
-    //#####################################################################
-
-
-    //######################################################################
-    /*!
-      \anchor sdhlibrary_cpp_sdh_h_csdh_axis
-       \name   Methods to access %SDH on axis-level
-
-       @{
-    */
-
-    //-----------------------------------------------------------------
-    /*!
-        Set the maximum allowed motor current(s) for axes.
-
-        The maximum allowed motor currents are sent to the %SDH.
-        The motor currents can be stored:
-        - axis specific
-        - mode specific (see #eMotorCurrentMode)
-
-        \param axes           - A vector of axis indices to access.
-        \param motor_currents - A vector of motor currents to set. If any of the numbers in the vector is \c NaN (Not a Number) then
-                                the currently set axis motor current will be kept for the corresponding axis.
-                                The value(s) are expected in the configured motor current unit system #uc_motor_current.
-        \param mode           - the mode to set the maximum motor current for. One of the #eMotorCurrentMode modes.
-
-        \remark
-        - The lengths of the \a axes and \a motor_currents vector must match.
-        - The indices can be given in any order, but the order of
-          their elements must match, i.e. \c motor_currents[i] will be applied
-          to axis \c axes[i] (not axis \c i).
-        - The indices are checked if they are valid axis indices.
-        - The motor currents are checked if they are in the allowed range
-          [0 .. #f_max_motor_current_v], i.e. it is checked that \c motor_currents[i],
-          converted to internal units, is in \c [0 .. \c f_max_motor_currents_v[axes[i]]].
-        - If \b any index or value is invalid then \b none of the specified
-          values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter* exception
-          is thrown.
-
-        See also #SetAxisMotorCurrent(int,double,eMotorCurrentMode)
-        for an overloaded variant to set a single axis motor current
-        or to set the same motor current for all axes.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Set maximum allowed motor current of all axes to the given values in mode "eMCM_MOVE"::
-          std::vector<double> all_motor_currents;
-          all_motor_currents.push_back( 0.0 );
-          all_motor_currents.push_back( 0.1 );
-          all_motor_currents.push_back( 0.2 );
-          all_motor_currents.push_back( 0.3 );
-          all_motor_currents.push_back( 0.4 );
-          all_motor_currents.push_back( 0.5 );
-          all_motor_currents.push_back( 0.6 );
+  */
+  std::vector<double> GetAxisEnable(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
-          hand.SetAxisMotorCurrent( hand.all_axes, all_motor_currents );
-
-
-          // Set maximum allowed motor current of all axes to 0.1 A in mode "eMCM_HOLD":
-          hand.SetAxisMotorCurrent( hand.All, 1.0, eMCM_HOLD );
-
-          // Set maximum allowed motor current of axis 3 to 0.75 A in mode "eMCM_MOVE":
-          hand.SetAxisMotorCurrent( 3, 0.75, eMCM_MOVE );
-
-          // Set maximum allowed motor current of for axis 0, 4 and 2 to 0.0 A,
-          // 0.4 A and 0.2 A respectively in mode "eMCM_GRIP"
-          std::vector<int> axes042;
-          axes042.push_back( 0 );
-          axes042.push_back( 4 );
-          axes042.push_back( 2 );
-          std::vector<double> motor_currents042;
-          motor_currents042.push_back( 0.0 );
-          motor_currents042.push_back( 0.4 );
-          motor_currents042.push_back( 0.2 );
-
-          hand.SetAxisMotorCurrent( axes042, states042, eMCM_GRIP );
-
-        \endcode
-
-        <hr>
-    */
-    void SetAxisMotorCurrent( std::vector<int> const& axes, std::vector<double> const& motor_currents, eMotorCurrentMode mode=eMCM_MOVE )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetAxisMotorCurrent(std::vector<int>const&,std::vector<double>const&,eMotorCurrentMode),
-        just for a single axis \a iAxis and a single motor current \a motor_current, see there.
-
-        If \a iAxis is #All then \a motor_current is set for all axes.
-    */
-    void SetAxisMotorCurrent( int iAxis, double motor_current, eMotorCurrentMode mode=eMCM_MOVE )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get the maximum allowed motor current(s) of axis(axes).
-
-        The maximum allowed motor currents are read from the %SDH.
-        The motor currents are stored:
-        - axis specific
-        - mode specific (see eMotorCurrentMode)
-
-        \param axes           - A vector of axis indices to access.
-        \param mode           - the mode to set the maximum motor current for. One of the #eMotorCurrentMode modes.
-
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-        - A vector of the motor currents of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_motor_current unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
-
-        See also #GetAxisMotorCurrent(int,eMotorCurrentMode) for an
-        overloaded variant to access a single axis.
 
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get maximum allowed motor currents of all axes
-          std::vector<double> v = hand.GetAxisMotorCurrent( hand.all_axes );
-          // now v is something like {0.1, 0.2, 0.3, 0.4, 0.5, 0,6, 0.7}
-
-          // Get maximum allowed motor current of axis 3 in mode "eMCM_MOVE"
-          double mc3 = hand.GetAxisMotorCurrent( 3, eMCM_MOVE );
-          // mc3 is now something like 0.75
-
-          // Get maximum allowed motor current of axis 3 and 5 in mode "eMCM_GRIP"
-          std::vector<int> axes35;
-          axes35.push_back( 3 );
-          axes35.push_back( 5 );
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisEnable(std::vector<int>const&), just for a single
+      axis \a iAxis, see there for details and examples.
+  */
+  double GetAxisEnable(int iAxis)
+  throw (cSDHLibraryException*);
 
-          v = hand.GetAxisMotorCurrent( axes35, eMCM_GRIP );
-          // now v is something like {0.5,0.5};
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetAxisMotorCurrent( std::vector<int> const& axes, eMotorCurrentMode mode=eMCM_MOVE )
-        throw (cSDHLibraryException*);
 
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisMotorCurrent(std::vector<int>const&,eMotorCurrentMode),
-        just for a single axis, see there for details and examples.
-    */
-    double GetAxisMotorCurrent( int iAxis, eMotorCurrentMode mode=eMCM_MOVE )
-        throw (cSDHLibraryException*);
+  //----------------------------------------------------------------------
+  /*!
+     Get the current actual state(s) of axis(axes).
+
+     The actual axis states are read from the %SDH.
 
+     \param axes - A vector of axis indices to access.
+
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-    //-----------------------------------------------------------------
-    /*!
-        Set enabled/disabled state of axis controller(s).
+      \return
+      - A vector of the actual states of the selected axes.
+      - The values are given as #eAxisState enum values
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-        The controllers of the selected axes are enabled/disabled in
-        the %SDH. Disabled axes are not powered and thus might not
-        remain in their current pose due to gravity, inertia or
-        other external influences. But to prevent overheating the axis
-        controllers should be switched of when not needed.
+      See also #GetAxisActualState(int) for an
+      overloaded variant to access a single axis.
 
-        \param axes   - A vector of axis indices to access.
-        \param states - A vector of enabled states (0 = disabled, !=0 = enabled) to set.
-                        If any of the numbers in the vector is \c NaN (Not a
-                        Number) then the currently set enabled state will be
-                        kept for the corresponding axis.
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-        \remark
-        - The lengths of the \a axes and \a states vector must match.
-        - The indices can be given in any order, but the order of
-          their elements must match, i.e. \c state[i] will be applied
-          to axis \c axes[i] (not axis \c i).
-        - The indices are checked if they are valid axis indices.
-        - If \b any index is invalid then \b none of the specified
-          values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
+        // Get actual axis state of all axes
+        std::vector<eAxisState> v = hand.GetAxisActualState( hand.all_axes )
+        // now v is something like {eAS_IDLE, eAS_POSITIONING, eAS_IDLE, eAS_IDLE, eAS_IDLE, eAS_DISABLED, eAS_IDLE}
 
-        See also #SetAxisEnable(int,double), #SetAxisEnable(int,bool)
-        for overloaded variants to set a single axis enabled/disabled
-        or to set the same state for all axes.  See further
-        #SetAxisEnable(std::vector<int>const&,std::vector<bool>const&) for a
-        variant that accepts a \c bool vector for the states to set.
+        // Get actual axis state of axis 3
+        eAxisState v3 = hand.GetAxisActualState( 3 );
+        // v3 is now something like eAS_IDLE
 
 
-        \par Examples:
-        \code
-          // Assuming 'hand' is a cSDH object ...
+        // Get actual state of axis 2 and 5
+        std::vector<int> axes25;
+        axes25.push_back( 2 );
+        axes25.push_back( 5 );
 
-          // Enable all axes:
-          hand.SetAxisEnable( hand.all_axes, hand.ones_v );
+        v = hand.GetAxisActualState( axes25 );
+        // now v is something like {eAS_IDLE, eAS_DISABLED}
+    \endcode
 
-          // Disable all axes:
-          hand.SetAxisEnable( All, 0 );
+    <hr>
+  */
+  std::vector<eAxisState> GetAxisActualState(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
-          // Enable axis 0 and 2 while disabling axis 4:
-          std::vector<int> axes042;
-          axes042.push_back( 0 );
-          axes042.push_back( 4 );
-          axes042.push_back( 2 );
 
-          std::vector<double> states042;
-          states042.push_back( 1.0 );
-          states042.push_back( 0.0 );
-          states042.push_back( 1.0 );
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisActualState(std::vector<int>const&),
+      just for a single axis \a iAxis, see there for details and examples.
+  */
+  eAxisState GetAxisActualState(int iAxis)
+  throw (cSDHLibraryException*);
 
-          hand.SetAxisEnable( axes042, states042 );
 
+  //-----------------------------------------------------------------
+  /*!
+      Wait until the movement(s) of of axis(axes) has finished
 
-          // Disable axis 2
-          hand.SetAxisEnable( 2, false );
-        \endcode
+      The state of the given axis(axes) is(are) queried until all
+      axes are no longer moving.
 
-        <hr>
-    */
-    void SetAxisEnable( std::vector<int> const& axes, std::vector<double> const& states )
-        throw (cSDHLibraryException*);
+      \param axes    - A vector of axis indices to access.
+      \param timeout - a timeout in seconds or -1.0 (default) to wait indefinetly.
 
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+        - If \a timeout < 0 then this function will wait arbitrarily long
+        - If a \a timeout is given then this function will throw a
+          cSDHErrorCommunication exception if the given axes are still
+          moving after \a timeout many seconds
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetAxisEnable(std::vector<int>const&,std::vector<double>const&),
-        just for a single axis \a iAxis and a single axis state \a state, see there.
+      See also #WaitAxis(int,double) for an overloaded variant to
+      wait for a single axis or all axes.
 
-        If \a iAxis is #All then \a state is applied to all axes.
-    */
-    void SetAxisEnable( int iAxis=All, double state=1.0 )
-        throw (cSDHLibraryException*);
+      \bug Due to a bug in %SDH firmwares prior to 0.0.2.6 the WaitAxis() command
+           was somewhat unreliable there. When called immediately after a movement command like MoveHand(),
+           then the WaitAxis() command returned immediately without waiting for the end of the movement.
+           With %SDH firmwares 0.0.2.6 and newer this is no longer problematic and WaitAxis() works as expected.
+           <br><b>=> Resolved in %SDH firmware 0.0.2.6</b>
 
+      \bug With %SDH firmware 0.0.2.6 WaitAxis() did not work if one of the new
+           velocity based controllers (eCT_VELOCITY, eCT_VELOCITY_ACCELERATION)
+           was used. With %SDH firmwares 0.0.2.7 and newer this now works. Here
+           the WaitAxis() waits until the selected axes come to velocity 0.0
+           <br><b>=> Resolved in %SDH firmware 0.0.2.7</b>
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetAxisEnable(std::vector<int>const&,std::vector<double>const&),
-        just accepting a vector of \c bool values as states, see there.
-    */
-    void SetAxisEnable( std::vector<int> const& axes, std::vector<bool> const& states )
-        throw (cSDHLibraryException*);
+      \par Examples:
+      Example 1, WaitAxis and eCT_POSE controller, see also the demo program demo-simple3:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
+        hand.SetController( eCT_POSE );
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetAxisEnable(std::vector<int>const&,std::vector<double>const&),
-        just for a single axis \a iAxis and a single axis state \a state, see there.
+        // Set a new target pose for axis 1,2 and 3
+        std::vector<int> axes123;
+        axes123.push_back( 1 );
+        axes123.push_back( 2 );
+        axes123.push_back( 3 );
 
-        If \a iAxis is #All then \a state is applied to all axes.
-    */
-    void SetAxisEnable( int iAxis=All, bool state=true )
-        throw (cSDHLibraryException*);
+        std::vector<double> angles123;
+        angles123.push_back( -20.0 );
+        angles123.push_back( -30.0 );
+        angles123.push_back( -40.0 );
 
 
-    //-----------------------------------------------------------------
-    /*!
-        Get enabled/disabled state of axis controller(s).
+        hand.SetAxisTargetAngle( axes123, angles123 );
 
-        The enabled/disabled state of the controllers of the selected
-        axes is read from the %SDH.
+        // Move axes there non sequentially:
+        hand.MoveAxis( axes123, false );
 
-        \param axes - A vector of axis indices to access.
+        // The last call returned immediately so we now have time to
+        // do something else while the hand is moving:
 
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
+        // ... insert any calculation here ...
 
-        \return
-        - A vector of enabled/disabled states as doubles (0=disabled,
-          1.0=enabled) of the selected axes.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
+        // Before doing something else with the hand make sure the
+        // selected axes have finished the last movement:
+        hand.WaitAxis( axes123 );
 
-        See also #GetAxisEnable(int) for an overloaded variant to
-        access a single axis.
 
+        // go back home (all angles to 0.0):
+        hand.SetAxisTargetAngle( hand.All, 0.0 );
 
-        \par Examples:
-        \code
-          // Assuming 'hand' is a cSDH object ...
+        // Move all axes there non sequentially:
+        hand.MoveAxis( hand.All, False );
 
-          // Get enabled state of all axes:
-          std::vector<double> v = hand.GetAxisEnable( hand.all_axes );
-          // now v is something like {0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0}
+        // ... insert any other calculation here ...
 
-          // Get enabled state of axis 3 and 5
-          std::vector<int> axes35;
-          axes35.push_back( 3 );
-          axes35.push_back( 5 );
+        // Wait until all axes are there, with a timeout of 10s:
+        hand.WaitAxis( hand.All, 10.0 );
 
-          v = hand.GetAxisEnable( axes35 );
-          // now v is something like {1.0, 0.0}
+        // now we are at the desired position.
+     \endcode
 
+     Example 2, WaitAxis and eCT_VELOCITY_ACCELERATION controller, see also the demo program demo-velocity-acceleration
+     \code
+        // Assuming "hand" is a cSDH object ...
 
-          // Get enabled state of axis 3
-          double v3 = hand.GetAxisEnable( 3 );
-          // now v3 is something like 1.0
+        hand.SetController( eCT_VELOCITY_ACCELERATION);
 
-        \endcode
+        // Set a new target velocity for axis 1,2 and 3
+        std::vector<int> axes123;
+        axes123.push_back( 1 );
+        axes123.push_back( 2 );
+        axes123.push_back( 3 );
 
-        <hr>
-    */
-    std::vector<double> GetAxisEnable( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
+        std::vector<double> velocities123;
+        velocities123.push_back( -20.0 );
+        velocities123.push_back( -30.0 );
+        velocities123.push_back( -40.0 );
 
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisEnable(std::vector<int>const&), just for a single
-        axis \a iAxis, see there for details and examples.
-    */
-    double GetAxisEnable( int iAxis )
-        throw (cSDHLibraryException*);
+        hand.SetAxisTargetVelocity( axes123, velocities123 ); // this will make the axes move!
 
+        // The last call returned immediately so we now have time to
+        // do something else while the hand is moving:
 
-    //----------------------------------------------------------------------
-    /*!
-       Get the current actual state(s) of axis(axes).
+        // ... insert any calculation here ...
 
-       The actual axis states are read from the %SDH.
+        // to break and stop the movement just set the target velocities to 0.0
+        velocities123[0] = 0.0;
+        velocities123[1] = 0.0;
+        velocities123[2] = 0.0;
 
-       \param axes - A vector of axis indices to access.
+        hand.SetAxisTargetVelocity( axes123, velocities123 ); // this will make the axes break with the default (de)acceleration
 
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
+        // The previous command returned immediately, so
+        // before doing something else with the hand make sure the
+        // selected axes have stopped:
+        hand.WaitAxis( axes123 );
 
-        \return
-        - A vector of the actual states of the selected axes.
-        - The values are given as #eAxisState enum values
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
+        // now the axes have stopped
+     \endcode
 
-        See also #GetAxisActualState(int) for an
-        overloaded variant to access a single axis.
+     <hr>
+  */
+  void WaitAxis(std::vector<int> const& axes, double timeout = -1.0)
+  throw (cSDHLibraryException*);
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
 
-          // Get actual axis state of all axes
-          std::vector<eAxisState> v = hand.GetAxisActualState( hand.all_axes )
-          // now v is something like {eAS_IDLE, eAS_POSITIONING, eAS_IDLE, eAS_IDLE, eAS_IDLE, eAS_DISABLED, eAS_IDLE}
 
-          // Get actual axis state of axis 3
-          eAxisState v3 = hand.GetAxisActualState( 3 );
-          // v3 is now something like eAS_IDLE
+  //----------------------------------------------------------------------
+  /*!
+      Like #WaitAxis(std::vector<int>const&,double),
+      just for a single axis \a iAxis, see there for details and examples.
 
+      If \a iAxis is #All then wait for all axes axes.
+  */
+  void WaitAxis(int iAxis, double timeout = -1.0)
+  throw (cSDHLibraryException*);
 
-          // Get actual state of axis 2 and 5
-          std::vector<int> axes25;
-          axes25.push_back( 2 );
-          axes25.push_back( 5 );
 
-          v = hand.GetAxisActualState( axes25 );
-          // now v is something like {eAS_IDLE, eAS_DISABLED}
+  //----------------------------------------------------------------------
+  /*!
+      Set the target angle(s) for axis(axes).
+
+      The target angles are stored in the %SDH, the movement
+      is not executed until an additional move command is sent.
+
+      \param axes   - A vector of axis indices to access.
+      \param angles - A vector of axis target angles to set. If any
+                      of the numbers in the vector is \c NaN (Not a Number)
+                      then the currently set axis target angle will be kept
+                      for the corresponding axis. The value(s) are expected
+                      in the configured angle unit system
+                      #uc_angle.
+
+      \remark
+      - Setting the target angle will \b not make the axis/axes move.
+      - The lengths of the \a axes and \a angles vector must match.
+      - The indices can be given in any order, but the order of
+        their elements must match, i.e. \c angles[i] will be applied
+        to axis \c axes[i] (not axis \c i).
+      - The indices are checked if they are valid axis indices.
+      - The angles are checked if they are in the allowed range
+        [#f_min_angle_v .. #f_max_angle_v], i.e. it is checked that \c angles[i],
+        converted to internal units, is in \c [#f_min_angle_v[axes[i]] .. \c f_max_angle_v[axes[i]]].
+      - If \b any index or value is invalid then \b none of the specified
+        values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      See also #SetAxisTargetAngle(int,double) for an overloaded variant to
+      set a single axis target angle or to set the same target angle for all
+      axes.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Set target axis angle of all axes to the given values:
+        std::vector<double> all_angles;
+        all_angles.push_back( 0.0 );
+        all_angles.push_back( -11.0 );
+        all_angles.push_back( -22.0 );
+        all_angles.push_back( -33.0 );
+        all_angles.push_back( -44.0 );
+        all_angles.push_back( -55.0 );
+        all_angles.push_back( -66.0 );
+
+        hand.SetAxisTargetAngle( hand.all_axes, all_angles );
+
+
+        // Set target axis angle of axis 3 to -42 degrees:
+        hand.SetAxisTargetAngle( 3, -42.0 );
+
+        // Set target angle of for axis 0, 4 and 2 to 0.0, -44.4 and -2.22 degrees respectively:
+        std::vector<int> axes042;
+        axes042.push_back( 0 );
+        axes042.push_back( 4 );
+        axes042.push_back( 2 );
+        std::vector<double> angles042;
+        angles042.push_back( 0.0 );
+        angles042.push_back( -44.4 );
+        angles042.push_back( -2.22 );
+
+        hand.SetAxisTargetAngle( axes042, angles042 );
+
+
+        // Set target axis angle of all axes to 0 degrees (home-position)
+        hand.SetAxisTargetAngle( hand.All, 0.0 );
+
       \endcode
 
       <hr>
-    */
-    std::vector<eAxisState> GetAxisActualState( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
+  */
+  void SetAxisTargetAngle(std::vector<int> const& axes, std::vector<double> const& angles)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetAxisTargetAngle(std::vector<int>const&,std::vector<double>const&),
+      just for a single axis \a iAxis and a single angle \a angle, see there for details and examples.
+
+      If \a iAxis is #All then \a motor_current is set for all axes.
+  */
+  void SetAxisTargetAngle(int iAxis, double angle)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Set the \b target angle(s) and get the \b actual angle(s) for axis(axes).
+
+      Opposed to SetAxisTargetAngle() this will make the fingers move to the
+      set target angles immediately, if the axis controllers are already enabled!
+
+      \param axes       - A vector of axis indices to access.
+      \param angles     - A vector of axis target angles to set. If any
+                          of the numbers in the vector is \c NaN (Not a
+                          Number) then the currently set axis target angle
+                          will be kept for the corresponding axis. The
+                          value(s) are expected in the configured angle
+                          unit system #uc_angle.
+
+      \return the actual angle(s) of the selected axes
 
+      \remark
+      - The lengths of the \a axes and \a angles vector must match.
+      - The indices can be given in any order, but the order of
+        their elements must match, i.e. \c angles[i] will be applied
+        to axis \c axes[i] (not axis \c i).
+      - The indices are checked if they are valid axis indices.
+      - The angles are checked if they are in the allowed range
+        [#f_min_angle_v .. #f_max_angle_v], i.e. it is checked that \c angles[i],
+        converted to internal units, is in \c [#f_min_angle_v[axis[i]] .. \c f_max_angle_v[axes[i]]].
+      - If \b any index or value is invalid then \b none of the specified
+        values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Set target axis angles of all axes to the given values and read back the actual angle:
+        std::vector<double> all_target_angles;
+        all_target_angles.push_back( 0.0 );
+        all_target_angles.push_back( 11.0 );
+        all_target_angles.push_back( 22.0 );
+        all_target_angles.push_back( 33.0 );
+        all_target_angles.push_back( 44.0 );
+        all_target_angles.push_back( 55.0 );
+        all_target_angles.push_back( 66.0 );
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisActualState(std::vector<int>const&),
-        just for a single axis \a iAxis, see there for details and examples.
-    */
-    eAxisState GetAxisActualState( int iAxis )
-        throw (cSDHLibraryException*);
+        std::vector<double> all_acutal_angles;
+        all_acutal_angles = hand.SetAxisTargetGetAxisActualAngle( hand.all_axes, all_target_angles );
 
 
-    //-----------------------------------------------------------------
-    /*!
-        Wait until the movement(s) of of axis(axes) has finished
+        // Set target angle of for axis 0,4 and 2 to 0.0, 44.4 and 2.22 degrees per second respectively:
+        std::vector<int> axes042;
+        axes042.push_back( 0 );
+        axes042.push_back( 4 );
+        axes042.push_back( 2 );
+        std::vector<double> target_angles042;
+        target_angles042.push_back( 0.0 );
+        target_angles042.push_back( 44.4 );
+        target_angles042.push_back( 2.22 );
 
-        The state of the given axis(axes) is(are) queried until all
-        axes are no longer moving.
+        std::vector<double> actual_angles042;
+        actual_angles042 = hand.SetAxisTargetGetAxisActualAngle( axes042, target_angles042 );
 
-        \param axes    - A vector of axis indices to access.
-        \param timeout - a timeout in seconds or -1.0 (default) to wait indefinetly.
+      \endcode
 
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-          - If \a timeout < 0 then this function will wait arbitrarily long
-          - If a \a timeout is given then this function will throw a
-            cSDHErrorCommunication exception if the given axes are still
-            moving after \a timeout many seconds
+      <hr>
+  */
+  std::vector<double> SetAxisTargetGetAxisActualAngle(std::vector<int> const& axes, std::vector<double> const& angles)
+  throw (cSDHLibraryException*);
 
-        See also #WaitAxis(int,double) for an overloaded variant to
-        wait for a single axis or all axes.
 
-        \bug Due to a bug in %SDH firmwares prior to 0.0.2.6 the WaitAxis() command
-             was somewhat unreliable there. When called immediately after a movement command like MoveHand(),
-             then the WaitAxis() command returned immediately without waiting for the end of the movement.
-             With %SDH firmwares 0.0.2.6 and newer this is no longer problematic and WaitAxis() works as expected.
-             <br><b>=> Resolved in %SDH firmware 0.0.2.6</b>
+  //-----------------------------------------------------------------
+  /*!
+      Get the target angle(s) of axis(axes).
 
-        \bug With %SDH firmware 0.0.2.6 WaitAxis() did not work if one of the new
-             velocity based controllers (eCT_VELOCITY, eCT_VELOCITY_ACCELERATION)
-             was used. With %SDH firmwares 0.0.2.7 and newer this now works. Here
-             the WaitAxis() waits until the selected axes come to velocity 0.0
-             <br><b>=> Resolved in %SDH firmware 0.0.2.7</b>
+      The currently set target angles are read from the %SDH.
 
-        \par Examples:
-        Example 1, WaitAxis and eCT_POSE controller, see also the demo program demo-simple3:
-        \code
-          // Assuming "hand" is a cSDH object ...
+      \param axes - A vector of axis indices to access.
 
-          hand.SetController( eCT_POSE );
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-          // Set a new target pose for axis 1,2 and 3
-          std::vector<int> axes123;
-          axes123.push_back( 1 );
-          axes123.push_back( 2 );
-          axes123.push_back( 3 );
+      \return
+      - A vector of the target angles of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angle unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-          std::vector<double> angles123;
-          angles123.push_back( -20.0 );
-          angles123.push_back( -30.0 );
-          angles123.push_back( -40.0 );
+      See also #GetAxisTargetAngle(int) for an
+      overloaded variant to access a single axis.
 
 
-          hand.SetAxisTargetAngle( axes123, angles123 );
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-          // Move axes there non sequentially:
-          hand.MoveAxis( axes123, false );
+        // Get target axis angle of all axes
+        std::vector<double> v = hand.GetAxisTargetAngle( hand.all_axes );
+        // now v is something like {0.0, 0.0, 42.0, 0.0, 47.11, 0,0, 0.0}
 
-          // The last call returned immediately so we now have time to
-          // do something else while the hand is moving:
+        // Get target axis angle of axis 2
+        double v2 = hand.GetAxisTargetAngle( 2 );
+        // v2 is now something like 42.0
 
-          // ... insert any calculation here ...
 
-          // Before doing something else with the hand make sure the
-          // selected axes have finished the last movement:
-          hand.WaitAxis( axes123 );
+        // Get target axis angle of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
+        v = hand.GetAxisTargetAngle( axes24 );
+        // now v is something like {42.0, 47.11}
 
-          // go back home (all angles to 0.0):
-          hand.SetAxisTargetAngle( hand.All, 0.0 );
+      \endcode
 
-          // Move all axes there non sequentially:
-          hand.MoveAxis( hand.All, False );
+      <hr>
+  */
+  std::vector<double> GetAxisTargetAngle(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
-          // ... insert any other calculation here ...
 
-          // Wait until all axes are there, with a timeout of 10s:
-          hand.WaitAxis( hand.All, 10.0 );
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisTargetAngle(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single angle, see there for details and
+      examples.
+  */
+  double GetAxisTargetAngle(int iAxis)
+  throw (cSDHLibraryException*);
 
-          // now we are at the desired position.
-       \endcode
 
-       Example 2, WaitAxis and eCT_VELOCITY_ACCELERATION controller, see also the demo program demo-velocity-acceleration
-       \code
-          // Assuming "hand" is a cSDH object ...
+  //-----------------------------------------------------------------
+  /*!
+     Get the current actual angle(s) of axis(axes).
 
-          hand.SetController( eCT_VELOCITY_ACCELERATION);
+     The actual angles are read from the %SDH.
 
-          // Set a new target velocity for axis 1,2 and 3
-          std::vector<int> axes123;
-          axes123.push_back( 1 );
-          axes123.push_back( 2 );
-          axes123.push_back( 3 );
+      \param axes - A vector of axis indices to access.
 
-          std::vector<double> velocities123;
-          velocities123.push_back( -20.0 );
-          velocities123.push_back( -30.0 );
-          velocities123.push_back( -40.0 );
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
+      \return
+      - A vector of the actual angles of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angle unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-          hand.SetAxisTargetVelocity( axes123, velocities123 ); // this will make the axes move!
-
-          // The last call returned immediately so we now have time to
-          // do something else while the hand is moving:
-
-          // ... insert any calculation here ...
+      See also #GetAxisActualAngle(int) for an
+      overloaded variant to access a single axis.
 
-          // to break and stop the movement just set the target velocities to 0.0
-          velocities123[0] = 0.0;
-          velocities123[1] = 0.0;
-          velocities123[2] = 0.0;
 
-          hand.SetAxisTargetVelocity( axes123, velocities123 ); // this will make the axes break with the default (de)acceleration
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-          // The previous command returned immediately, so
-          // before doing something else with the hand make sure the
-          // selected axes have stopped:
-          hand.WaitAxis( axes123 );
+        // Get actual axis angle of all axes
+        std::vector<double> v = hand.GetAxisActualAngle( hand.all_axes );
+        // now v is something like {0.0, 0.0, 42.0, 0.0, 47.11, 0,0, 0.0}
 
-          // now the axes have stopped
-       \endcode
+        // Get actual axis angle of axis 2
+        double v2 = hand.GetAxisActualAngle( 2 );
+        // 2 is now something like 42.0
 
-       <hr>
-    */
-    void WaitAxis( std::vector<int> const& axes, double timeout = -1.0 )
-        throw (cSDHLibraryException*);
 
+        // Get actual axis angle of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
+        v = hand.GetAxisActualAngle( axes24 );
+        // now v is something like {42.0, 47.11}
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #WaitAxis(std::vector<int>const&,double),
-        just for a single axis \a iAxis, see there for details and examples.
+      \endcode
 
-        If \a iAxis is #All then wait for all axes axes.
-    */
-    void WaitAxis( int iAxis, double timeout = -1.0 )
-        throw (cSDHLibraryException*);
+      <hr>
+  */
+  std::vector<double> GetAxisActualAngle(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
 
-    //----------------------------------------------------------------------
-    /*!
-        Set the target angle(s) for axis(axes).
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisActualAngle(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single angle, see there for details and
+      examples.
+  */
+  double GetAxisActualAngle(int iAxis)
+  throw (cSDHLibraryException*);
 
-        The target angles are stored in the %SDH, the movement
-        is not executed until an additional move command is sent.
 
-        \param axes   - A vector of axis indices to access.
-        \param angles - A vector of axis target angles to set. If any
-                        of the numbers in the vector is \c NaN (Not a Number)
-                        then the currently set axis target angle will be kept
-                        for the corresponding axis. The value(s) are expected
-                        in the configured angle unit system
-                        #uc_angle.
+  //-----------------------------------------------------------------
+  /*!
+      Set the target velocity(s) for axis(axes).
 
-        \remark
-        - Setting the target angle will \b not make the axis/axes move.
-        - The lengths of the \a axes and \a angles vector must match.
-        - The indices can be given in any order, but the order of
-          their elements must match, i.e. \c angles[i] will be applied
-          to axis \c axes[i] (not axis \c i).
-        - The indices are checked if they are valid axis indices.
-        - The angles are checked if they are in the allowed range
-          [#f_min_angle_v .. #f_max_angle_v], i.e. it is checked that \c angles[i],
-          converted to internal units, is in \c [#f_min_angle_v[axes[i]] .. \c f_max_angle_v[axes[i]]].
-        - If \b any index or value is invalid then \b none of the specified
-          values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        See also #SetAxisTargetAngle(int,double) for an overloaded variant to
-        set a single axis target angle or to set the same target angle for all
-        axes.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Set target axis angle of all axes to the given values:
-          std::vector<double> all_angles;
-          all_angles.push_back( 0.0 );
-          all_angles.push_back( -11.0 );
-          all_angles.push_back( -22.0 );
-          all_angles.push_back( -33.0 );
-          all_angles.push_back( -44.0 );
-          all_angles.push_back( -55.0 );
-          all_angles.push_back( -66.0 );
-
-          hand.SetAxisTargetAngle( hand.all_axes, all_angles );
-
-
-          // Set target axis angle of axis 3 to -42 degrees:
-          hand.SetAxisTargetAngle( 3, -42.0 );
-
-          // Set target angle of for axis 0, 4 and 2 to 0.0, -44.4 and -2.22 degrees respectively:
-          std::vector<int> axes042;
-          axes042.push_back( 0 );
-          axes042.push_back( 4 );
-          axes042.push_back( 2 );
-          std::vector<double> angles042;
-          angles042.push_back( 0.0 );
-          angles042.push_back( -44.4 );
-          angles042.push_back( -2.22 );
-
-          hand.SetAxisTargetAngle( axes042, angles042 );
-
+      The target velocities are stored in the %SDH. The time at which
+      a new target velocities will take effect depends on the current
+      axis controller type:
+      - in eCT_POSE controller type the new target velocities will
+        not take effect until an additional move command is sent:
+        MoveAxis(), MoveFinger(), MoveHand()
+      - in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller type
+        the new target velocity will take effect immediately,
+        if the axis controllers are already enabled.
+        This means that in eCT_VELOCITY_ACCELERATION controller type
+        the accelerations must be set with SetAxisTargetAcceleration()
+        \b before calling SetAxisTargetVelocity().
 
-          // Set target axis angle of all axes to 0 degrees (home-position)
-          hand.SetAxisTargetAngle( hand.All, 0.0 );
-
-        \endcode
+      \param axes       - A vector of axis indices to access.
+      \param velocities - A vector of axis target angles to set. If any
+                          of the numbers in the vector is \c NaN (Not a
+                          Number) then the currently set axis target velocity
+                          will be kept for the corresponding axis. The
+                          value(s) are expected in the configured angular
+                          velocity unit system #uc_angular_velocity.
 
-        <hr>
-    */
-    void SetAxisTargetAngle( std::vector<int> const& axes, std::vector<double> const& angles )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetAxisTargetAngle(std::vector<int>const&,std::vector<double>const&),
-        just for a single axis \a iAxis and a single angle \a angle, see there for details and examples.
 
-        If \a iAxis is #All then \a motor_current is set for all axes.
-    */
-    void SetAxisTargetAngle( int iAxis, double angle )
-        throw (cSDHLibraryException*);
 
-
-    //----------------------------------------------------------------------
-    /*!
-        Set the \b target angle(s) and get the \b actual angle(s) for axis(axes).
-
-        Opposed to SetAxisTargetAngle() this will make the fingers move to the
-        set target angles immediately, if the axis controllers are already enabled!
-
-        \param axes       - A vector of axis indices to access.
-        \param angles     - A vector of axis target angles to set. If any
-                            of the numbers in the vector is \c NaN (Not a
-                            Number) then the currently set axis target angle
-                            will be kept for the corresponding axis. The
-                            value(s) are expected in the configured angle
-                            unit system #uc_angle.
-
-        \return the actual angle(s) of the selected axes
-
-        \remark
-        - The lengths of the \a axes and \a angles vector must match.
-        - The indices can be given in any order, but the order of
-          their elements must match, i.e. \c angles[i] will be applied
-          to axis \c axes[i] (not axis \c i).
-        - The indices are checked if they are valid axis indices.
-        - The angles are checked if they are in the allowed range
-          [#f_min_angle_v .. #f_max_angle_v], i.e. it is checked that \c angles[i],
-          converted to internal units, is in \c [#f_min_angle_v[axis[i]] .. \c f_max_angle_v[axes[i]]].
-        - If \b any index or value is invalid then \b none of the specified
-          values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Set target axis angles of all axes to the given values and read back the actual angle:
-          std::vector<double> all_target_angles;
-          all_target_angles.push_back( 0.0 );
-          all_target_angles.push_back( 11.0 );
-          all_target_angles.push_back( 22.0 );
-          all_target_angles.push_back( 33.0 );
-          all_target_angles.push_back( 44.0 );
-          all_target_angles.push_back( 55.0 );
-          all_target_angles.push_back( 66.0 );
-
-          std::vector<double> all_acutal_angles;
-          all_acutal_angles = hand.SetAxisTargetGetAxisActualAngle( hand.all_axes, all_target_angles );
-
-
-          // Set target angle of for axis 0,4 and 2 to 0.0, 44.4 and 2.22 degrees per second respectively:
-          std::vector<int> axes042;
-          axes042.push_back( 0 );
-          axes042.push_back( 4 );
-          axes042.push_back( 2 );
-          std::vector<double> target_angles042;
-          target_angles042.push_back( 0.0 );
-          target_angles042.push_back( 44.4 );
-          target_angles042.push_back( 2.22 );
-
-          std::vector<double> actual_angles042;
-          actual_angles042 = hand.SetAxisTargetGetAxisActualAngle( axes042, target_angles042 );
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> SetAxisTargetGetAxisActualAngle( std::vector<int> const& axes, std::vector<double> const& angles )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get the target angle(s) of axis(axes).
-
-        The currently set target angles are read from the %SDH.
-
-        \param axes - A vector of axis indices to access.
-
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-        - A vector of the target angles of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angle unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
-
-        See also #GetAxisTargetAngle(int) for an
-        overloaded variant to access a single axis.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get target axis angle of all axes
-          std::vector<double> v = hand.GetAxisTargetAngle( hand.all_axes );
-          // now v is something like {0.0, 0.0, 42.0, 0.0, 47.11, 0,0, 0.0}
-
-          // Get target axis angle of axis 2
-          double v2 = hand.GetAxisTargetAngle( 2 );
-          // v2 is now something like 42.0
-
-
-          // Get target axis angle of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
-
-          v = hand.GetAxisTargetAngle( axes24 );
-          // now v is something like {42.0, 47.11}
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetAxisTargetAngle( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisTargetAngle(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single angle, see there for details and
-        examples.
-    */
-    double GetAxisTargetAngle( int iAxis )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-       Get the current actual angle(s) of axis(axes).
-
-       The actual angles are read from the %SDH.
-
-        \param axes - A vector of axis indices to access.
-
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-        - A vector of the actual angles of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angle unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
-
-        See also #GetAxisActualAngle(int) for an
-        overloaded variant to access a single axis.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get actual axis angle of all axes
-          std::vector<double> v = hand.GetAxisActualAngle( hand.all_axes );
-          // now v is something like {0.0, 0.0, 42.0, 0.0, 47.11, 0,0, 0.0}
-
-          // Get actual axis angle of axis 2
-          double v2 = hand.GetAxisActualAngle( 2 );
-          // 2 is now something like 42.0
-
-
-          // Get actual axis angle of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
-
-          v = hand.GetAxisActualAngle( axes24 );
-          // now v is something like {42.0, 47.11}
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetAxisActualAngle( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisActualAngle(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single angle, see there for details and
-        examples.
-    */
-    double GetAxisActualAngle( int iAxis )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Set the target velocity(s) for axis(axes).
-
-        The target velocities are stored in the %SDH. The time at which
-        a new target velocities will take effect depends on the current
-        axis controller type:
-        - in eCT_POSE controller type the new target velocities will
-          not take effect until an additional move command is sent:
-          MoveAxis(), MoveFinger(), MoveHand()
-        - in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller type
-          the new target velocity will take effect immediately,
-          if the axis controllers are already enabled.
-          This means that in eCT_VELOCITY_ACCELERATION controller type
-          the accelerations must be set with SetAxisTargetAcceleration()
-          \b before calling SetAxisTargetVelocity().
-
-        \param axes       - A vector of axis indices to access.
-        \param velocities - A vector of axis target angles to set. If any
-                            of the numbers in the vector is \c NaN (Not a
-                            Number) then the currently set axis target velocity
-                            will be kept for the corresponding axis. The
-                            value(s) are expected in the configured angular
-                            velocity unit system #uc_angular_velocity.
-
-
-
-        \remark
-        - The lengths of the \a axes and \a velocities vector must match.
-        - The indices can be given in any order, but the order of
-          their elements must match, i.e. \c velocities[i] will be applied
-          to axis \c axes[i] (not axis \c i).
-        - The indices are checked if they are valid axis indices.
-        - The velocities are checked if they are in the allowed range:
-          - in eCT_POSE controller type:
-            [0 .. #f_max_velocity_v], i.e. it is checked that \c velocities[i],
-            converted to internal units, is in \c [0 .. \c f_max_velocity_v[axes[i]]].
-          - in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller type:
-            [-#f_max_velocity_v .. #f_max_velocity_v], i.e. it is checked that \c velocities[i],
-            converted to internal units, is in \c [-f_max_velocity_v[axes[i]] .. \c f_max_velocity_v[axes[i]]].
-        - If \b any index or value is invalid then \b none of the specified
-          values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        See also #SetAxisTargetVelocity(int,double) for an overloaded variant
-        to set a single axis target velocity or to set the same target velocity
-        for all axes.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Set target axis velocity of all axes to the given values:
-          std::vector<double> all_velocities;
-          all_velocities.push_back( 0.0 );
-          all_velocities.push_back( 11.0 );
-          all_velocities.push_back( 22.0 );
-          all_velocities.push_back( 33.0 );
-          all_velocities.push_back( 44.0 );
-          all_velocities.push_back( 55.0 );
-          all_velocities.push_back( 66.0 );
-
-          hand.SetAxisTargetVelocity( hand.all_axes, all_velocities );
-
-
-          // Set target axis velocity of axis 3 to 42 degrees per second:
-          hand.SetAxisTargetVelocity( 3, 42.0 );
-
-          // Set target velocity of for axis 0,4 and 2 to 0.0, 44.4 and 2.22 degrees per second respectively:
-          std::vector<int> axes042;
-          axes042.push_back( 0 );
-          axes042.push_back( 4 );
-          axes042.push_back( 2 );
-          std::vector<double> velocities042;
-          velocities042.push_back( 0.0 );
-          velocities042.push_back( 44.4 );
-          velocities042.push_back( 2.22 );
-
-          hand.SetAxisTargetVelocity( axes042, velocities042 );
-
-
-          // Set target axis velocity of all axes to 47.11 degrees per second
-          hand.SetAxisTargetVelocity( hand.All, 47.11 );
-
-        \endcode
-
-        <hr>
-    */
-    void SetAxisTargetVelocity( std::vector<int> const& axes, std::vector<double> const& velocities )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetAxisTargetVelocity(std::vector<int>const&,std::vector<double>const&),
-        just for a single axis \a iAxis and a single velocity \a velocity, see there for details and examples.
-    */
-    void SetAxisTargetVelocity( int iAxis, double velocity )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Set the \b target velocity(s) and get the \b actual velocitiy(s) for axis(axes).
-
-        The target velocities are stored in the %SDH. The time at which
-        a new target velocities will take effect depends on the current
-        axis controller type:
-        - in eCT_POSE controller type the new target velocities will
-          not take effect until an additional move command is sent:
-          MoveAxis(), MoveFinger(), MoveHand()
-        - in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller type
-          the new target velocity will take effect immediately,
-          if the axis controllers are already enabled.
-          This means that in eCT_VELOCITY_ACCELERATION controller type
-          the accelerations must be set with SetAxisTargetAcceleration()
-          \b before calling SetAxisTargetVelocity().
-
-        \param axes       - A vector of axis indices to access.
-        \param velocities - A vector of axis target velocities to set. If any
-                            of the numbers in the vector is \c NaN (Not a
-                            Number) then the currently set axis target velocity
-                            will be kept for the corresponding axis. The
-                            value(s) are expected in the configured angular
-                            velocity unit system #uc_angular_velocity.
-
-        \return the actual velocity(s) of the selected axes
-
-        \remark
-        - The lengths of the \a axes and \a velocities vector must match.
-        - The indices can be given in any order, but the order of
-          their elements must match, i.e. \c velocities[i] will be applied
-          to axis \c axes[i] (not axis \c i).
-        - The indices are checked if they are valid axis indices.
-        - The velocities are checked if they are in the allowed range:
-          - in eCT_POSE controller type:
-            [0 .. #f_max_velocity_v], i.e. it is checked that \c velocities[i],
-            converted to internal units, is in \c [0 .. \c f_max_velocity_v[axes[i]]].
-          - in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller type:
-            [-#f_max_velocity_v .. #f_max_velocity_v], i.e. it is checked that \c velocities[i],
-            converted to internal units, is in \c [-f_max_velocity_v[axes[i]] .. \c f_max_velocity_v[axes[i]]].
-        - If \b any index or value is invalid then \b none of the specified
-          values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Set target axis velocity of all axes to the given values and read back the actual velocity:
-          std::vector<double> all_target_velocities;
-          all_target_velocities.push_back( 0.0 );
-          all_target_velocities.push_back( 11.0 );
-          all_target_velocities.push_back( 22.0 );
-          all_target_velocities.push_back( 33.0 );
-          all_target_velocities.push_back( 44.0 );
-          all_target_velocities.push_back( 55.0 );
-          all_target_velocities.push_back( 66.0 );
-
-          std::vector<double> all_acutal_velocities;
-          all_acutal_velocities = hand.SetAxisTargetGetAxisActualVelocity( hand.all_axes, all_target_velocities );
-
-
-          // Set target velocity of for axis 0,4 and 2 to 0.0, 44.4 and 2.22 degrees per second respectively:
-          std::vector<int> axes042;
-          axes042.push_back( 0 );
-          axes042.push_back( 4 );
-          axes042.push_back( 2 );
-          std::vector<double> target_velocities042;
-          target_velocities042.push_back( 0.0 );
-          target_velocities042.push_back( 44.4 );
-          target_velocities042.push_back( 2.22 );
-
-          std::vector<double> actual_velocities042;
-          actual_velocities042 = hand.SetAxisTargetGetAxisActualVelocity( axes042, target_velocities042 );
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> SetAxisTargetGetAxisActualVelocity( std::vector<int> const& axes, std::vector<double> const& velocities )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get the target velocity(s) of axis(axes).
-
-        The currently set target velocities are read from the %SDH.
-
-        \param axes - A vector of axis indices to access.
-
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-        - A vector of the target velocities of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angular_velocity unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
-
-        See also #GetAxisTargetVelocity(int) for an
-        overloaded variant to access a single axis.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get target axis velocity of all axes
-          std::vector<double> v = hand.GetAxisTargetVelocity( hand.all_axes );
-          // now v is something like {0.0, 0.0, 42.0, 0.0, 47.11, 0,0, 0.0}
-
-          // Get target axis velocity of axis 2
-          double v2 = hand.GetAxisTargetVelocity( 2 );
-          // v2 is now something like 42.0
-
-
-          // Get target axis velocity of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
-
-          v = hand.GetAxisTargetVelocity( axes24 );
-          // now v is something like {42.0, 47.11}
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetAxisTargetVelocity( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisTargetVelocity(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single velocity, see there for details
-        and examples.
-    */
-    double GetAxisTargetVelocity( int iAxis )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get the velocity limit(s) of axis(axes).
-
-        The velocity limit(s) are read from the %SDH.
-
-        \param axes - A vector of axis indices to access.
-
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-        - A vector of the velocity limits of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angular_velocity unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
-
-        See also #GetAxisLimitVelocity(int) for an
-        overloaded variant to access a single axis.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get axis velocity limits of all axes
-          std::vector<double> v = hand.GetAxisLimitVelocity( hand.all_axes );
-          // now v is something like {81.0, 140.0, 120.0, 140.0, 120.0, 140.0, 120.0}
-
-          // Get axis velocity limit of axis 2
-          double v2 = hand.GetAxisLimitVelocity( 2 );
-          // v2 is now something like 120.0
-
-
-          // Get axis velocity limits of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
-
-          v = hand.GetAxisLimitVelocity( axes24 );
-          // now v is something like {120.0,120.0}
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetAxisLimitVelocity( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisLimitVelocity(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single velocity limit, see there for details
-        and examples.
-    */
-    double GetAxisLimitVelocity( int iAxis )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get the acceleration limit(s) of axis(axes).
-
-        The acceleration limit(s) are read from the %SDH.
-
-        \param axes - A vector of axis indices to access.
-
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-        - A vector of the acceleration limits of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angular_acceleration unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
-
-        See also #GetAxisLimitAcceleration(int) for an
-        overloaded variant to access a single axis.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get axis acceleration limits of all axes
-          std::vector<double> v = hand.GetAxisLimitAcceleration( hand.all_axes );
-          // now v is something like {81.0, 140.0, 120.0, 140.0, 120.0, 140.0, 120.0}
-
-          // Get axis acceleration limit of axis 2
-          double v2 = hand.GetAxisLimitAcceleration( 2 );
-          // v2 is now something like 120.0
-
-
-          // Get axis acceleration limits of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
-
-          v = hand.GetAxisLimitAcceleration( axes24 );
-          // now v is something like {120.0,120.0}
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetAxisLimitAcceleration( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisLimitAcceleration(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single acceleration limit, see there for details
-        and examples.
-    */
-    double GetAxisLimitAcceleration( int iAxis )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get the actual velocity(s) of axis(axes).
-
-        \param axes - A vector of axis indices to access.
-
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-        - A vector of the actual velocities of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angular_velocity unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
-
-        See also #GetAxisActualVelocity(int) for an
-        overloaded variant to access a single axis.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get actual axis velocity of all axes
-          std::vector<double> v = hand.GetAxisActualVelocity( hand.all_axes );
-          // now v is something like {0.1, 0.2, 0.3, 13.2, 0.5, 0.0, 0.7}
-
-          // Get actual axis velocity of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
-          v = hand.GetAxisActualVelocity( axes24 );
-          // now v is something like {13.2, 0.0}
-
-          // Get actual axis velocity of axis 2
-          double v3 = hand.GetAxisActualVelocity( 2 );
-          // v3 is now something like 13.2
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetAxisActualVelocity( std::vector<int>const& axes )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisActualVelocity(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single velocity, see there for details
-        and examples.
-    */
-    double GetAxisActualVelocity( int iAxis )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get the current reference velocity(s) of axis(axes). (This velocity is used internally by the %SDH in eCT_VELOCITY_ACCELERATION mode).
-
-        \param axes - A vector of axis indices to access.
-
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-        - A vector of the reference velocities of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angular_velocity unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
-
-        See also #GetAxisReferenceVelocity(int) for an
-        overloaded variant to access a single axis.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Switch to "velocity control with acceleration ramp" controller mode first.
-          // (When in another controller mode like the default eCT_POSE,
-          //  then the reference velocities will not be valid):
-          hand.SetController( eCT_VELOCITY_ACCELERATION );
-
-          // Get reference axis velocity of all axes
-          std::vector<double> v = hand.GetAxisReferenceVelocity( hand.all_axes );
-          // now v is something like {0.1, 0.2, 0.3, 13.2, 0.5, 0.0, 0.7}
-
-          // Get reference axis velocity of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
-          v = hand.GetAxisReferenceVelocity( axes24 );
-          // now v is something like {13.2, 0.0}
-
-          // Get reference axis velocity of axis 2
-          double v3 = hand.GetAxisReferenceVelocity( 2 );
-          // v3 is now something like 13.2
-
-        \endcode
-
-        \remark
-          - the underlying rvel command of the %SDH firmware is not
-            available in firmwares prior to 0.0.2.6. For such hands
-            calling rvel will fail miserably.
-          - The availability of an appropriate %SDH firmware is \b not checked
-            here due to performance losses when this function is used often.
-
-        <hr>
-    */
-    std::vector<double> GetAxisReferenceVelocity( std::vector<int>const& axes )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisReferenceVelocity(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single velocity, see there for details
-        and examples.
-    */
-    double GetAxisReferenceVelocity( int iAxis )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Set the target acceleration(s) for axis(axes).
-
-        The target accelerations are stored in the %SDH and are used only for:
-        - the eCT_POSE controller type with eVP_RAMP velocity profile
-        - the eCT_VELOCITY_ACCELERATION controller type
-
-        Setting the target acceleration will not affect an ongoing movement,
-        nor will it start a new movement. To take effect an additional command
-        must be sent:
-        - in eCT_POSE controller type a move command: MoveAxis() MoveFinger() MoveHand()
-        - in eCT_VELOCITY_ACCELERATION controller type the velocity must be set: SetAxisTargetVelocity()
-
-        \param axes          - A vector of axis indices to access.
-        \param accelerations - A vector of axis target accelerations to set. If any
-                               of the numbers in the vector is \c NaN
-                               (Not a Number) then the currently set
-                               axis target angle will be kept for the
-                               corresponding axis. The value(s) are
-                               expected in the configured angular
-                               acceleration unit system
-                               #uc_angular_acceleration.
-
-        \remark
-        - The lengths of the \a axes and \a accelerations vector must match.
-        - The indices can be given in any order, but the order of
-          their elements must match, i.e. \c accelerations[i] will be applied
-          to axis \c axes[i] (not axis \c i).
-        - The indices are checked if they are valid axis indices.
-        - The accelerations are checked if they are in the allowed range
-          [0 .. #f_max_velocity_v], i.e. it is checked that \c accelerations[i],
+      \remark
+      - The lengths of the \a axes and \a velocities vector must match.
+      - The indices can be given in any order, but the order of
+        their elements must match, i.e. \c velocities[i] will be applied
+        to axis \c axes[i] (not axis \c i).
+      - The indices are checked if they are valid axis indices.
+      - The velocities are checked if they are in the allowed range:
+        - in eCT_POSE controller type:
+          [0 .. #f_max_velocity_v], i.e. it is checked that \c velocities[i],
           converted to internal units, is in \c [0 .. \c f_max_velocity_v[axes[i]]].
-        - If \b any index or value is invalid then \b none of the specified
-          values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
+        - in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller type:
+          [-#f_max_velocity_v .. #f_max_velocity_v], i.e. it is checked that \c velocities[i],
+          converted to internal units, is in \c [-f_max_velocity_v[axes[i]] .. \c f_max_velocity_v[axes[i]]].
+      - If \b any index or value is invalid then \b none of the specified
+        values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      See also #SetAxisTargetVelocity(int,double) for an overloaded variant
+      to set a single axis target velocity or to set the same target velocity
+      for all axes.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Set target axis velocity of all axes to the given values:
+        std::vector<double> all_velocities;
+        all_velocities.push_back( 0.0 );
+        all_velocities.push_back( 11.0 );
+        all_velocities.push_back( 22.0 );
+        all_velocities.push_back( 33.0 );
+        all_velocities.push_back( 44.0 );
+        all_velocities.push_back( 55.0 );
+        all_velocities.push_back( 66.0 );
+
+        hand.SetAxisTargetVelocity( hand.all_axes, all_velocities );
+
+
+        // Set target axis velocity of axis 3 to 42 degrees per second:
+        hand.SetAxisTargetVelocity( 3, 42.0 );
+
+        // Set target velocity of for axis 0,4 and 2 to 0.0, 44.4 and 2.22 degrees per second respectively:
+        std::vector<int> axes042;
+        axes042.push_back( 0 );
+        axes042.push_back( 4 );
+        axes042.push_back( 2 );
+        std::vector<double> velocities042;
+        velocities042.push_back( 0.0 );
+        velocities042.push_back( 44.4 );
+        velocities042.push_back( 2.22 );
+
+        hand.SetAxisTargetVelocity( axes042, velocities042 );
+
+
+        // Set target axis velocity of all axes to 47.11 degrees per second
+        hand.SetAxisTargetVelocity( hand.All, 47.11 );
+
+      \endcode
+
+      <hr>
+  */
+  void SetAxisTargetVelocity(std::vector<int> const& axes, std::vector<double> const& velocities)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetAxisTargetVelocity(std::vector<int>const&,std::vector<double>const&),
+      just for a single axis \a iAxis and a single velocity \a velocity, see there for details and examples.
+  */
+  void SetAxisTargetVelocity(int iAxis, double velocity)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Set the \b target velocity(s) and get the \b actual velocitiy(s) for axis(axes).
+
+      The target velocities are stored in the %SDH. The time at which
+      a new target velocities will take effect depends on the current
+      axis controller type:
+      - in eCT_POSE controller type the new target velocities will
+        not take effect until an additional move command is sent:
+        MoveAxis(), MoveFinger(), MoveHand()
+      - in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller type
+        the new target velocity will take effect immediately,
+        if the axis controllers are already enabled.
+        This means that in eCT_VELOCITY_ACCELERATION controller type
+        the accelerations must be set with SetAxisTargetAcceleration()
+        \b before calling SetAxisTargetVelocity().
+
+      \param axes       - A vector of axis indices to access.
+      \param velocities - A vector of axis target velocities to set. If any
+                          of the numbers in the vector is \c NaN (Not a
+                          Number) then the currently set axis target velocity
+                          will be kept for the corresponding axis. The
+                          value(s) are expected in the configured angular
+                          velocity unit system #uc_angular_velocity.
+
+      \return the actual velocity(s) of the selected axes
+
+      \remark
+      - The lengths of the \a axes and \a velocities vector must match.
+      - The indices can be given in any order, but the order of
+        their elements must match, i.e. \c velocities[i] will be applied
+        to axis \c axes[i] (not axis \c i).
+      - The indices are checked if they are valid axis indices.
+      - The velocities are checked if they are in the allowed range:
+        - in eCT_POSE controller type:
+          [0 .. #f_max_velocity_v], i.e. it is checked that \c velocities[i],
+          converted to internal units, is in \c [0 .. \c f_max_velocity_v[axes[i]]].
+        - in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller type:
+          [-#f_max_velocity_v .. #f_max_velocity_v], i.e. it is checked that \c velocities[i],
+          converted to internal units, is in \c [-f_max_velocity_v[axes[i]] .. \c f_max_velocity_v[axes[i]]].
+      - If \b any index or value is invalid then \b none of the specified
+        values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-        See also #SetAxisTargetAcceleration(int,double) for an
-        overloaded variant to set a single axis target acceleration or
-        to set the same target acceleration for all axes.
+        // Set target axis velocity of all axes to the given values and read back the actual velocity:
+        std::vector<double> all_target_velocities;
+        all_target_velocities.push_back( 0.0 );
+        all_target_velocities.push_back( 11.0 );
+        all_target_velocities.push_back( 22.0 );
+        all_target_velocities.push_back( 33.0 );
+        all_target_velocities.push_back( 44.0 );
+        all_target_velocities.push_back( 55.0 );
+        all_target_velocities.push_back( 66.0 );
 
+        std::vector<double> all_acutal_velocities;
+        all_acutal_velocities = hand.SetAxisTargetGetAxisActualVelocity( hand.all_axes, all_target_velocities );
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
 
-          // Set target axis acceleration of all axes to the given values:
-          std::vector<double> all_accelerations;
-          all_accelerations.push_back( 100.0 );
-          all_accelerations.push_back( 101.0 );
-          all_accelerations.push_back( 102.0 );
-          all_accelerations.push_back( 103.0 );
-          all_accelerations.push_back( 104.0 );
-          all_accelerations.push_back( 105.0 );
-          all_accelerations.push_back( 106.0 );
+        // Set target velocity of for axis 0,4 and 2 to 0.0, 44.4 and 2.22 degrees per second respectively:
+        std::vector<int> axes042;
+        axes042.push_back( 0 );
+        axes042.push_back( 4 );
+        axes042.push_back( 2 );
+        std::vector<double> target_velocities042;
+        target_velocities042.push_back( 0.0 );
+        target_velocities042.push_back( 44.4 );
+        target_velocities042.push_back( 2.22 );
 
-          hand.SetAxisTargetAcceleration( hand.all_axes, all_accelerations );
+        std::vector<double> actual_velocities042;
+        actual_velocities042 = hand.SetAxisTargetGetAxisActualVelocity( axes042, target_velocities042 );
 
+      \endcode
 
-          // Set target axis acceleration of axis 3 to 420 degrees per square-second:
-          hand.SetAxisTargetAcceleration( 3, 420.0 );
+      <hr>
+  */
+  std::vector<double> SetAxisTargetGetAxisActualVelocity(std::vector<int> const& axes, std::vector<double> const& velocities)
+  throw (cSDHLibraryException*);
 
-          // Set target acceleration of for axis 0,4 and 2 to 0.0, 444.0 and 222 degrees per square-second respectively:
-          std::vector<int> axes042;
-          axes042.push_back( 0 );
-          axes042.push_back( 4 );
-          axes042.push_back( 2 );
-          std::vector<double> accelerations042;
-          accelerations042.push_back( 100.0 );
-          accelerations042.push_back( 104.0 );
-          accelerations042.push_back( 102.0 );
 
-          hand.SetAxisTargetAcceleration( axes042, accelerations042 );
+  //-----------------------------------------------------------------
+  /*!
+      Get the target velocity(s) of axis(axes).
 
+      The currently set target velocities are read from the %SDH.
 
-          // Set target axis acceleration of all axes to 142.1 degrees per square-second
-          hand.SetAxisTargetAcceleration( hand.All, 142.1 );
+      \param axes - A vector of axis indices to access.
 
-        \endcode
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-        <hr>
-    */
-    void SetAxisTargetAcceleration( std::vector<int>const& axes, std::vector<double>const& accelerations )
-        throw (cSDHLibraryException*);
+      \return
+      - A vector of the target velocities of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angular_velocity unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
+      See also #GetAxisTargetVelocity(int) for an
+      overloaded variant to access a single axis.
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetAxisTargetAcceleration(std::vector<int>const&,std::vector<double>const&),
-        just for a single axis \a iAxis and a single acceleration \a acceleration, see there for details and examples.
-    */
-    void SetAxisTargetAcceleration( int iAxis, double acceleration )
-        throw (cSDHLibraryException*);
 
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-    //-----------------------------------------------------------------
-    /*!
-        Get the target acceleration(s) of axis(axes).
+        // Get target axis velocity of all axes
+        std::vector<double> v = hand.GetAxisTargetVelocity( hand.all_axes );
+        // now v is something like {0.0, 0.0, 42.0, 0.0, 47.11, 0,0, 0.0}
 
-        The currently set target accelerations are read from the %SDH.
+        // Get target axis velocity of axis 2
+        double v2 = hand.GetAxisTargetVelocity( 2 );
+        // v2 is now something like 42.0
 
-        \param axes - A vector of axis indices to access.
 
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
+        // Get target axis velocity of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
-        \return
-        - A vector of the target accelerations of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angular_acceleration unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
+        v = hand.GetAxisTargetVelocity( axes24 );
+        // now v is something like {42.0, 47.11}
 
-        See also #GetAxisTargetAcceleration(int) for an
-        overloaded variant to access a single axis.
+      \endcode
 
+      <hr>
+  */
+  std::vector<double> GetAxisTargetVelocity(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
 
-          // Get target axis acceleration of all axes
-          std::vector<double> v = hand.GetAxisTargetAcceleration( hand.all_axes );
-          // now v is something like {100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0}
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisTargetVelocity(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single velocity, see there for details
+      and examples.
+  */
+  double GetAxisTargetVelocity(int iAxis)
+  throw (cSDHLibraryException*);
 
-          // Get target axis acceleration of axis 2
-          double v2 = hand.GetAxisTargetAcceleration( 2 );
-          // v2 is now something like 100.0
 
+  //-----------------------------------------------------------------
+  /*!
+      Get the velocity limit(s) of axis(axes).
 
-          // Get target axis acceleration of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
+      The velocity limit(s) are read from the %SDH.
 
-          v = hand.GetAxisTargetAcceleration( axes24 );
-          // now v is something like {100.0, 100.0}
+      \param axes - A vector of axis indices to access.
 
-        \endcode
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-        <hr>
-    */
-    std::vector<double> GetAxisTargetAcceleration( std::vector<int>const& axes )
-        throw (cSDHLibraryException*);
+      \return
+      - A vector of the velocity limits of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angular_velocity unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
+      See also #GetAxisLimitVelocity(int) for an
+      overloaded variant to access a single axis.
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisTargetAcceleration(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single acceleration, see there for details
-        and examples.
-    */
-    double GetAxisTargetAcceleration( int iAxis )
-        throw (cSDHLibraryException*);
 
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-    //-----------------------------------------------------------------
-    /*!
-        Get the minimum angle(s) of axis(axes).
+        // Get axis velocity limits of all axes
+        std::vector<double> v = hand.GetAxisLimitVelocity( hand.all_axes );
+        // now v is something like {81.0, 140.0, 120.0, 140.0, 120.0, 140.0, 120.0}
 
-        The minimum angles are currently not read from the %SDH, but are stored
-        in the library.
+        // Get axis velocity limit of axis 2
+        double v2 = hand.GetAxisLimitVelocity( 2 );
+        // v2 is now something like 120.0
 
-        \param axes - A vector of axis indices to access.
 
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
+        // Get axis velocity limits of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
-        \return
-        - A vector of the min angles of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angle unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
+        v = hand.GetAxisLimitVelocity( axes24 );
+        // now v is something like {120.0,120.0}
 
-        See also #GetAxisMinAngle(int) for an
-        overloaded variant to access a single axis.
+      \endcode
 
+      <hr>
+  */
+  std::vector<double> GetAxisLimitVelocity(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
 
-          // Get minimum axis angles of all axes
-          std::vector<double> v = hand.GetAxisMinAngle( hand.all_axes );
-          // now v is something like {0.0, -90.0, -90.0, -90.0, -90.0, -90.0, -90.0}
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisLimitVelocity(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single velocity limit, see there for details
+      and examples.
+  */
+  double GetAxisLimitVelocity(int iAxis)
+  throw (cSDHLibraryException*);
 
-          // Get minimum axis angle of axis 3
-          double v3 = hand.GetAxisMinAngle( 3 );
-          // v3 is now something like -90.0
 
-          // Get minimum axis angle of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
+  //-----------------------------------------------------------------
+  /*!
+      Get the acceleration limit(s) of axis(axes).
 
-          v = hand.GetAxisMinAngle( axes24 );
-          // now v is something like {-90.0, -90.0}
+      The acceleration limit(s) are read from the %SDH.
 
+      \param axes - A vector of axis indices to access.
 
-          // Or if you change the angle unit system:
-          hand.UseRadians();
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-          v = hand.GetAxisMinAngle( hand.all_axes );
-          // now v is something like {0.0, -1.5707963267948966, -1.5707963267948966, -1.5707963267948966, -1.5707963267948966, -1.5707963267948966, -1.5707963267948966}
-        \endcode
+      \return
+      - A vector of the acceleration limits of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angular_acceleration unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-        <hr>
-    */
-    std::vector<double> GetAxisMinAngle( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
+      See also #GetAxisLimitAcceleration(int) for an
+      overloaded variant to access a single axis.
 
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisMinAngle(std::vector<int>const&), just for a single axis
-        \a iAxis and returning a single minimum angle, see there for details
-        and examples.
-    */
-    double GetAxisMinAngle( int iAxis )
-        throw (cSDHLibraryException*);
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
+        // Get axis acceleration limits of all axes
+        std::vector<double> v = hand.GetAxisLimitAcceleration( hand.all_axes );
+        // now v is something like {81.0, 140.0, 120.0, 140.0, 120.0, 140.0, 120.0}
 
-    //-----------------------------------------------------------------
-    /*!
-        Get the maximum angle(s) of axis(axes).
+        // Get axis acceleration limit of axis 2
+        double v2 = hand.GetAxisLimitAcceleration( 2 );
+        // v2 is now something like 120.0
 
-        The maximum angles are currently not read from the %SDH, but are stored
-        in the library.
 
-        \param axes - A vector of axis indices to access.
+        // Get axis acceleration limits of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
+        v = hand.GetAxisLimitAcceleration( axes24 );
+        // now v is something like {120.0,120.0}
 
-        \return
-        - A vector of the max angles of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angle unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
+      \endcode
 
-        See also #GetAxisMaxAngle(int) for an
-        overloaded variant to access a single axis.
+      <hr>
+  */
+  std::vector<double> GetAxisLimitAcceleration(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisLimitAcceleration(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single acceleration limit, see there for details
+      and examples.
+  */
+  double GetAxisLimitAcceleration(int iAxis)
+  throw (cSDHLibraryException*);
 
-          // Get maximum axis angles of all axes
-          std::vector<double> v = hand.GetAxisMaxAngle( hand.all_axes );
-          // now v is something like {90.0, 90.0, 90.0, 90.0, 90.0, 90.0, 90.0}
 
-          // Get maximum axis angle of axis 3
-          double v3 = hand.GetAxisMaxAngle( 3 );
-          // v3 is now something like 90.0
+  //-----------------------------------------------------------------
+  /*!
+      Get the actual velocity(s) of axis(axes).
 
-          // Get maximum axis angle of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
+      \param axes - A vector of axis indices to access.
 
-          v = hand.GetAxisMaxAngle( axes24 );
-          // now v is something like {90.0, 90.0}
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
+      \return
+      - A vector of the actual velocities of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angular_velocity unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-          // Or if you change the angle unit system:
-          hand.UseRadians();
+      See also #GetAxisActualVelocity(int) for an
+      overloaded variant to access a single axis.
 
-          v = hand.GetAxisMaxAngle( hand.all_axes );
-          // now v is something like { 1.5707963267948966, 1.5707963267948966, 1.5707963267948966, 1.5707963267948966, 1.5707963267948966, 1.5707963267948966, 1.5707963267948966}
-        \endcode
 
-        <hr>
-    */
-    std::vector<double> GetAxisMaxAngle( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
+        // Get actual axis velocity of all axes
+        std::vector<double> v = hand.GetAxisActualVelocity( hand.all_axes );
+        // now v is something like {0.1, 0.2, 0.3, 13.2, 0.5, 0.0, 0.7}
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisMaxAngle(std::vector<int>const&), just for a single axis
-        \a iAxis and returning a single maximum angle, see there for details
-        and examples.
-    */
-    double GetAxisMaxAngle( int iAxis )
-        throw (cSDHLibraryException*);
+        // Get actual axis velocity of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
+        v = hand.GetAxisActualVelocity( axes24 );
+        // now v is something like {13.2, 0.0}
 
+        // Get actual axis velocity of axis 2
+        double v3 = hand.GetAxisActualVelocity( 2 );
+        // v3 is now something like 13.2
 
-    //-----------------------------------------------------------------
-    /*!
-       Get the maximum velocity(s) of axis(axes). These are the
-       (theoretical) maximum velocities as determined by the maximum motor
-       velocity and gear box ratio. The values do not take things like
-       friction or inertia into account. So it is likely that these
-       maximum velocities cannot be reached by the real hardware in reality.
+      \endcode
 
-       The maximum velocities are currently read once from the %SDH when
-       the communication to the %SDH is opened. Later queries of this
-       maximum velocities will use the values stored in the library.
+      <hr>
+  */
+  std::vector<double> GetAxisActualVelocity(std::vector<int>const& axes)
+  throw (cSDHLibraryException*);
 
-        \param axes - A vector of axis indices to access.
 
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisActualVelocity(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single velocity, see there for details
+      and examples.
+  */
+  double GetAxisActualVelocity(int iAxis)
+  throw (cSDHLibraryException*);
 
-        \return
-        - A vector of the max angular velocities of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angular_velocity unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
 
-        See also #GetAxisMaxVelocity(int) for an
-        overloaded variant to access a single axis.
+  //-----------------------------------------------------------------
+  /*!
+      Get the current reference velocity(s) of axis(axes). (This velocity is used internally by the %SDH in eCT_VELOCITY_ACCELERATION mode).
 
+      \param axes - A vector of axis indices to access.
+
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \return
+      - A vector of the reference velocities of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angular_velocity unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
+      See also #GetAxisReferenceVelocity(int) for an
+      overloaded variant to access a single axis.
 
-          // Get maximum axis angular velocities of all axes
-          std::vector<double> v = hand.GetAxisMaxVelocity( hand.all_axes );
-          // now v is something like {83.857,200.000,157.895,200.000,157.895,200.000,157.895}
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Switch to "velocity control with acceleration ramp" controller mode first.
+        // (When in another controller mode like the default eCT_POSE,
+        //  then the reference velocities will not be valid):
+        hand.SetController( eCT_VELOCITY_ACCELERATION );
 
-          // Get maximum axis angular velocity of axis 3
-          double v3 = hand.GetAxisMaxVelocity( 3 );
-          // v3 is now something like 200.0
+        // Get reference axis velocity of all axes
+        std::vector<double> v = hand.GetAxisReferenceVelocity( hand.all_axes );
+        // now v is something like {0.1, 0.2, 0.3, 13.2, 0.5, 0.0, 0.7}
 
-          // Get maximum axis angular velocity of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
+        // Get reference axis velocity of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
+        v = hand.GetAxisReferenceVelocity( axes24 );
+        // now v is something like {13.2, 0.0}
+
+        // Get reference axis velocity of axis 2
+        double v3 = hand.GetAxisReferenceVelocity( 2 );
+        // v3 is now something like 13.2
+
+      \endcode
 
-          v = hand.GetAxisMaxVelocity( axes24 );
-          // now v is something like {157.895, 157.895}
+      \remark
+        - the underlying rvel command of the %SDH firmware is not
+          available in firmwares prior to 0.0.2.6. For such hands
+          calling rvel will fail miserably.
+        - The availability of an appropriate %SDH firmware is \b not checked
+          here due to performance losses when this function is used often.
 
+      <hr>
+  */
+  std::vector<double> GetAxisReferenceVelocity(std::vector<int>const& axes)
+  throw (cSDHLibraryException*);
 
-          // Or if you change the angular velocity unit system:
-          hand.UseRadians();
 
-          v = hand.GetAxisMaxVelocity( hand.all_axes );
-          // now v is something like {1.46358075084, 3.49065850399, 2.75578762244, 3.49065850399, 2.75578762244, 3.49065850399, 2.75578762244}
-        \endcode
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisReferenceVelocity(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single velocity, see there for details
+      and examples.
+  */
+  double GetAxisReferenceVelocity(int iAxis)
+  throw (cSDHLibraryException*);
 
-        <hr>
-    */
-    std::vector<double> GetAxisMaxVelocity( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
 
+  //-----------------------------------------------------------------
+  /*!
+      Set the target acceleration(s) for axis(axes).
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisMaxVelocity(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single minimum angle, see there for
-        details and examples.
-    */
-    double GetAxisMaxVelocity( int iAxis )
-        throw (cSDHLibraryException*);
+      The target accelerations are stored in the %SDH and are used only for:
+      - the eCT_POSE controller type with eVP_RAMP velocity profile
+      - the eCT_VELOCITY_ACCELERATION controller type
 
+      Setting the target acceleration will not affect an ongoing movement,
+      nor will it start a new movement. To take effect an additional command
+      must be sent:
+      - in eCT_POSE controller type a move command: MoveAxis() MoveFinger() MoveHand()
+      - in eCT_VELOCITY_ACCELERATION controller type the velocity must be set: SetAxisTargetVelocity()
 
-    //-----------------------------------------------------------------
-    /*!
-       Get the maximum acceleration(s) of axis(axes).
+      \param axes          - A vector of axis indices to access.
+      \param accelerations - A vector of axis target accelerations to set. If any
+                             of the numbers in the vector is \c NaN
+                             (Not a Number) then the currently set
+                             axis target angle will be kept for the
+                             corresponding axis. The value(s) are
+                             expected in the configured angular
+                             acceleration unit system
+                             #uc_angular_acceleration.
 
-       The maximum accelerations are currently not read from the %SDH, but are
-       stored in the library.
+      \remark
+      - The lengths of the \a axes and \a accelerations vector must match.
+      - The indices can be given in any order, but the order of
+        their elements must match, i.e. \c accelerations[i] will be applied
+        to axis \c axes[i] (not axis \c i).
+      - The indices are checked if they are valid axis indices.
+      - The accelerations are checked if they are in the allowed range
+        [0 .. #f_max_velocity_v], i.e. it is checked that \c accelerations[i],
+        converted to internal units, is in \c [0 .. \c f_max_velocity_v[axes[i]]].
+      - If \b any index or value is invalid then \b none of the specified
+        values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-        \param axes - A vector of axis indices to access.
+      See also #SetAxisTargetAcceleration(int,double) for an
+      overloaded variant to set a single axis target acceleration or
+      to set the same target acceleration for all axes.
 
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
 
-        \return
-        - A vector of the max angular accelerations of the selected axes.
-        - The values are converted to the selected external unit
-          system using the configured #uc_angular_acceleration unit converter object.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-        See also #GetAxisMaxAcceleration(int) for an
-        overloaded variant to access a single axis.
+        // Set target axis acceleration of all axes to the given values:
+        std::vector<double> all_accelerations;
+        all_accelerations.push_back( 100.0 );
+        all_accelerations.push_back( 101.0 );
+        all_accelerations.push_back( 102.0 );
+        all_accelerations.push_back( 103.0 );
+        all_accelerations.push_back( 104.0 );
+        all_accelerations.push_back( 105.0 );
+        all_accelerations.push_back( 106.0 );
 
+        hand.SetAxisTargetAcceleration( hand.all_axes, all_accelerations );
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
 
-          // Get maximum axis angular accelerations of all axes
-          std::vector<double> v = hand.GetAxisMaxAcceleration( hand.all_axes );
-          // now v is something like {1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0}
+        // Set target axis acceleration of axis 3 to 420 degrees per square-second:
+        hand.SetAxisTargetAcceleration( 3, 420.0 );
 
-          // Get maximum axis angular acceleration of axis 3
-          double v3 = hand.GetAxisMaxAcceleration( 3 );
-          // v3 is now something like 1000.0
+        // Set target acceleration of for axis 0,4 and 2 to 0.0, 444.0 and 222 degrees per square-second respectively:
+        std::vector<int> axes042;
+        axes042.push_back( 0 );
+        axes042.push_back( 4 );
+        axes042.push_back( 2 );
+        std::vector<double> accelerations042;
+        accelerations042.push_back( 100.0 );
+        accelerations042.push_back( 104.0 );
+        accelerations042.push_back( 102.0 );
 
-          // Get maximum axis angular acceleration of axis 2 and 4
-          std::vector<int> axes24;
-          axes24.push_back( 2 );
-          axes24.push_back( 4 );
+        hand.SetAxisTargetAcceleration( axes042, accelerations042 );
 
-          v = hand.GetAxisMaxAcceleration( axes24 );
-          // now v is something like {1000.0, 1000.0}
 
+        // Set target axis acceleration of all axes to 142.1 degrees per square-second
+        hand.SetAxisTargetAcceleration( hand.All, 142.1 );
 
-          // Or if you change the angular acceleration unit system:
-          hand.UseRadians();
+      \endcode
 
-          v = hand.GetAxisMaxAcceleration( hand.all_axes );
-          // now v is something like {17.453292519943293, 17.453292519943293, 17.453292519943293, 17.453292519943293, 17.453292519943293, 17.453292519943293, 17.453292519943293}
-        \endcode
+      <hr>
+  */
+  void SetAxisTargetAcceleration(std::vector<int>const& axes, std::vector<double>const& accelerations)
+  throw (cSDHLibraryException*);
 
-        <hr>
-    */
-    std::vector<double> GetAxisMaxAcceleration( std::vector<int> const& axes )
-        throw (cSDHLibraryException*);
 
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetAxisTargetAcceleration(std::vector<int>const&,std::vector<double>const&),
+      just for a single axis \a iAxis and a single acceleration \a acceleration, see there for details and examples.
+  */
+  void SetAxisTargetAcceleration(int iAxis, double acceleration)
+  throw (cSDHLibraryException*);
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetAxisMaxAcceleration(std::vector<int>const&), just for a single
-        axis \a iAxis and returning a single minimum angle, see there for
-        details and examples.
-    */
-    double GetAxisMaxAcceleration( int iAxis )
-        throw (cSDHLibraryException*);
 
+  //-----------------------------------------------------------------
+  /*!
+      Get the target acceleration(s) of axis(axes).
 
-    //-----------------------------------------------------------------
-    /*!
-        Move selected axis/axes to the previously set target pose with
-        the previously set velocity profile, (maximum) target
-        velocities and target accelerations
+      The currently set target accelerations are read from the %SDH.
 
-        \param axes    - A vector of axis indices to access.
-        \param sequ    - flag: if true (default) then the function executes sequentially
-                         and returns not until after the %SDH has
-                         finished the movement. If false then the
-                         function returns immediately after the
-                         movement command has been sent to the %SDH
-                         (the currently set target axis angles for other axes will
-                         then be \b overwritten with their current actual
-                         axis angles).
+      \param axes - A vector of axis indices to access.
 
-        - The indices in \a axes are checked if they are valid axis indices.
-        - If any index is invalid then no movement is performed, instead a
-          #SDH::cSDHErrorInvalidParameter* exception is thrown.
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-        \return
-        The expected/elapsed execution time for the movement in the configured time unit system #uc_time
+      \return
+      - A vector of the target accelerations of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angular_acceleration unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-        \remark
-          - The axes will be enabled automatically.
-          - Currently the actual movement velocity of an axis is
-            determined by the %SDH firmware to make the movements of all
-            involved axes start and end synchronously at the same time. Therefore
-            the axis that needs the longest time for its movement at its
-            given maximum velocity determines the velocities of all the
-            other axes.
-          - Other axes than those selected by \a axes will \b NOT move, even if
-            target axis angles for the axes have been set.
-            (Remember: as axis 0 is used by finger 0 and 2 these
-            two fingers cannot be moved completely idependent of each other.)
-          - If \a sequ is true then the currently set target axis angles for other
-            fingers will be restored upon return of the function.
-          - If \a sequ is false then the currently set target axis angles for other
-            fingers will be \b overwritten with their current actual axis angles
+      See also #GetAxisTargetAcceleration(int) for an
+      overloaded variant to access a single axis.
 
-        See also #MoveAxis(int,bool) for an overloaded variant to move a
-        single axis.
 
-        \par Examples:
-        \code
-          // Assuming 'hand' is a cSDH object ...
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-          // create an index vector for adressing axes 0, 4 and 2 (in that order)
-          std::vector<int> axes042;
-          axes042.push_back( 0 );
-          axes042.push_back( 4 );
-          axes042.push_back( 2 );
+        // Get target axis acceleration of all axes
+        std::vector<double> v = hand.GetAxisTargetAcceleration( hand.all_axes );
+        // now v is something like {100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0}
 
-          // Set a new target pose for axes 0, 4 and 2:
-          std::vector<double> angles042;
-          angles042.push_back( 0.0 );
-          angles042.push_back( -44.4 );
-          angles042.push_back( -22.2 );
+        // Get target axis acceleration of axis 2
+        double v2 = hand.GetAxisTargetAcceleration( 2 );
+        // v2 is now something like 100.0
 
-          hand.SetFingerTargetAngle( axes042, angles042 );
 
+        // Get target axis acceleration of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
-          // First move Axis 0 only to its new target position:
-          hand.MoveAxis( 0 );
+        v = hand.GetAxisTargetAcceleration( axes24 );
+        // now v is something like {100.0, 100.0}
 
-          // The axis 0 has now reached its target position 0.0 degrees.  The
-          // target poses for axes 4 and 2 are still set since the
-          // last MoveAxes() call was sequentially (und thus it could
-          // restore the previously set target axis angles of not
-          // selected axes after the movement finished)
+      \endcode
 
+      <hr>
+  */
+  std::vector<double> GetAxisTargetAcceleration(std::vector<int>const& axes)
+  throw (cSDHLibraryException*);
 
-          // So move axes 4 and 2 now, this time non-sequentially:
-          std::vector<int> axes42;
-          axes42.push_back( 4 );
-          axes42.push_back( 2 );
 
-          double t = hand.MoveAxes( axis42, false );
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisTargetAcceleration(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single acceleration, see there for details
+      and examples.
+  */
+  double GetAxisTargetAcceleration(int iAxis)
+  throw (cSDHLibraryException*);
 
-          // The two axes 4 and 2 are now moving to their target position.
-          // We have to wait until the non-sequential call has finished:
-          SleepSec( t );
 
-          // The axes 4 and 2 have now moved to -44.4 and -22.2.
+  //-----------------------------------------------------------------
+  /*!
+      Get the minimum angle(s) of axis(axes).
 
-          // The target angles for other axes have by now been
-          // overwritten since the last MoveAxis() call was
-          // non-sequentially (und thus it could \b NOT restore the
-          // previously set target axis angles of not selected axes
-          // after the movement finished)
+      The minimum angles are currently not read from the %SDH, but are stored
+      in the library.
 
+      \param axes - A vector of axis indices to access.
 
-          // Set new target angles for all axes ("home pose");
-          hand.SetAxisTargetAngle( hand.All, 0.0 );
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-          // Now move all axes back to home pose:
-          hand.MoveAxes( hand.All );
+      \return
+      - A vector of the min angles of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angle unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-        \endcode
+      See also #GetAxisMinAngle(int) for an
+      overloaded variant to access a single axis.
 
-        \bug
-        With %SDH firmware < 0.0.2.7 calling MoveAxis() while some axes are moving
-        in eCT_POSE controller type will make the joints jerk.
-        This is resolved in %SDH firmware 0.0.2.7 for the eCT_POSE controller type with
-        velocity profile eVP_RAMP. For the eCT_POSE controller type with velocity profile
-        eVP_SIN_SQUARE changing target points/ velocities while moving will still make
-        the axes jerk.
-        <br><b>=> Partly resolved in %SDH firmware 0.0.2.7</b>
 
-        <hr>
-    */
-    double MoveAxis( std::vector<int>const& axes, bool sequ=true )
-        throw (cSDHLibraryException*);
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
+        // Get minimum axis angles of all axes
+        std::vector<double> v = hand.GetAxisMinAngle( hand.all_axes );
+        // now v is something like {0.0, -90.0, -90.0, -90.0, -90.0, -90.0, -90.0}
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #MoveAxis(std::vector<int>const&,bool), just for a single axis
-        \a iAxis (or all axes if #All is given).
-    */
-    double MoveAxis( int iAxis, bool sequ=true )
-        throw (cSDHLibraryException*);
+        // Get minimum axis angle of axis 3
+        double v3 = hand.GetAxisMinAngle( 3 );
+        // v3 is now something like -90.0
 
+        // Get minimum axis angle of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
-    // unimplemented from SAH:
-    // def GetJointAngle( int iFinger,double* pafAngle);
-    // def GetJointSpeed( int iFinger,double* pafSpeed);
-    // def GetJointTorque( int iFinger,double* pafTorque);
+        v = hand.GetAxisMinAngle( axes24 );
+        // now v is something like {-90.0, -90.0}
 
 
-    //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_axis
-    //! @}
-    //#####################################################################
+        // Or if you change the angle unit system:
+        hand.UseRadians();
 
-    //######################################################################
-    /*!
-      \anchor sdhlibrary_cpp_sdh_h_csdh_finger
-       \name   Methods to access %SDH on finger-level
+        v = hand.GetAxisMinAngle( hand.all_axes );
+        // now v is something like {0.0, -1.5707963267948966, -1.5707963267948966, -1.5707963267948966, -1.5707963267948966, -1.5707963267948966, -1.5707963267948966}
+      \endcode
 
-       @{
-    */
+      <hr>
+  */
+  std::vector<double> GetAxisMinAngle(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Set enabled/disabled state of axis controllers of finger(s).
 
-        The controllers of the axes of the selected fingers are
-        enabled/disabled in the %SDH. Disabled axes are not powered and thus
-        might not remain in their current pose due to gravity, inertia or
-        other external influences. But to prevent overheating the axis
-        controllers should be switched of when not needed.
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisMinAngle(std::vector<int>const&), just for a single axis
+      \a iAxis and returning a single minimum angle, see there for details
+      and examples.
+  */
+  double GetAxisMinAngle(int iAxis)
+  throw (cSDHLibraryException*);
 
-        \param fingers - A vector of finger indices to access.
-        \param states  - A vector of enabled states (0 = disabled, !=0 = enabled) to set.
-                         If any of the numbers in the vector is \c NaN (Not a
-                         Number) then the currently set enabled state will be
-                         kept for the corresponding axis.
 
-        \remark
-        - The lengths of the \a fingers and \a states vector must match.
-        - The indices can be given in any order, but the order of
-          their elements must match, i.e. \c state[i] will be applied
-          to finger \c fingers[i] (not finger \c i).
-        - The indices are checked if they are valid finger indices.
-        - If \b any index is invalid then \b none of the specified
-          values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-        - As axis 0 is used for finger 0 and 2, axis 0 is disabled only
-          if both finger 0 and 1 are disabled.
+  //-----------------------------------------------------------------
+  /*!
+      Get the maximum angle(s) of axis(axes).
 
-        See also #SetFingerEnable(int,double), #SetFingerEnable(int,bool)
-        for overloaded variants to set a single finger enabled/disabled
-        or to set the same state for all fingers.  See further
-        #SetFingerEnable(std::vector<int>const&,std::vector<bool>const&) for a
-        variant that accepts a \c bool vector for the states to set.
+      The maximum angles are currently not read from the %SDH, but are stored
+      in the library.
 
+      \param axes - A vector of axis indices to access.
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-          // Enable finger 1 and 2 while disabling finger 0 :
-          std::vector<double> states012;
-          states012.push_back( 0.0 );
-          states012.push_back( 1.0 );
-          states012.push_back( 1.0 );
+      \return
+      - A vector of the max angles of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angle unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-          hand.SetFingerEnable( hand.all_axes, states012 );
-          // (this will keep axis 0 (used by the disabled finger 0) enabled,
-          // since axis 0 is needed by the enabled finger 2 too);
+      See also #GetAxisMaxAngle(int) for an
+      overloaded variant to access a single axis.
 
-          // Enable all fingers:
-          hand.SetFingerEnable( hand.All,true );
 
-          // Disable all fingers:
-          hand.SetFingerEnable( hand.All, 0.0 );
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-          // Disable finger 2:
-          hand.SetFingerEnable( 2, false );
+        // Get maximum axis angles of all axes
+        std::vector<double> v = hand.GetAxisMaxAngle( hand.all_axes );
+        // now v is something like {90.0, 90.0, 90.0, 90.0, 90.0, 90.0, 90.0}
 
-        \endcode
+        // Get maximum axis angle of axis 3
+        double v3 = hand.GetAxisMaxAngle( 3 );
+        // v3 is now something like 90.0
 
-        <hr>
-    */
-    void SetFingerEnable( std::vector<int> const& fingers, std::vector<double> const& states )
-        throw (cSDHLibraryException*);
+        // Get maximum axis angle of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
+        v = hand.GetAxisMaxAngle( axes24 );
+        // now v is something like {90.0, 90.0}
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetFingerEnable(std::vector<int>const&,std::vector<double>const&),
-        just for a single finger \a iAxis and a single angle \a angle, see
-        there for details and examples.
-    */
-    void SetFingerEnable( int iFinger, double state=1.0 )
-        throw (cSDHLibraryException*);
 
+        // Or if you change the angle unit system:
+        hand.UseRadians();
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetFingerEnable(std::vector<int>const&,std::vector<double>const&),
-        just with states as vector of \c bool values, see there for details and
-        examples.
-    */
-    void SetFingerEnable( std::vector<int> const& fingers, std::vector<bool> const& states )
-        throw (cSDHLibraryException*);
+        v = hand.GetAxisMaxAngle( hand.all_axes );
+        // now v is something like { 1.5707963267948966, 1.5707963267948966, 1.5707963267948966, 1.5707963267948966, 1.5707963267948966, 1.5707963267948966, 1.5707963267948966}
+      \endcode
 
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #SetFingerEnable(std::vector<int>const&,std::vector<double>const&),
-        just for a single finger \a iAxis and a single angle \a angle, see
-        there for details and examples.
-    */
-    void SetFingerEnable( int iFinger, bool state )
-        throw (cSDHLibraryException*);
+      <hr>
+  */
+  std::vector<double> GetAxisMaxAngle(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
 
-    //-----------------------------------------------------------------
-    /*!
-        Get enabled/disabled state of axis controllers of finger(s).
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisMaxAngle(std::vector<int>const&), just for a single axis
+      \a iAxis and returning a single maximum angle, see there for details
+      and examples.
+  */
+  double GetAxisMaxAngle(int iAxis)
+  throw (cSDHLibraryException*);
 
-        The enabled/disabled state of the controllers of the selected
-        fingers is read from the %SDH. A finger is reported disabled if
-        any of its axes is disabled and reported enabled if all its
-        axes are enabled.
 
-        \param fingers - A vector of finger indices to access.
+  //-----------------------------------------------------------------
+  /*!
+     Get the maximum velocity(s) of axis(axes). These are the
+     (theoretical) maximum velocities as determined by the maximum motor
+     velocity and gear box ratio. The values do not take things like
+     friction or inertia into account. So it is likely that these
+     maximum velocities cannot be reached by the real hardware in reality.
 
-        - The indices in \a fingers are checked if they are valid finger indices.
-        - If \b any finger index is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
+     The maximum velocities are currently read once from the %SDH when
+     the communication to the %SDH is opened. Later queries of this
+     maximum velocities will use the values stored in the library.
 
-        \return
-        - A vector of enabled/disabled states as doubles (0=disabled,
-          1.0=enabled) of the selected axes.
-        - The order of the elements of the \a axes vector and the returned values
-          vector \a rv matches. I.e. \c rv[i] will be the value of axis
-          \c axes[i] (not axis \c i).
+      \param axes - A vector of axis indices to access.
 
-        See also #GetAxisEnable(int) for an overloaded variant to
-        access a single axis.
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
+      \return
+      - A vector of the max angular velocities of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angular_velocity unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
+      See also #GetAxisMaxVelocity(int) for an
+      overloaded variant to access a single axis.
 
-          // Get enabled state of all fingers:
-          std::vector<double> v = hand.GetFingerEnable( hand.all_fingers );
-          // now v is something like {0.0, 1.0, 0.0}
 
-          // Get enabled state of finger 0 and 2
-          std::vector<int> fingers02;
-          fingers02.push_back( 0 );
-          fingers02.push_back( 2 );
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-          v = hand.GetFingerEnable( fingers02 );
-          // now v is something like {0.0, 0.0}
+        // Get maximum axis angular velocities of all axes
+        std::vector<double> v = hand.GetAxisMaxVelocity( hand.all_axes );
+        // now v is something like {83.857,200.000,157.895,200.000,157.895,200.000,157.895}
 
-          // Get enabled state of finger 1
-          double v1 = hand.GetFingerEnable( 1 );
-          // now v1 is something like 1.0
+        // Get maximum axis angular velocity of axis 3
+        double v3 = hand.GetAxisMaxVelocity( 3 );
+        // v3 is now something like 200.0
 
-        \endcode
+        // Get maximum axis angular velocity of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
-        <hr>
-    */
-    std::vector<double> GetFingerEnable( std::vector<int> const& fingers )
-        throw (cSDHLibraryException*);
+        v = hand.GetAxisMaxVelocity( axes24 );
+        // now v is something like {157.895, 157.895}
 
 
-    //----------------------------------------------------------------------
-    /*!
-        Like #GetFingerEnable(std::vector<int>const&),
-        just for a single finger \a iFinger and returning a single
-        double value
-    */
-    double GetFingerEnable( int iFinger )
-        throw (cSDHLibraryException*);
+        // Or if you change the angular velocity unit system:
+        hand.UseRadians();
 
+        v = hand.GetAxisMaxVelocity( hand.all_axes );
+        // now v is something like {1.46358075084, 3.49065850399, 2.75578762244, 3.49065850399, 2.75578762244, 3.49065850399, 2.75578762244}
+      \endcode
 
-    //-----------------------------------------------------------------
-    /*!
-        Set the target angle(s) for a single finger.
+      <hr>
+  */
+  std::vector<double> GetAxisMaxVelocity(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
-        The target axis angles \a angle of finger \a iFinger are stored
-        in the %SDH. The movement is not executed until an additional
-        move command is sent.
 
-        \param iFinger - index of finger to access.
-                         This must be a single index.
-        \param angles  - the angle(s) to set or \c None to set the current actual axis angles of the finger as target angle.
-                         This can be a single number or a \ref sdhlibrary_cpp_sdh_h_csdh_vector "vector" of numbers.
-                         The value(s) are expected in the configured angle unit system #uc_angle.
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisMaxVelocity(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single minimum angle, see there for
+      details and examples.
+  */
+  double GetAxisMaxVelocity(int iAxis)
+  throw (cSDHLibraryException*);
 
-        \remark
-        - Setting the target angles will \b not make the finger move.
-        - The \a iFinger index is checked if it is a valid finger index.
-        - The angles are checked if they are in the allowed range
-          [0 .. #f_max_angle_v], i.e. it is checked that \c angles[i],
-          converted to internal units, is in \c [0 .. \c f_max_angle_v[finger_axis_index[iFinger][i]]].
-        - If \b any index or value is invalid then \b none of the specified
-          values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
 
-        See also #SetFingerTargetAngle(int,double,double,double) for an
-        overloaded variant to set finger axis target angles from single \c
-        double values.
+  //-----------------------------------------------------------------
+  /*!
+     Get the maximum acceleration(s) of axis(axes).
 
+     The maximum accelerations are currently not read from the %SDH, but are
+     stored in the library.
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
+      \param axes - A vector of axis indices to access.
 
-          // Set target axis angles of finger 0 to { 10.0, -08.15, 47.11 } degrees
-          std::vector<double> angles;
-          angles.push_back( 10.0 );
-          angles.push_back( -08.15 );
-          angles.push_back(  47.11 );
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If \b any axis index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
 
-          hand.SetFingerTargetAngle( 0, angles );
+      \return
+      - A vector of the max angular accelerations of the selected axes.
+      - The values are converted to the selected external unit
+        system using the configured #uc_angular_acceleration unit converter object.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
 
+      See also #GetAxisMaxAcceleration(int) for an
+      overloaded variant to access a single axis.
 
-          // Set target axis angles of finger 1 to { 0.0, 24.7, 17.4 } degrees
-          angles[0] = 0.0;   // "virtual" base axis of finger 1
-          angles[1] = 24.7;
-          angles[2] = 17.4;
-          hand.SetFingerTargetAngle( 1, { 0.0, 24.7, 17.4 } );
 
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-          // Set target axis angles of all axes of finger 0 to 12.34 degrees
-          hand.SetFingerTargetAngle( 0, 12.34, 12.34, 12.34 );
+        // Get maximum axis angular accelerations of all axes
+        std::vector<double> v = hand.GetAxisMaxAcceleration( hand.all_axes );
+        // now v is something like {1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0}
 
+        // Get maximum axis angular acceleration of axis 3
+        double v3 = hand.GetAxisMaxAcceleration( 3 );
+        // v3 is now something like 1000.0
 
-          // REMARK: the last command changed the previously set target axis
-          // angle for axis 0, since axis 0 is used as base axis for both
-          // finger 0 and 2!
-        \endcode
+        // Get maximum axis angular acceleration of axis 2 and 4
+        std::vector<int> axes24;
+        axes24.push_back( 2 );
+        axes24.push_back( 4 );
 
-        <hr>
-    */
-    void SetFingerTargetAngle( int iFinger, std::vector<double> const& angles )
-        throw (cSDHLibraryException*);
+        v = hand.GetAxisMaxAcceleration( axes24 );
+        // now v is something like {1000.0, 1000.0}
 
 
-    //-----------------------------------------------------------------
-    /*!
-        Like #SetFingerTargetAngle(int,std::vector<double>const&), just with
-        individual finger axis angles \a a0, \a a1 and \a a2.
-    */
-    void SetFingerTargetAngle( int iFinger, double a0, double a1, double a2 )
-        throw (cSDHLibraryException*);
+        // Or if you change the angular acceleration unit system:
+        hand.UseRadians();
 
+        v = hand.GetAxisMaxAcceleration( hand.all_axes );
+        // now v is something like {17.453292519943293, 17.453292519943293, 17.453292519943293, 17.453292519943293, 17.453292519943293, 17.453292519943293, 17.453292519943293}
+      \endcode
 
-    //-----------------------------------------------------------------
-    /*!
-        Get the target axis angles of a single finger.
+      <hr>
+  */
+  std::vector<double> GetAxisMaxAcceleration(std::vector<int> const& axes)
+  throw (cSDHLibraryException*);
 
-        The target axis angles of finger \a iFinger are read from the %SDH.
 
-        \param iFinger - index of finger to access.
-                         This must be a single index
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetAxisMaxAcceleration(std::vector<int>const&), just for a single
+      axis \a iAxis and returning a single minimum angle, see there for
+      details and examples.
+  */
+  double GetAxisMaxAcceleration(int iAxis)
+  throw (cSDHLibraryException*);
 
-        \remark
-        - The \a iFinger index is checked if it is a valid finger index.
-        - If \a iFinger is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
 
-        \return
-        - A list of the selected fingers target axis angles
+  //-----------------------------------------------------------------
+  /*!
+      Move selected axis/axes to the previously set target pose with
+      the previously set velocity profile, (maximum) target
+      velocities and target accelerations
+
+      \param axes    - A vector of axis indices to access.
+      \param sequ    - flag: if true (default) then the function executes sequentially
+                       and returns not until after the %SDH has
+                       finished the movement. If false then the
+                       function returns immediately after the
+                       movement command has been sent to the %SDH
+                       (the currently set target axis angles for other axes will
+                       then be \b overwritten with their current actual
+                       axis angles).
+
+      - The indices in \a axes are checked if they are valid axis indices.
+      - If any index is invalid then no movement is performed, instead a
+        #SDH::cSDHErrorInvalidParameter* exception is thrown.
+
+      \return
+      The expected/elapsed execution time for the movement in the configured time unit system #uc_time
+
+      \remark
+        - The axes will be enabled automatically.
+        - Currently the actual movement velocity of an axis is
+          determined by the %SDH firmware to make the movements of all
+          involved axes start and end synchronously at the same time. Therefore
+          the axis that needs the longest time for its movement at its
+          given maximum velocity determines the velocities of all the
+          other axes.
+        - Other axes than those selected by \a axes will \b NOT move, even if
+          target axis angles for the axes have been set.
+          (Remember: as axis 0 is used by finger 0 and 2 these
+          two fingers cannot be moved completely idependent of each other.)
+        - If \a sequ is true then the currently set target axis angles for other
+          fingers will be restored upon return of the function.
+        - If \a sequ is false then the currently set target axis angles for other
+          fingers will be \b overwritten with their current actual axis angles
+
+      See also #MoveAxis(int,bool) for an overloaded variant to move a
+      single axis.
+
+      \par Examples:
+      \code
+        // Assuming 'hand' is a cSDH object ...
+
+        // create an index vector for adressing axes 0, 4 and 2 (in that order)
+        std::vector<int> axes042;
+        axes042.push_back( 0 );
+        axes042.push_back( 4 );
+        axes042.push_back( 2 );
+
+        // Set a new target pose for axes 0, 4 and 2:
+        std::vector<double> angles042;
+        angles042.push_back( 0.0 );
+        angles042.push_back( -44.4 );
+        angles042.push_back( -22.2 );
+
+        hand.SetFingerTargetAngle( axes042, angles042 );
+
+
+        // First move Axis 0 only to its new target position:
+        hand.MoveAxis( 0 );
+
+        // The axis 0 has now reached its target position 0.0 degrees.  The
+        // target poses for axes 4 and 2 are still set since the
+        // last MoveAxes() call was sequentially (und thus it could
+        // restore the previously set target axis angles of not
+        // selected axes after the movement finished)
+
+
+        // So move axes 4 and 2 now, this time non-sequentially:
+        std::vector<int> axes42;
+        axes42.push_back( 4 );
+        axes42.push_back( 2 );
+
+        double t = hand.MoveAxes( axis42, false );
+
+        // The two axes 4 and 2 are now moving to their target position.
+        // We have to wait until the non-sequential call has finished:
+        SleepSec( t );
+
+        // The axes 4 and 2 have now moved to -44.4 and -22.2.
+
+        // The target angles for other axes have by now been
+        // overwritten since the last MoveAxis() call was
+        // non-sequentially (und thus it could \b NOT restore the
+        // previously set target axis angles of not selected axes
+        // after the movement finished)
+
+
+        // Set new target angles for all axes ("home pose");
+        hand.SetAxisTargetAngle( hand.All, 0.0 );
+
+        // Now move all axes back to home pose:
+        hand.MoveAxes( hand.All );
+
+      \endcode
+
+      \bug
+      With %SDH firmware < 0.0.2.7 calling MoveAxis() while some axes are moving
+      in eCT_POSE controller type will make the joints jerk.
+      This is resolved in %SDH firmware 0.0.2.7 for the eCT_POSE controller type with
+      velocity profile eVP_RAMP. For the eCT_POSE controller type with velocity profile
+      eVP_SIN_SQUARE changing target points/ velocities while moving will still make
+      the axes jerk.
+      <br><b>=> Partly resolved in %SDH firmware 0.0.2.7</b>
+
+      <hr>
+  */
+  double MoveAxis(std::vector<int>const& axes, bool sequ = true)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #MoveAxis(std::vector<int>const&,bool), just for a single axis
+      \a iAxis (or all axes if #All is given).
+  */
+  double MoveAxis(int iAxis, bool sequ = true)
+  throw (cSDHLibraryException*);
+
+
+  // unimplemented from SAH:
+  // def GetJointAngle( int iFinger,double* pafAngle);
+  // def GetJointSpeed( int iFinger,double* pafSpeed);
+  // def GetJointTorque( int iFinger,double* pafTorque);
+
+
+  //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_axis
+  //! @}
+  //#####################################################################
+
+  //######################################################################
+  /*!
+    \anchor sdhlibrary_cpp_sdh_h_csdh_finger
+     \name   Methods to access %SDH on finger-level
+
+     @{
+  */
+
+  //-----------------------------------------------------------------
+  /*!
+      Set enabled/disabled state of axis controllers of finger(s).
+
+      The controllers of the axes of the selected fingers are
+      enabled/disabled in the %SDH. Disabled axes are not powered and thus
+      might not remain in their current pose due to gravity, inertia or
+      other external influences. But to prevent overheating the axis
+      controllers should be switched of when not needed.
+
+      \param fingers - A vector of finger indices to access.
+      \param states  - A vector of enabled states (0 = disabled, !=0 = enabled) to set.
+                       If any of the numbers in the vector is \c NaN (Not a
+                       Number) then the currently set enabled state will be
+                       kept for the corresponding axis.
+
+      \remark
+      - The lengths of the \a fingers and \a states vector must match.
+      - The indices can be given in any order, but the order of
+        their elements must match, i.e. \c state[i] will be applied
+        to finger \c fingers[i] (not finger \c i).
+      - The indices are checked if they are valid finger indices.
+      - If \b any index is invalid then \b none of the specified
+        values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+      - As axis 0 is used for finger 0 and 2, axis 0 is disabled only
+        if both finger 0 and 1 are disabled.
+
+      See also #SetFingerEnable(int,double), #SetFingerEnable(int,bool)
+      for overloaded variants to set a single finger enabled/disabled
+      or to set the same state for all fingers.  See further
+      #SetFingerEnable(std::vector<int>const&,std::vector<bool>const&) for a
+      variant that accepts a \c bool vector for the states to set.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Enable finger 1 and 2 while disabling finger 0 :
+        std::vector<double> states012;
+        states012.push_back( 0.0 );
+        states012.push_back( 1.0 );
+        states012.push_back( 1.0 );
+
+        hand.SetFingerEnable( hand.all_axes, states012 );
+        // (this will keep axis 0 (used by the disabled finger 0) enabled,
+        // since axis 0 is needed by the enabled finger 2 too);
+
+        // Enable all fingers:
+        hand.SetFingerEnable( hand.All,true );
+
+        // Disable all fingers:
+        hand.SetFingerEnable( hand.All, 0.0 );
+
+        // Disable finger 2:
+        hand.SetFingerEnable( 2, false );
+
+      \endcode
+
+      <hr>
+  */
+  void SetFingerEnable(std::vector<int> const& fingers, std::vector<double> const& states)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetFingerEnable(std::vector<int>const&,std::vector<double>const&),
+      just for a single finger \a iAxis and a single angle \a angle, see
+      there for details and examples.
+  */
+  void SetFingerEnable(int iFinger, double state = 1.0)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetFingerEnable(std::vector<int>const&,std::vector<double>const&),
+      just with states as vector of \c bool values, see there for details and
+      examples.
+  */
+  void SetFingerEnable(std::vector<int> const& fingers, std::vector<bool> const& states)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #SetFingerEnable(std::vector<int>const&,std::vector<double>const&),
+      just for a single finger \a iAxis and a single angle \a angle, see
+      there for details and examples.
+  */
+  void SetFingerEnable(int iFinger, bool state)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get enabled/disabled state of axis controllers of finger(s).
+
+      The enabled/disabled state of the controllers of the selected
+      fingers is read from the %SDH. A finger is reported disabled if
+      any of its axes is disabled and reported enabled if all its
+      axes are enabled.
+
+      \param fingers - A vector of finger indices to access.
+
+      - The indices in \a fingers are checked if they are valid finger indices.
+      - If \b any finger index is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \return
+      - A vector of enabled/disabled states as doubles (0=disabled,
+        1.0=enabled) of the selected axes.
+      - The order of the elements of the \a axes vector and the returned values
+        vector \a rv matches. I.e. \c rv[i] will be the value of axis
+        \c axes[i] (not axis \c i).
+
+      See also #GetAxisEnable(int) for an overloaded variant to
+      access a single axis.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Get enabled state of all fingers:
+        std::vector<double> v = hand.GetFingerEnable( hand.all_fingers );
+        // now v is something like {0.0, 1.0, 0.0}
+
+        // Get enabled state of finger 0 and 2
+        std::vector<int> fingers02;
+        fingers02.push_back( 0 );
+        fingers02.push_back( 2 );
+
+        v = hand.GetFingerEnable( fingers02 );
+        // now v is something like {0.0, 0.0}
+
+        // Get enabled state of finger 1
+        double v1 = hand.GetFingerEnable( 1 );
+        // now v1 is something like 1.0
+
+      \endcode
+
+      <hr>
+  */
+  std::vector<double> GetFingerEnable(std::vector<int> const& fingers)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #GetFingerEnable(std::vector<int>const&),
+      just for a single finger \a iFinger and returning a single
+      double value
+  */
+  double GetFingerEnable(int iFinger)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Set the target angle(s) for a single finger.
+
+      The target axis angles \a angle of finger \a iFinger are stored
+      in the %SDH. The movement is not executed until an additional
+      move command is sent.
+
+      \param iFinger - index of finger to access.
+                       This must be a single index.
+      \param angles  - the angle(s) to set or \c None to set the current actual axis angles of the finger as target angle.
+                       This can be a single number or a \ref sdhlibrary_cpp_sdh_h_csdh_vector "vector" of numbers.
+                       The value(s) are expected in the configured angle unit system #uc_angle.
+
+      \remark
+      - Setting the target angles will \b not make the finger move.
+      - The \a iFinger index is checked if it is a valid finger index.
+      - The angles are checked if they are in the allowed range
+        [0 .. #f_max_angle_v], i.e. it is checked that \c angles[i],
+        converted to internal units, is in \c [0 .. \c f_max_angle_v[finger_axis_index[iFinger][i]]].
+      - If \b any index or value is invalid then \b none of the specified
+        values is sent to the %SDH, instead a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      See also #SetFingerTargetAngle(int,double,double,double) for an
+      overloaded variant to set finger axis target angles from single \c
+      double values.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Set target axis angles of finger 0 to { 10.0, -08.15, 47.11 } degrees
+        std::vector<double> angles;
+        angles.push_back( 10.0 );
+        angles.push_back( -08.15 );
+        angles.push_back(  47.11 );
+
+        hand.SetFingerTargetAngle( 0, angles );
+
+
+        // Set target axis angles of finger 1 to { 0.0, 24.7, 17.4 } degrees
+        angles[0] = 0.0;   // "virtual" base axis of finger 1
+        angles[1] = 24.7;
+        angles[2] = 17.4;
+        hand.SetFingerTargetAngle( 1, { 0.0, 24.7, 17.4 } );
+
+
+        // Set target axis angles of all axes of finger 0 to 12.34 degrees
+        hand.SetFingerTargetAngle( 0, 12.34, 12.34, 12.34 );
+
+
+        // REMARK: the last command changed the previously set target axis
+        // angle for axis 0, since axis 0 is used as base axis for both
+        // finger 0 and 2!
+      \endcode
+
+      <hr>
+  */
+  void SetFingerTargetAngle(int iFinger, std::vector<double> const& angles)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Like #SetFingerTargetAngle(int,std::vector<double>const&), just with
+      individual finger axis angles \a a0, \a a1 and \a a2.
+  */
+  void SetFingerTargetAngle(int iFinger, double a0, double a1, double a2)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get the target axis angles of a single finger.
+
+      The target axis angles of finger \a iFinger are read from the %SDH.
+
+      \param iFinger - index of finger to access.
+                       This must be a single index
+
+      \remark
+      - The \a iFinger index is checked if it is a valid finger index.
+      - If \a iFinger is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \return
+      - A list of the selected fingers target axis angles
+      - The values are returned in the configured angle unit system #uc_angle.
+
+      See also #GetFingerTargetAngle(int,double&,double&,double&) for an
+      overloaded variant to get finger axis target angles into single \c
+      double values.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Get target axis angles of finger 0
+        std::vector<double> v = hand.GetFingerTargetAngle( 0 );
+        // now v is something like {42.0, -10.0, 47.11}
+
+        // Get target axis angles of finger 1
+        double a0, a1, a2;
+        hand.GetFingerTargetAngle( 1, a0, a1, a2 );
+        // now a0, a1, a2 are something like 0.0, 24.7 and -5.5 respectively.
+      \endcode
+
+      <hr>
+  */
+  std::vector<double> GetFingerTargetAngle(int iFinger)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Like #GetFingerTargetAngle(int), just returning the target axis angles
+      in the \a a0, \a a1 and \a a2 parameters which are given by reference.
+  */
+  void GetFingerTargetAngle(int iFinger, double& a0, double& a1, double& a2)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get the current actual axis angles of a single finger.
+
+      The current actual axis angles of finger \a iFinger are read from the %SDH.
+
+      \param iFinger - index of finger to access.
+                       This must be a single index.
+
+      \remark
+      - The \a iFinger index is checked if it is a valid finger index.
+      - If \a iFinger is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \return
+      - A list of the current actual axis angles of the selected finger
+      - The values are returned in the configured angle unit system #uc_angle.
+
+      See also #GetFingerActualAngle(int,double&,double&,double&) for an
+      overloaded variant to get finger axis actual angles into single \c double
+      values.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Get actual axis angles of finger 0
+        std::vector<double> v = hand.GetFingerActualAngle( 0 );
+        // v is now something like {42.0, -10.0, 47.11}
+
+        // Get actual axis angles of finger 1
+        double a0, a1, a2;
+        hand.GetFingerTargetAngle( 1, a0, a1, a2 );
+        // now a0, a1, a2 are something like 0.0, 24.7 and -5.5 respectively.
+      \endcode
+
+     <hr>
+  */
+  std::vector<double> GetFingerActualAngle(int iFinger)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Like #GetFingerActualAngle(int), just returning the actual axis angles
+      in the \a a0, \a a1 and \a a2 parameters which are given by reference.
+  */
+  void GetFingerActualAngle(int iFinger, double& a0, double& a1, double& a2)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get the minimum axis angles of a single finger.
+
+      The minimum axis angles of finger \a iFingers axes, stored in the
+      library, are returned.
+
+      \param iFinger - index of finger to access.
+                       This must be a single index
+
+      \remark
+      - The \a iFinger index is checked if it is a valid finger index.
+      - If \a iFinger is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \return
+        - A list of the selected fingers minimum axis angles
         - The values are returned in the configured angle unit system #uc_angle.
 
-        See also #GetFingerTargetAngle(int,double&,double&,double&) for an
-        overloaded variant to get finger axis target angles into single \c
-        double values.
+      See also #GetFingerMinAngle(int,double&,double&,double&) for an
+      overloaded variant to get finger axis min angles into single \c double
+      values.
 
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-          // Get target axis angles of finger 0
-          std::vector<double> v = hand.GetFingerTargetAngle( 0 );
-          // now v is something like {42.0, -10.0, 47.11}
-
-          // Get target axis angles of finger 1
-          double a0, a1, a2;
-          hand.GetFingerTargetAngle( 1, a0, a1, a2 );
-          // now a0, a1, a2 are something like 0.0, 24.7 and -5.5 respectively.
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetFingerTargetAngle( int iFinger )
-        throw (cSDHLibraryException*);
+        // Get minimum axis angles of finger 0
+        std::vector<double> v = hand.GetFingerMinAngle( 0 );
+        // now v is something like {0.0, -90.0, -90.0}
 
 
-    //-----------------------------------------------------------------
-    /*!
-        Like #GetFingerTargetAngle(int), just returning the target axis angles
-        in the \a a0, \a a1 and \a a2 parameters which are given by reference.
-    */
-    void GetFingerTargetAngle( int iFinger, double& a0, double& a1, double& a2 )
-        throw (cSDHLibraryException*);
+        // Get target axis angles of finger 1
+        double a0, a1, a2;
+        hand.GetFingerMinAngle( 1, a0, a1, a2 );
+        // now a0, a1, a2 are something like 0.0, -90.0, -90.0 respectively.
 
 
-    //-----------------------------------------------------------------
-    /*!
-        Get the current actual axis angles of a single finger.
+        // Or if you change the angle unit system:
+        hand.UseRadians();
+        v = hand.GetFingerMinAngle( 0 );
+        // now v is something like {0.0, -1.5707963267948966, -1.5707963267948966}
 
-        The current actual axis angles of finger \a iFinger are read from the %SDH.
+      \endcode
 
-        \param iFinger - index of finger to access.
-                         This must be a single index.
+      <hr>
+  */
+  std::vector<double> GetFingerMinAngle(int iFinger)
+  throw (cSDHLibraryException*);
 
-        \remark
-        - The \a iFinger index is checked if it is a valid finger index.
-        - If \a iFinger is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
 
-        \return
-        - A list of the current actual axis angles of the selected finger
+  //-----------------------------------------------------------------
+  /*!
+      Like #GetFingerMinAngle(int), just returning
+      the finger axis min angles in the \a a0, \a a1 and \a a2 parameters
+      which are given by reference.
+  */
+  void GetFingerMinAngle(int iFinger, double& a0, double& a1, double& a2)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get the maximum axis angles of a single finger.
+
+      The maximum axis angles of finger \a iFingers axes, stored in the
+      library, are returned.
+
+      \param iFinger - index of finger to access.
+                       This must be a single index
+
+      \remark
+      - The \a iFinger index is checked if it is a valid finger index.
+      - If \a iFinger is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+      \return
+        - A list of the selected fingers maximum axis angles
         - The values are returned in the configured angle unit system #uc_angle.
 
-        See also #GetFingerActualAngle(int,double&,double&,double&) for an
-        overloaded variant to get finger axis actual angles into single \c double
-        values.
+      See also #GetFingerMaxAngle(int,double&,double&,double&) for an
+      overloaded variant to get finger axis max angles into single \c double
+      values.
 
 
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
 
-          // Get actual axis angles of finger 0
-          std::vector<double> v = hand.GetFingerActualAngle( 0 );
-          // v is now something like {42.0, -10.0, 47.11}
+        // Get maximum axis angles of finger 0
+        std::vector<double> v = hand.GetFingerMaxAngle( 0 );
+        // now v is something like {90.0, 90.0, 90.0}
 
-          // Get actual axis angles of finger 1
-          double a0, a1, a2;
-          hand.GetFingerTargetAngle( 1, a0, a1, a2 );
-          // now a0, a1, a2 are something like 0.0, 24.7 and -5.5 respectively.
-        \endcode
 
-       <hr>
-    */
-    std::vector<double> GetFingerActualAngle( int iFinger )
-        throw (cSDHLibraryException*);
+        // Get target axis angles of finger 1
+        double a0, a1, a2;
+        hand.GetFingerMaxAngle( 1, a0, a1, a2 );
+        // now a0, a1, a2 are something like 90.0, 90.0, 90.0 respectively.
 
 
-    //-----------------------------------------------------------------
-    /*!
-        Like #GetFingerActualAngle(int), just returning the actual axis angles
-        in the \a a0, \a a1 and \a a2 parameters which are given by reference.
-    */
-    void GetFingerActualAngle( int iFinger, double& a0, double& a1, double& a2 )
-        throw (cSDHLibraryException*);
+        // Or if you change the angle unit system:
+        hand.UseRadians();
+        v = hand.GetFingerMaxAngle( 0 );
+        // now v is something like {1.5707963267948966, 1.5707963267948966, 1.5707963267948966}
 
+      \endcode
 
-    //-----------------------------------------------------------------
-    /*!
-        Get the minimum axis angles of a single finger.
+      <hr>
+  */
+  std::vector<double> GetFingerMaxAngle(int iFinger)
+  throw (cSDHLibraryException*);
 
-        The minimum axis angles of finger \a iFingers axes, stored in the
-        library, are returned.
 
-        \param iFinger - index of finger to access.
-                         This must be a single index
-
-        \remark
-        - The \a iFinger index is checked if it is a valid finger index.
-        - If \a iFinger is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-          - A list of the selected fingers minimum axis angles
-          - The values are returned in the configured angle unit system #uc_angle.
-
-        See also #GetFingerMinAngle(int,double&,double&,double&) for an
-        overloaded variant to get finger axis min angles into single \c double
-        values.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get minimum axis angles of finger 0
-          std::vector<double> v = hand.GetFingerMinAngle( 0 );
-          // now v is something like {0.0, -90.0, -90.0}
-
-
-          // Get target axis angles of finger 1
-          double a0, a1, a2;
-          hand.GetFingerMinAngle( 1, a0, a1, a2 );
-          // now a0, a1, a2 are something like 0.0, -90.0, -90.0 respectively.
-
-
-          // Or if you change the angle unit system:
-          hand.UseRadians();
-          v = hand.GetFingerMinAngle( 0 );
-          // now v is something like {0.0, -1.5707963267948966, -1.5707963267948966}
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetFingerMinAngle( int iFinger )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Like #GetFingerMinAngle(int), just returning
-        the finger axis min angles in the \a a0, \a a1 and \a a2 parameters
-        which are given by reference.
-    */
-    void GetFingerMinAngle( int iFinger, double& a0, double& a1, double& a2 )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get the maximum axis angles of a single finger.
-
-        The maximum axis angles of finger \a iFingers axes, stored in the
-        library, are returned.
-
-        \param iFinger - index of finger to access.
-                         This must be a single index
-
-        \remark
-        - The \a iFinger index is checked if it is a valid finger index.
-        - If \a iFinger is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-        \return
-          - A list of the selected fingers maximum axis angles
-          - The values are returned in the configured angle unit system #uc_angle.
-
-        See also #GetFingerMaxAngle(int,double&,double&,double&) for an
-        overloaded variant to get finger axis max angles into single \c double
-        values.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get maximum axis angles of finger 0
-          std::vector<double> v = hand.GetFingerMaxAngle( 0 );
-          // now v is something like {90.0, 90.0, 90.0}
-
-
-          // Get target axis angles of finger 1
-          double a0, a1, a2;
-          hand.GetFingerMaxAngle( 1, a0, a1, a2 );
-          // now a0, a1, a2 are something like 90.0, 90.0, 90.0 respectively.
-
-
-          // Or if you change the angle unit system:
-          hand.UseRadians();
-          v = hand.GetFingerMaxAngle( 0 );
-          // now v is something like {1.5707963267948966, 1.5707963267948966, 1.5707963267948966}
-
-        \endcode
-
-        <hr>
-    */
-    std::vector<double> GetFingerMaxAngle( int iFinger )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Like #GetFingerMaxAngle(int), just returning
-        the finger axis max angles in the \a a0, \a a1 and \a a2 parameters
-        which are given by reference.
-    */
-    void GetFingerMaxAngle( int iFinger, double& a0, double& a1, double& a2 )
-        throw (cSDHLibraryException*);
-
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get the cartesian xyz finger tip position of a single finger from the
-        given axis angles (forward kinematics).
-
-        \param iFinger - index of finger to access.
-                         This must be a single index
-        \param angles  - a vector of NUMBER_OF_AXES_PER_FINGER angles.
-                         The values are expected in the configured angle unit
-                         system #uc_angle.
-
-        \remark
-        - The \a iFinger index is checked if it is a valid finger index.
-        - The angles are checked if they are in the allowed range
-          [0 .. #f_max_angle_v], i.e. it is checked that \c angles[i],
-          converted to internal units, is in \c [0 .. \c f_max_angle_v[finger_axis_index[iFinger][i]]].
-        - If any index or value is invalid then a #SDH::cSDHErrorInvalidParameter*
-          exception is thrown.
-
-
-        \return
-          - A vector of the x,y,z values of the finger tip position
-          - The values are returned in the configured position unit system #uc_position.
-
-        See also #GetFingerXYZ(int,double,double,double) for an overloaded
-        variant to get finger tip position from single \c double values.
-
-
-        \par Examples:
-        \code
-          // Assuming "hand" is a cSDH object ...
-
-          // Get actual finger angles of finger 0:
-          std::vector<double> angles = hand.GetFingerActualAngle( 0 );
-
-          // Get actual finger tip position of finger 0:
-          std::vector<double> position = hand.GetFingerXYZ( 0, angles );
-          // now position is something like {18.821618775581801, 32.600000000000001, 174.0}
-          // (assuming that finger 0 is at axis angles {0,0,0})
-
-          // Get finger tip position of finger 2 at axis angles {90,-90,-90}:
-          position = hand.GetFingerXYZ( 2, 90, -90, -90 );
-          // now position is something like {18.821618775581804, 119.60000000000002, -53.0}
-
-          // Or if you change the angle unit system:
-          hand.UseRadians();
-          position = hand.GetFingerXYZ( 0, 1.5707963267948966, -1.5707963267948966, -1.5707963267948966 );
-          // now position is still something like {18.821618775581804, 119.60000000000002, -53.0}
-
-          // Or if you change the position unit system too:
-          hand.uc_position = &cSDH::uc_position_meter
-          position = hand.GetFingerXYZ( 0, 1.5707963267948966, -1.5707963267948966, -1.5707963267948966 );
-          // now position is still something like {0.018821618775581, 0.119.60000000000002, -0.052999999999}
-        \endcode
-
-       <hr>
-    */
-    std::vector<double> GetFingerXYZ( int iFinger, std::vector<double> const& angles )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Like #SetFingerTargetAngle(int,std::vector<double>const&), just with
-        individual finger axis angles \a a0, \a a1 and \a a2.
-    */
-    std::vector<double> GetFingerXYZ( int iFinger, double a0, double a1, double a2 )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Move selected finger(s) to the previously set target pose with
-        the previously set velocity profile, (maximum) target
-        velocities and target accelerations.
-
-        \param fingers - A vector of finger indices to access.
-        \param sequ    - flag: if true (default) then the function executes sequentially
-                         and returns not until after the %SDH has
-                         finished the movement. If false then the
-                         function returns immediately after the
-                         movement command has been sent to the %SDH
-                         (the currently set target axis angles for other fingers will
-                         then be \b overwritten with their current actual
-                         axis angles).
-
-        - The indices in \a fingers are checked if they are valid finger indices.
-        - If any index is invalid then no movement is performed, instead a
-          #SDH::cSDHErrorInvalidParameter* exception is thrown.
-
-        \return
-        The expected/elapsed execution time for the movement in the configured time unit system #uc_time
-
-        \remark
-          - The axes will be enabled automatically.
-          - Currently the actual movement velocity of an axis is
-            determined by the %SDH firmware to make the movements of all
-            involved axes start and end synchronously at the same time. Therefore
-            the axis that needs the longest time for its movement at its
-            given maximum velocity determines the velocities of all the
-            other axes.
-          - Other fingers than \a iFinger will \b NOT move, even if
-            target axis angles for their axes have been set.
-            (Exception: as axis 0 is used by finger 0 and 2 these
-            two fingers cannot be moved completely idependent of each other.)
-          - If \a sequ is true then the currently set target axis angles for other
-            fingers will be restored upon return of the function.
-          - If \a sequ is false then the currently set target axis angles for other
-            fingers will be \b overwritten with their current actual axis angles
-
-        See also #MoveFinger(int,bool) for an overloaded variant to move a
-        single finger.
-
-        \par Examples:
-        \code
-          // Assuming 'hand' is a cSDH object ...
-
-          // Set a new target pose for finger 0:
-          hand.SetFingerTargetAngle( 0, 0.0, 0.0, 0.0 );
-
-          // Set a new target pose for finger 1
-          hand.SetFingerTargetAngle( 1, 0.0, -10.0, -10.0 );
-
-          // Set a new target pose for finger 2
-          hand.SetFingerTargetAngle( 2, 20.0, -20.0, -20.0 );
-
-          // Move finger 0 only (and finger 2 partly as axis 0 also belongs to finger 2);
-          hand.MoveFinger( 0, true );
-          // The finger 0 has been moved to {20,0,0}
-          // (axis 0 is 'wrong' since the target angle for axis 0 has been overwritten
-          //  while setting the target angles for finger 2);
-
-          // The target poses for finger 1 and 2 are still set since the
-          // last MoveFinger() call was sequentially.
-          // So move finger 1 now:
-          double t = hand.MoveFinger( 1, false );
-
-          // wait until the non-sequential call has finished:
-          SleepSec( t );
-
-          // The finger 1 has been moved to {0,-10,-10}.
-
-          // The target angles for finger 2 have been overwritten since the
-          // last MoveFinger() call was non-sequentially.
-
-          // Therefore this next call will just keep the fingers in their
-          // current positions:
-          hand.MoveFinger( hand.All, true );
-
-
-          // Set new target angles for all axes ("home pose");
-          hand.SetAxisTargetAngle( hand.All, 0.0 );
-
-          // Now move all axes back to home pose:
-          hand.MoveHand();
-
-        \endcode
-
-        \bug
-        With %SDH firmware < 0.0.2.7 calling MoveFinger() while some axes are moving
-        in eCT_POSE controller type will make the joints jerk.
-        This is resolved in %SDH firmware 0.0.2.7 for the eCT_POSE controller type with
-        velocity profile eVP_RAMP. For the eCT_POSE controller type with velocity profile
-        eVP_SIN_SQUARE changing target points/ velocities while moving will still make
-        the axes jerk.
-        <br><b>=> Partly resolved in %SDH firmware 0.0.2.7</b>
-        <hr>
-    */
-    double MoveFinger( std::vector<int>const& fingers, bool sequ=true )
-        throw (cSDHLibraryException*);
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Like #MoveFinger(std::vector<int>const&,bool), just for a single finger
-        \a iFinger (or all fingers if #All is given).
-    */
-    double MoveFinger( int iFinger, bool sequ=true )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-       Move all fingers to the previously set target pose with
-       the previously set (maximum) velocities.
-
-       This is just a shortcut to #MoveFinger(int,bool) with \a
-       iFinger set to \c hand.All and \a sequ as indicated, so see there for
-       details and examples.
-
-       \bug
-       With %SDH firmware < 0.0.2.7 calling MoveHand() while some axes are moving
-       in eCT_POSE controller type will make the joints jerk.
-       This is resolved in %SDH firmware 0.0.2.7 for the eCT_POSE controller type with
-       velocity profile eVP_RAMP. For the eCT_POSE controller type with velocity profile
-       eVP_SIN_SQUARE changing target points/ velocities while moving will still make
-       the axes jerk.
-       <br><b>=> Parltly resolved in %SDH firmware 0.0.2.7</b>
-    */
-    double MoveHand( bool sequ=true )
-        throw (cSDHLibraryException*);
-
-
-    //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_finger
-    //! @}
-    //#####################################################################
-
-
-    //######################################################################
-    /*!
-      \anchor sdhlibrary_cpp_sdh_h_csdh_grip
-       \name   Methods to access %%SDH grip skills
-
-       @{
-    */
-
-    //-----------------------------------------------------------------
-    /*!
-      Get the maximum velocity of grip skills
-
-       The maximum velocity is currently not read from the %SDH, but is stored
-       in the library.
-
-       \return
-         - a single double value is returned representing the velocity in the #uc_angular_velocity unit system
-
-
-       \par Examples:
-       \code
-         // Assuming "hand" is a cSDH object ...
-
-         // Get maximum grip skill velocity
-         double v = hand.GetGripMaxVelocity();
-         // v is now something like 100.0
-
-         // Or if you change the velocity unit system:
-         hand.UseRadians();
-         v = hand.GetGripMaxVelocity();
-         // now v is something like 1.7453292519943295
-       \endcode
-
-       <hr>
-    */
-    double GetGripMaxVelocity( void );
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Perform one of the internal #eGraspId "grips" or "grasps"
-
-        \warning THIS DOES NOT WORK WITH %SDH FIRMWARE PRIOR TO 0.0.2.6 AND SDHLIBRARY-CPP PRIOR to 0.0.1.12
-          This was a feature in the ancient times of the SDH1 and now does work
-          again for %SDH firmware 0.0.2.6 and newer and SDHLIBRARY-CPP 0.0.1.12 and newer. We intend to further improve this
-          feature (e.g. store user defined grips within the %SDH) in the future,
-          but a particular deadline a has not been determined yet.
-
-        \bug
-          With %SDH firmware > 0.0.2.6 and SDHLibrary < 0.0.1.12 GripHand() does not work (<a href="https://192.168.101.101/mechatronik/show_bug.cgi?id=575">Bug 575</a>)
-          <br><b>=> Resolved in SDHLibrary 0.0.1.12</b>
-
-        \bug
-          With %SDH firmware < 0.0.2.6 GripHand() does not work and might
-          yield undefined behaviour there
-          <br><b>=> Resolved in %SDH firmware 0.0.2.6</b>
-
-        \bug Currently the performing of a skill or grip with GripHand() can \b NOT be
-             interrupted!!!  Even if the command is sent with \a sequ=false it \b cannot
-             be stoped or emergency stopped.
-
-        \param grip     - The index of the grip to perform [0..eGID_DIMENSION-1] (s.a. eGraspId)
-        \param close    - close-ratio: [0.0 .. 1.0] where 0.0 is 'fully opened' and 1.0 is 'fully closed'
-        \param velocity - maximum allowed angular axis velocity in the chosen external unit system #uc_angular_velocity
-        \param sequ     - flag: if true (default) then the function executes sequentially
-                          and returns not until after the %SDH has
-                          finished the movement. If false then the
-                          function returns immediately after the
-                          movement command has been sent to the %SDH.
-
-        - The \a close and \a velocity values are checked if they are in their
-          allowed range.
-        - If \b any value is invalid then \b no grip is perfomed, instead a
-          #SDH::cSDHErrorInvalidParameter* exception is thrown.
-
-        \return
-          The expected/elapsed execution time for the movement in the configured time
-          unit system #uc_time.
-
-        \remark
-          - Currently the actual movement velocity of an axis is
-            determined by the %SDH firmware to make the movements of all
-            involved axes start and end synchronously at the same time. Therefore
-            the axis that needs the longest time for its movement at its
-            given maximum velocity determines the velocities of all the
-            other axes.
-          - The currently set target axis angles are not changed by this command
-          - The movement uses the eMotorCurrentMode motor current modes "eMCM_GRIP"
-            while gripping and then changes the motor current mode to
-            "eMCM_HOLD". After the movement previously set motor currents
-            set for mode "eMCM_MOVE" are \b overwritten!
-
-        \par Examples:
-        \code
-          // Assuming 'hand' is a cSDH object ...
-
-          // Perform a fully opened centrical grip at 50 degrees per second:
-          hand.GripHand( hand.eGID_CENTRICAL, 0.0, 50.0, true );
-
-          // Now close it 50% with 30 degrees per second:
-          hand.GripHand( hand.eGID_CENTRICAL, 0.5, 30.0, true );
-
-          // Then close it completely with 20 degrees per second:
-          hand.GripHand( hand.eGID_CENTRICAL, 1.0, 20.0, true );
-        \endcode
-
-        <hr>
-    */
-    double GripHand( eGraspId grip, double close, double velocity, bool sequ=true )
-        throw (cSDHLibraryException*);
-
-
-    //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_grip
-    //!  @}
-    //#####################################################################
+  //-----------------------------------------------------------------
+  /*!
+      Like #GetFingerMaxAngle(int), just returning
+      the finger axis max angles in the \a a0, \a a1 and \a a2 parameters
+      which are given by reference.
+  */
+  void GetFingerMaxAngle(int iFinger, double& a0, double& a1, double& a2)
+  throw (cSDHLibraryException*);
+
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get the cartesian xyz finger tip position of a single finger from the
+      given axis angles (forward kinematics).
+
+      \param iFinger - index of finger to access.
+                       This must be a single index
+      \param angles  - a vector of NUMBER_OF_AXES_PER_FINGER angles.
+                       The values are expected in the configured angle unit
+                       system #uc_angle.
+
+      \remark
+      - The \a iFinger index is checked if it is a valid finger index.
+      - The angles are checked if they are in the allowed range
+        [0 .. #f_max_angle_v], i.e. it is checked that \c angles[i],
+        converted to internal units, is in \c [0 .. \c f_max_angle_v[finger_axis_index[iFinger][i]]].
+      - If any index or value is invalid then a #SDH::cSDHErrorInvalidParameter*
+        exception is thrown.
+
+
+      \return
+        - A vector of the x,y,z values of the finger tip position
+        - The values are returned in the configured position unit system #uc_position.
+
+      See also #GetFingerXYZ(int,double,double,double) for an overloaded
+      variant to get finger tip position from single \c double values.
+
+
+      \par Examples:
+      \code
+        // Assuming "hand" is a cSDH object ...
+
+        // Get actual finger angles of finger 0:
+        std::vector<double> angles = hand.GetFingerActualAngle( 0 );
+
+        // Get actual finger tip position of finger 0:
+        std::vector<double> position = hand.GetFingerXYZ( 0, angles );
+        // now position is something like {18.821618775581801, 32.600000000000001, 174.0}
+        // (assuming that finger 0 is at axis angles {0,0,0})
+
+        // Get finger tip position of finger 2 at axis angles {90,-90,-90}:
+        position = hand.GetFingerXYZ( 2, 90, -90, -90 );
+        // now position is something like {18.821618775581804, 119.60000000000002, -53.0}
+
+        // Or if you change the angle unit system:
+        hand.UseRadians();
+        position = hand.GetFingerXYZ( 0, 1.5707963267948966, -1.5707963267948966, -1.5707963267948966 );
+        // now position is still something like {18.821618775581804, 119.60000000000002, -53.0}
+
+        // Or if you change the position unit system too:
+        hand.uc_position = &cSDH::uc_position_meter
+        position = hand.GetFingerXYZ( 0, 1.5707963267948966, -1.5707963267948966, -1.5707963267948966 );
+        // now position is still something like {0.018821618775581, 0.119.60000000000002, -0.052999999999}
+      \endcode
+
+     <hr>
+  */
+  std::vector<double> GetFingerXYZ(int iFinger, std::vector<double> const& angles)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Like #SetFingerTargetAngle(int,std::vector<double>const&), just with
+      individual finger axis angles \a a0, \a a1 and \a a2.
+  */
+  std::vector<double> GetFingerXYZ(int iFinger, double a0, double a1, double a2)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Move selected finger(s) to the previously set target pose with
+      the previously set velocity profile, (maximum) target
+      velocities and target accelerations.
+
+      \param fingers - A vector of finger indices to access.
+      \param sequ    - flag: if true (default) then the function executes sequentially
+                       and returns not until after the %SDH has
+                       finished the movement. If false then the
+                       function returns immediately after the
+                       movement command has been sent to the %SDH
+                       (the currently set target axis angles for other fingers will
+                       then be \b overwritten with their current actual
+                       axis angles).
+
+      - The indices in \a fingers are checked if they are valid finger indices.
+      - If any index is invalid then no movement is performed, instead a
+        #SDH::cSDHErrorInvalidParameter* exception is thrown.
+
+      \return
+      The expected/elapsed execution time for the movement in the configured time unit system #uc_time
+
+      \remark
+        - The axes will be enabled automatically.
+        - Currently the actual movement velocity of an axis is
+          determined by the %SDH firmware to make the movements of all
+          involved axes start and end synchronously at the same time. Therefore
+          the axis that needs the longest time for its movement at its
+          given maximum velocity determines the velocities of all the
+          other axes.
+        - Other fingers than \a iFinger will \b NOT move, even if
+          target axis angles for their axes have been set.
+          (Exception: as axis 0 is used by finger 0 and 2 these
+          two fingers cannot be moved completely idependent of each other.)
+        - If \a sequ is true then the currently set target axis angles for other
+          fingers will be restored upon return of the function.
+        - If \a sequ is false then the currently set target axis angles for other
+          fingers will be \b overwritten with their current actual axis angles
+
+      See also #MoveFinger(int,bool) for an overloaded variant to move a
+      single finger.
+
+      \par Examples:
+      \code
+        // Assuming 'hand' is a cSDH object ...
+
+        // Set a new target pose for finger 0:
+        hand.SetFingerTargetAngle( 0, 0.0, 0.0, 0.0 );
+
+        // Set a new target pose for finger 1
+        hand.SetFingerTargetAngle( 1, 0.0, -10.0, -10.0 );
+
+        // Set a new target pose for finger 2
+        hand.SetFingerTargetAngle( 2, 20.0, -20.0, -20.0 );
+
+        // Move finger 0 only (and finger 2 partly as axis 0 also belongs to finger 2);
+        hand.MoveFinger( 0, true );
+        // The finger 0 has been moved to {20,0,0}
+        // (axis 0 is 'wrong' since the target angle for axis 0 has been overwritten
+        //  while setting the target angles for finger 2);
+
+        // The target poses for finger 1 and 2 are still set since the
+        // last MoveFinger() call was sequentially.
+        // So move finger 1 now:
+        double t = hand.MoveFinger( 1, false );
+
+        // wait until the non-sequential call has finished:
+        SleepSec( t );
+
+        // The finger 1 has been moved to {0,-10,-10}.
+
+        // The target angles for finger 2 have been overwritten since the
+        // last MoveFinger() call was non-sequentially.
+
+        // Therefore this next call will just keep the fingers in their
+        // current positions:
+        hand.MoveFinger( hand.All, true );
+
+
+        // Set new target angles for all axes ("home pose");
+        hand.SetAxisTargetAngle( hand.All, 0.0 );
+
+        // Now move all axes back to home pose:
+        hand.MoveHand();
+
+      \endcode
+
+      \bug
+      With %SDH firmware < 0.0.2.7 calling MoveFinger() while some axes are moving
+      in eCT_POSE controller type will make the joints jerk.
+      This is resolved in %SDH firmware 0.0.2.7 for the eCT_POSE controller type with
+      velocity profile eVP_RAMP. For the eCT_POSE controller type with velocity profile
+      eVP_SIN_SQUARE changing target points/ velocities while moving will still make
+      the axes jerk.
+      <br><b>=> Partly resolved in %SDH firmware 0.0.2.7</b>
+      <hr>
+  */
+  double MoveFinger(std::vector<int>const& fingers, bool sequ = true)
+  throw (cSDHLibraryException*);
+
+
+  //----------------------------------------------------------------------
+  /*!
+      Like #MoveFinger(std::vector<int>const&,bool), just for a single finger
+      \a iFinger (or all fingers if #All is given).
+  */
+  double MoveFinger(int iFinger, bool sequ = true)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+     Move all fingers to the previously set target pose with
+     the previously set (maximum) velocities.
+
+     This is just a shortcut to #MoveFinger(int,bool) with \a
+     iFinger set to \c hand.All and \a sequ as indicated, so see there for
+     details and examples.
+
+     \bug
+     With %SDH firmware < 0.0.2.7 calling MoveHand() while some axes are moving
+     in eCT_POSE controller type will make the joints jerk.
+     This is resolved in %SDH firmware 0.0.2.7 for the eCT_POSE controller type with
+     velocity profile eVP_RAMP. For the eCT_POSE controller type with velocity profile
+     eVP_SIN_SQUARE changing target points/ velocities while moving will still make
+     the axes jerk.
+     <br><b>=> Parltly resolved in %SDH firmware 0.0.2.7</b>
+  */
+  double MoveHand(bool sequ = true)
+  throw (cSDHLibraryException*);
+
+
+  //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_finger
+  //! @}
+  //#####################################################################
+
+
+  //######################################################################
+  /*!
+    \anchor sdhlibrary_cpp_sdh_h_csdh_grip
+     \name   Methods to access %%SDH grip skills
+
+     @{
+  */
+
+  //-----------------------------------------------------------------
+  /*!
+    Get the maximum velocity of grip skills
+
+     The maximum velocity is currently not read from the %SDH, but is stored
+     in the library.
+
+     \return
+       - a single double value is returned representing the velocity in the #uc_angular_velocity unit system
+
+
+     \par Examples:
+     \code
+       // Assuming "hand" is a cSDH object ...
+
+       // Get maximum grip skill velocity
+       double v = hand.GetGripMaxVelocity();
+       // v is now something like 100.0
+
+       // Or if you change the velocity unit system:
+       hand.UseRadians();
+       v = hand.GetGripMaxVelocity();
+       // now v is something like 1.7453292519943295
+     \endcode
+
+     <hr>
+  */
+  double GetGripMaxVelocity(void);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Perform one of the internal #eGraspId "grips" or "grasps"
+
+      \warning THIS DOES NOT WORK WITH %SDH FIRMWARE PRIOR TO 0.0.2.6 AND SDHLIBRARY-CPP PRIOR to 0.0.1.12
+        This was a feature in the ancient times of the SDH1 and now does work
+        again for %SDH firmware 0.0.2.6 and newer and SDHLIBRARY-CPP 0.0.1.12 and newer. We intend to further improve this
+        feature (e.g. store user defined grips within the %SDH) in the future,
+        but a particular deadline a has not been determined yet.
+
+      \bug
+        With %SDH firmware > 0.0.2.6 and SDHLibrary < 0.0.1.12 GripHand() does not work (<a href="https://192.168.101.101/mechatronik/show_bug.cgi?id=575">Bug 575</a>)
+        <br><b>=> Resolved in SDHLibrary 0.0.1.12</b>
+
+      \bug
+        With %SDH firmware < 0.0.2.6 GripHand() does not work and might
+        yield undefined behaviour there
+        <br><b>=> Resolved in %SDH firmware 0.0.2.6</b>
+
+      \bug Currently the performing of a skill or grip with GripHand() can \b NOT be
+           interrupted!!!  Even if the command is sent with \a sequ=false it \b cannot
+           be stoped or emergency stopped.
+
+      \param grip     - The index of the grip to perform [0..eGID_DIMENSION-1] (s.a. eGraspId)
+      \param close    - close-ratio: [0.0 .. 1.0] where 0.0 is 'fully opened' and 1.0 is 'fully closed'
+      \param velocity - maximum allowed angular axis velocity in the chosen external unit system #uc_angular_velocity
+      \param sequ     - flag: if true (default) then the function executes sequentially
+                        and returns not until after the %SDH has
+                        finished the movement. If false then the
+                        function returns immediately after the
+                        movement command has been sent to the %SDH.
+
+      - The \a close and \a velocity values are checked if they are in their
+        allowed range.
+      - If \b any value is invalid then \b no grip is perfomed, instead a
+        #SDH::cSDHErrorInvalidParameter* exception is thrown.
+
+      \return
+        The expected/elapsed execution time for the movement in the configured time
+        unit system #uc_time.
+
+      \remark
+        - Currently the actual movement velocity of an axis is
+          determined by the %SDH firmware to make the movements of all
+          involved axes start and end synchronously at the same time. Therefore
+          the axis that needs the longest time for its movement at its
+          given maximum velocity determines the velocities of all the
+          other axes.
+        - The currently set target axis angles are not changed by this command
+        - The movement uses the eMotorCurrentMode motor current modes "eMCM_GRIP"
+          while gripping and then changes the motor current mode to
+          "eMCM_HOLD". After the movement previously set motor currents
+          set for mode "eMCM_MOVE" are \b overwritten!
+
+      \par Examples:
+      \code
+        // Assuming 'hand' is a cSDH object ...
+
+        // Perform a fully opened centrical grip at 50 degrees per second:
+        hand.GripHand( hand.eGID_CENTRICAL, 0.0, 50.0, true );
+
+        // Now close it 50% with 30 degrees per second:
+        hand.GripHand( hand.eGID_CENTRICAL, 0.5, 30.0, true );
+
+        // Then close it completely with 20 degrees per second:
+        hand.GripHand( hand.eGID_CENTRICAL, 1.0, 20.0, true );
+      \endcode
+
+      <hr>
+  */
+  double GripHand(eGraspId grip, double close, double velocity, bool sequ = true)
+  throw (cSDHLibraryException*);
+
+
+  //  end of doxygen name group sdhlibrary_cpp_sdh_h_csdh_grip
+  //!  @}
+  //#####################################################################
 
 private:
-    /*!
-     * Update settings like min/max velocities and accelerations from the connected %SDH
-     */
-    void UpdateSettingsFromSDH();
+  /*!
+   * Update settings like min/max velocities and accelerations from the connected %SDH
+   */
+  void UpdateSettingsFromSDH();
 
-    /*!
-     * Adjust the limits for the velocity and acceleration according to the controller type.
-     *
-     * - in pose controller the velocities and accelerations are always positive and thus the minimum is 0.0
-     * - in velocity based controllers the velocities and accelerations can be positive or negative and thus the minimum is -maximum
-     */
-    void AdjustLimits( cSDHBase::eControllerType controller );
+  /*!
+   * Adjust the limits for the velocity and acceleration according to the controller type.
+   *
+   * - in pose controller the velocities and accelerations are always positive and thus the minimum is 0.0
+   * - in velocity based controllers the velocities and accelerations can be positive or negative and thus the minimum is -maximum
+   */
+  void AdjustLimits(cSDHBase::eControllerType controller);
 
 
-    //! string containing the %SDH firmware release of the attaced %SDH (something like "0.0.2.7")
-    std::string release_firmware;
+  //! string containing the %SDH firmware release of the attaced %SDH (something like "0.0.2.7")
+  std::string release_firmware;
 
-    //! cached value of the axis controller type
-    eControllerType controller_type;
+  //! cached value of the axis controller type
+  eControllerType controller_type;
 
-    // unimplemented from SAH:
-    // def GetFingerTipFT( int iFinger,double* pafFTData);
+  // unimplemented from SAH:
+  // def GetFingerTipFT( int iFinger,double* pafFTData);
 
-    // def GetFingerEnableState( int iFinger, int* piEnableState);
+  // def GetFingerEnableState( int iFinger, int* piEnableState);
 
-    // def GetCommandedValues( int iFinger, double* pafAngle,double* pafVelocity);
-    // def GetHandConfig( int* piConfig);
-    // def GetFingerLimitsStatus( int iPort,int iFinger,int* paiLimitStatus);
-    // def ClearTorqueSensorOffset( int iPort,int iFinger);
+  // def GetCommandedValues( int iFinger, double* pafAngle,double* pafVelocity);
+  // def GetHandConfig( int* piConfig);
+  // def GetFingerLimitsStatus( int iPort,int iFinger,int* paiLimitStatus);
+  // def ClearTorqueSensorOffset( int iPort,int iFinger);
 
-    // def SetStiffnessFactor( int iFinger, double* pafStiffnessFactor);
+  // def SetStiffnessFactor( int iFinger, double* pafStiffnessFactor);
 
 
 

--- a/schunk_sdh/common/include/schunk_sdh/sdh_codes.h
+++ b/schunk_sdh/common/include/schunk_sdh/sdh_codes.h
@@ -67,8 +67,8 @@ NAMESPACE_SDH_START
 // Function prototypes (function declarations)
 //----------------------------------------------------------------------
 
-char const* SDHCommandCodeToString( eCommandCode cc );
-char const* SDHReturnCodeToString( eReturnCode rc );
+char const* SDHCommandCodeToString(eCommandCode cc);
+char const* SDHReturnCodeToString(eReturnCode rc);
 
 NAMESPACE_SDH_END
 

--- a/schunk_sdh/common/include/schunk_sdh/sdh_command_codes.h
+++ b/schunk_sdh/common/include/schunk_sdh/sdh_command_codes.h
@@ -78,69 +78,69 @@
 */
 enum eCommandCodeEnum
 {
-    // Movement commands:
-    CMDC_V = 128,   // assign a value so that non ASCII codes are used
+  // Movement commands:
+  CMDC_V = 128,   // assign a value so that non ASCII codes are used
 
-    CMDC_VEL,
-    //130:
-    CMDC_RVEL,
-    CMDC_POS,
-    CMDC_STATE,
-    CMDC_P,
-    CMDC_A,
-    CMDC_M,
-    CMDC_STOP,
-    CMDC_VP,
-    CMDC_CON,
-    CMDC_TPAP,
-    //140:
-    CMDC_TVAV,
+  CMDC_VEL,
+  //130:
+  CMDC_RVEL,
+  CMDC_POS,
+  CMDC_STATE,
+  CMDC_P,
+  CMDC_A,
+  CMDC_M,
+  CMDC_STOP,
+  CMDC_VP,
+  CMDC_CON,
+  CMDC_TPAP,
+  //140:
+  CMDC_TVAV,
 
-    // Diagnostic and identification commands:
-    CMDC_VLIM,
-    CMDC_ALIM,
-    CMDC_POS_SAVE,
-    CMDC_REF,
-    CMDC_TEMP,
-    CMDC_ID,
-    CMDC_SN,
-    CMDC_VER,
-    CMDC_VER_DATE,
-    //150:
-    CMDC_SOC,
-    CMDC_SOC_DATE,
-    CMDC_NUMAXIS,
-    CMDC_P_MIN,
-    CMDC_P_MAX,
-    CMDC_P_OFFSET,
-    CMDC_GET_DURATION,
+  // Diagnostic and identification commands:
+  CMDC_VLIM,
+  CMDC_ALIM,
+  CMDC_POS_SAVE,
+  CMDC_REF,
+  CMDC_TEMP,
+  CMDC_ID,
+  CMDC_SN,
+  CMDC_VER,
+  CMDC_VER_DATE,
+  //150:
+  CMDC_SOC,
+  CMDC_SOC_DATE,
+  CMDC_NUMAXIS,
+  CMDC_P_MIN,
+  CMDC_P_MAX,
+  CMDC_P_OFFSET,
+  CMDC_GET_DURATION,
 
-    // Grip commands:
-    CMDC_IGRIP,
-    CMDC_IHOLD,
-    CMDC_SELGRIP,
-    //160:
-    CMDC_GRIP,
+  // Grip commands:
+  CMDC_IGRIP,
+  CMDC_IHOLD,
+  CMDC_SELGRIP,
+  //160:
+  CMDC_GRIP,
 
-    // Setup and configuration commands:
-    CMDC_PID,
-    CMDC_KV,
-    CMDC_ILIM,
-    CMDC_POWER,
+  // Setup and configuration commands:
+  CMDC_PID,
+  CMDC_KV,
+  CMDC_ILIM,
+  CMDC_POWER,
 
-    // Misc. commands:
-    CMDC_DEMO,
-    CMDC_USER_ERRORS,
-    CMDC_TERMINAL,
-    CMDC_DEBUG,
-    CMDC_USE_FIXED_LENGTH,
-    //170:
-    CMDC_CHANGE_RS232,
-    CMDC_CHANGE_CHANNEL,
+  // Misc. commands:
+  CMDC_DEMO,
+  CMDC_USER_ERRORS,
+  CMDC_TERMINAL,
+  CMDC_DEBUG,
+  CMDC_USE_FIXED_LENGTH,
+  //170:
+  CMDC_CHANGE_RS232,
+  CMDC_CHANGE_CHANNEL,
 
 #if USE_CMD_TEST
 
-    CMDC_TEST,
+  CMDC_TEST,
 #endif
 } SDH__attribute__((packed));
 

--- a/schunk_sdh/common/include/schunk_sdh/sdh_return_codes.h
+++ b/schunk_sdh/common/include/schunk_sdh/sdh_return_codes.h
@@ -71,47 +71,47 @@
 */
 enum eReturnCodeEnum
 {
-    RC_OK = 0,                 //!< Success, no error
-    RC_NOT_AVAILABLE,          //!< Error: An accessed ressource is not available
-    RC_NOT_INITIALIZED,        //!< Error: An accessed ressource has not been initialized
-    RC_ALREADY_RUNNING,        //!< Error: Data acquisition: the acquisition loop is already running
-    RC_FEATURE_NOT_SUPPORTED,
-    RC_INCONSISTENT_DATA,
-    RC_TIMEOUT,                //!< Error: timeout occured
-    RC_READ_ERROR,             //!< Error: could not read
-    RC_WRITE_ERROR,            //!< Error: could not write
-    RC_INSUFFICIENT_RESOURCES, //!< Error: Insufficient ressources
-    RC_CHECKSUM_ERROR,
-    RC_NOT_ENOUGH_PARAMS,      //!< Error: not enough parameters on command line
-    RC_NO_PARAMS_EXPECTED,
-    RC_CMD_UNKNOWN,            //!< Error: unknown command on command line
-    RC_CMD_FORMAT_ERROR,       //!< Error: invalid format of command line parameters
-    RC_ACCESS_DENIED,
-    RC_ALREADY_OPEN,
-    RC_CMD_FAILED,
-    RC_CMD_ABORTED,
-    RC_INVALID_HANDLE,
-    RC_DEVICE_NOT_FOUND,
-    RC_DEVICE_NOT_OPENED,
-    RC_IO_ERROR,               //!< Error: Input/Output error like bus-off detected
-    RC_INVALID_PARAMETER,      //!< Error: invalid parameter on command line
-    RC_RANGE_ERROR,
-    RC_NO_DATAPIPE,
-    RC_INDEX_OUT_OF_BOUNDS,    //!< Error: A given index parameter is invalid
-    RC_HOMING_ERROR,
-    RC_AXIS_DISABLED,
-    RC_OVER_TEMPERATURE,
-    RC_MAX_COMMANDS_EXCEEDED,  //!< Error: cannot add more than CI_MAX_COMMANDS to interpreter / POSCON_MAX_OSCILLOSCOPE parameters to oscilloscope
-    RC_INVALID_PASSWORD,       //!< Error: invalid password given for change user command
-    RC_MAX_COMMANDLINE_EXCEEDED, //!< Error: the command line given is too long
-    RC_CRC_ERROR,              //!< Cyclic Redundancy Code error while receiving binary input
-    RC_NO_COMMAND,             //!< Not really an error: reading input did not yield a new command
+  RC_OK = 0,                 //!< Success, no error
+  RC_NOT_AVAILABLE,          //!< Error: An accessed ressource is not available
+  RC_NOT_INITIALIZED,        //!< Error: An accessed ressource has not been initialized
+  RC_ALREADY_RUNNING,        //!< Error: Data acquisition: the acquisition loop is already running
+  RC_FEATURE_NOT_SUPPORTED,
+  RC_INCONSISTENT_DATA,
+  RC_TIMEOUT,                //!< Error: timeout occured
+  RC_READ_ERROR,             //!< Error: could not read
+  RC_WRITE_ERROR,            //!< Error: could not write
+  RC_INSUFFICIENT_RESOURCES, //!< Error: Insufficient ressources
+  RC_CHECKSUM_ERROR,
+  RC_NOT_ENOUGH_PARAMS,      //!< Error: not enough parameters on command line
+  RC_NO_PARAMS_EXPECTED,
+  RC_CMD_UNKNOWN,            //!< Error: unknown command on command line
+  RC_CMD_FORMAT_ERROR,       //!< Error: invalid format of command line parameters
+  RC_ACCESS_DENIED,
+  RC_ALREADY_OPEN,
+  RC_CMD_FAILED,
+  RC_CMD_ABORTED,
+  RC_INVALID_HANDLE,
+  RC_DEVICE_NOT_FOUND,
+  RC_DEVICE_NOT_OPENED,
+  RC_IO_ERROR,               //!< Error: Input/Output error like bus-off detected
+  RC_INVALID_PARAMETER,      //!< Error: invalid parameter on command line
+  RC_RANGE_ERROR,
+  RC_NO_DATAPIPE,
+  RC_INDEX_OUT_OF_BOUNDS,    //!< Error: A given index parameter is invalid
+  RC_HOMING_ERROR,
+  RC_AXIS_DISABLED,
+  RC_OVER_TEMPERATURE,
+  RC_MAX_COMMANDS_EXCEEDED,  //!< Error: cannot add more than CI_MAX_COMMANDS to interpreter / POSCON_MAX_OSCILLOSCOPE parameters to oscilloscope
+  RC_INVALID_PASSWORD,       //!< Error: invalid password given for change user command
+  RC_MAX_COMMANDLINE_EXCEEDED, //!< Error: the command line given is too long
+  RC_CRC_ERROR,              //!< Cyclic Redundancy Code error while receiving binary input
+  RC_NO_COMMAND,             //!< Not really an error: reading input did not yield a new command
 
-    RC_INTERNAL,               //!< Error: callback function reports internal error
-    RC_UNKNOWN_ERROR,          //!< Error: unknown error
+  RC_INTERNAL,               //!< Error: callback function reports internal error
+  RC_UNKNOWN_ERROR,          //!< Error: unknown error
 
-    // Dont forget to add new enums to ReturnCodeToString() too.
-    RC_DIMENSION          //!< End marker and dimension
+  // Dont forget to add new enums to ReturnCodeToString() too.
+  RC_DIMENSION          //!< End marker and dimension
 } SDH__attribute__((__packed__));
 
 //! typedef for eCommandCodeEnum, see there

--- a/schunk_sdh/common/include/schunk_sdh/sdhbase.h
+++ b/schunk_sdh/common/include/schunk_sdh/sdhbase.h
@@ -78,8 +78,8 @@ extern VCC_EXPORT std::ostream* g_sdh_debug_log;
 class VCC_EXPORT cSDHErrorInvalidParameter: public cSDHLibraryException
 {
 public:
-  cSDHErrorInvalidParameter( cMsg const & _msg )
-    : cSDHLibraryException( "cSDHErrorInvalidParameter", _msg )
+  cSDHErrorInvalidParameter(cMsg const & _msg)
+    : cSDHLibraryException("cSDHErrorInvalidParameter", _msg)
   {}
 };
 //======================================================================
@@ -98,239 +98,240 @@ class VCC_EXPORT cSDHBase
 {
 public:
 
-    //! Anonymous enum (instead of define like macros)
-    enum {
-        All = -1 //!< A meta-value that means "access all possible values"
-    };
+  //! Anonymous enum (instead of define like macros)
+  enum
+  {
+    All = -1 //!< A meta-value that means "access all possible values"
+  };
 
 
-    /*!
-      The error codes of the %SDH firmware
-       \internal
-        In the %SDH firmware these enums are of type DSA_STAT
-    */
-    enum eErrorCode
-    {
-        eEC_SUCCESS = 0,
-        eEC_NOT_AVAILABLE,
-        eEC_NOT_INITIALIZED,
-        eEC_ALREADY_RUNNING,
-        eEC_FEATURE_NOT_SUPPORTED,
-        eEC_INCONSISTENT_DATA,
-        eEC_TIMEOUT,
-        eEC_READ_ERROR,
-        eEC_WRITE_ERROR,
-        eEC_INSUFFICIENT_RESOURCES,
-        eEC_CHECKSUM_ERROR,
-        eEC_NOT_ENOUGH_PARAMS,
-        eEC_NO_PARAMS_EXPECTED,
-        eEC_CMD_UNKNOWN,
-        eEC_CMD_FORMAT_ERROR,
-        eEC_ACCESS_DENIED,
-        eEC_ALREADY_OPEN,
-        eEC_CMD_FAILED,
-        eEC_CMD_ABORTED,
-        eEC_INVALID_HANDLE,
-        eEC_DEVICE_NOT_FOUND,
-        eEC_DEVICE_NOT_OPENED,
-        eEC_IO_ERROR,
-        eEC_INVALID_PARAMETER,
-        eEC_RANGE_ERROR,
-        eEC_NO_DATAPIPE,
-        eEC_INDEX_OUT_OF_BOUNDS,
-        eEC_HOMING_ERROR,
-        eEC_AXIS_DISABLED,
-        eEC_OVER_TEMPERATURE,
-        eEC_MAX_COMMANDS_EXCEEDED,
-        eEC_INVALID_PASSWORD,
-        eEC_MAX_COMMANDLINE_EXCEEDED,
-        eEC_CRC_ERROR,
-        eEC_NO_COMMAND,
+  /*!
+    The error codes of the %SDH firmware
+     \internal
+      In the %SDH firmware these enums are of type DSA_STAT
+  */
+  enum eErrorCode
+  {
+    eEC_SUCCESS = 0,
+    eEC_NOT_AVAILABLE,
+    eEC_NOT_INITIALIZED,
+    eEC_ALREADY_RUNNING,
+    eEC_FEATURE_NOT_SUPPORTED,
+    eEC_INCONSISTENT_DATA,
+    eEC_TIMEOUT,
+    eEC_READ_ERROR,
+    eEC_WRITE_ERROR,
+    eEC_INSUFFICIENT_RESOURCES,
+    eEC_CHECKSUM_ERROR,
+    eEC_NOT_ENOUGH_PARAMS,
+    eEC_NO_PARAMS_EXPECTED,
+    eEC_CMD_UNKNOWN,
+    eEC_CMD_FORMAT_ERROR,
+    eEC_ACCESS_DENIED,
+    eEC_ALREADY_OPEN,
+    eEC_CMD_FAILED,
+    eEC_CMD_ABORTED,
+    eEC_INVALID_HANDLE,
+    eEC_DEVICE_NOT_FOUND,
+    eEC_DEVICE_NOT_OPENED,
+    eEC_IO_ERROR,
+    eEC_INVALID_PARAMETER,
+    eEC_RANGE_ERROR,
+    eEC_NO_DATAPIPE,
+    eEC_INDEX_OUT_OF_BOUNDS,
+    eEC_HOMING_ERROR,
+    eEC_AXIS_DISABLED,
+    eEC_OVER_TEMPERATURE,
+    eEC_MAX_COMMANDS_EXCEEDED,
+    eEC_INVALID_PASSWORD,
+    eEC_MAX_COMMANDLINE_EXCEEDED,
+    eEC_CRC_ERROR,
+    eEC_NO_COMMAND,
 
-        eEC_INTERNAL,
-        eEC_UNKNOWN_ERROR,
+    eEC_INTERNAL,
+    eEC_UNKNOWN_ERROR,
 
-        eEC_DIMENSION         //!< Endmarker and dimension
-    };
-
-
-    /*!
-      \brief The enum values of the known grasps
-       \internal
-         In the %SDH firmware these enums are of type TGRIP
-    */
-    enum eGraspId
-    {
-        // ??? fehlt e vor enums:
-        eGID_INVALID = -1,    //!< invalid grasp id
-        eGID_CENTRICAL = 0,   //!< centrical grasp:   ???
-        eGID_PARALLEL = 1,    //!< parallel grasp:    ???
-        eGID_CYLINDRICAL = 2, //!< cylindrical grasp: ???
-        eGID_SPHERICAL = 3,   //!< spherecial grasp:  ???
-
-        eGID_DIMENSION        //!< Endmarker and dimension
-    };
+    eEC_DIMENSION         //!< Endmarker and dimension
+  };
 
 
-    //! An enum for all possible %SDH internal controller types (order must match that in the %SDH firmware in inc/sdh2.h)
-    enum eControllerType
-    {
-        eCT_INVALID = -1,          //!< invalid controller_type (needed for cSDHSerial::con() to indicate "read current controller type")
-        eCT_POSE = 0,              //!< coordinated position controller (position per axis => "pose controller"), all axes start and stop moving at the same time
-        eCT_VELOCITY,              //!< velocity controller, velocities of axes are controlled independently (not implemented in %SDH firmwares up to and including 0.0.2.5)
-        eCT_VELOCITY_ACCELERATION, //!< velocity controller with acceleration ramp, velocities and accelerations of axes are controlled independently (not implemented in %SDH firmwares up to and including 0.0.2.5)
+  /*!
+    \brief The enum values of the known grasps
+     \internal
+       In the %SDH firmware these enums are of type TGRIP
+  */
+  enum eGraspId
+  {
+    // ??? fehlt e vor enums:
+    eGID_INVALID = -1,    //!< invalid grasp id
+    eGID_CENTRICAL = 0,   //!< centrical grasp:   ???
+    eGID_PARALLEL = 1,    //!< parallel grasp:    ???
+    eGID_CYLINDRICAL = 2, //!< cylindrical grasp: ???
+    eGID_SPHERICAL = 3,   //!< spherecial grasp:  ???
+
+    eGID_DIMENSION        //!< Endmarker and dimension
+  };
+
+
+  //! An enum for all possible %SDH internal controller types (order must match that in the %SDH firmware in inc/sdh2.h)
+  enum eControllerType
+  {
+    eCT_INVALID = -1,          //!< invalid controller_type (needed for cSDHSerial::con() to indicate "read current controller type")
+    eCT_POSE = 0,              //!< coordinated position controller (position per axis => "pose controller"), all axes start and stop moving at the same time
+    eCT_VELOCITY,              //!< velocity controller, velocities of axes are controlled independently (not implemented in %SDH firmwares up to and including 0.0.2.5)
+    eCT_VELOCITY_ACCELERATION, //!< velocity controller with acceleration ramp, velocities and accelerations of axes are controlled independently (not implemented in %SDH firmwares up to and including 0.0.2.5)
 
 // TODO: not implemented yet
 //        eCT_POSITION,              //!< position controller, positions of axes are controlled independently  (not implemented in %SDH firmwares up to and including 0.0.2.5)
 
-        eCT_DIMENSION         //!< Endmarker and dimension
-    };
+    eCT_DIMENSION         //!< Endmarker and dimension
+  };
 
 
-    //! An enum for all possible %SDH internal velocity profile types
-    enum eVelocityProfile
-    {
-        eVP_INVALID = -1,  //!< not a valid velocity profile, used to make #SDH::cSDHSerial::vp() read the velocity profile from the %SDH firmware
-        eVP_SIN_SQUARE,    //!< sin square velocity profile
-        eVP_RAMP,          //!< ramp velocity profile
+  //! An enum for all possible %SDH internal velocity profile types
+  enum eVelocityProfile
+  {
+    eVP_INVALID = -1,  //!< not a valid velocity profile, used to make #SDH::cSDHSerial::vp() read the velocity profile from the %SDH firmware
+    eVP_SIN_SQUARE,    //!< sin square velocity profile
+    eVP_RAMP,          //!< ramp velocity profile
 
-        eVP_DIMENSION      //!< endmarker and dimension
-    };
+    eVP_DIMENSION      //!< endmarker and dimension
+  };
 
-    //-----------------------------------------------------------------
-    /*!
-      Constructor of cSDHBase class, initilize internal variables and settings
+  //-----------------------------------------------------------------
+  /*!
+    Constructor of cSDHBase class, initilize internal variables and settings
 
-       \param debug_level : debug level of the created object.
-                            If the \a debug_level of an object is > 0 then
-                            it will output debug messages.
-       - (Subclasses of cSDHBase like cSDH or cSDHSerial use additional settings, see there.)
+     \param debug_level : debug level of the created object.
+                          If the \a debug_level of an object is > 0 then
+                          it will output debug messages.
+     - (Subclasses of cSDHBase like cSDH or cSDHSerial use additional settings, see there.)
 
-    */
-    cSDHBase( int debug_level );
-
-
-    //-----------------------------------------------------------------
-    /*!
-      virtual destructor to make compiler happy
-    */
-    virtual ~cSDHBase()
-    {}
+  */
+  cSDHBase(int debug_level);
 
 
-    //! Check if \a index is in [0 .. \a maxindex-1] or All. Throw a cSDHErrorInvalidParameter exception if not.
-    void CheckIndex( int index, int maxindex, char const* name="" )
-        throw (cSDHErrorInvalidParameter*);
+  //-----------------------------------------------------------------
+  /*!
+    virtual destructor to make compiler happy
+  */
+  virtual ~cSDHBase()
+  {}
 
 
-    //! Check if \a value is in [\a minvalue .. \a maxvalue]. Throw a cSDHErrorInvalidParameter exception if not.
-    void CheckRange( double value, double minvalue, double maxvalue, char const* name="" )
-        throw (cSDHErrorInvalidParameter*);
+  //! Check if \a index is in [0 .. \a maxindex-1] or All. Throw a cSDHErrorInvalidParameter exception if not.
+  void CheckIndex(int index, int maxindex, char const* name = "")
+  throw (cSDHErrorInvalidParameter*);
 
 
-    //! Check if any value[i] in array \a values is in [\a minvalue[i] .. \a maxvalue[i]]. Throw a cSDHErrorInvalidParameter exception if not.
-    void CheckRange( double* values, double* minvalues, double* maxvalues, char const* name="" )
-        throw (cSDHErrorInvalidParameter*);
+  //! Check if \a value is in [\a minvalue .. \a maxvalue]. Throw a cSDHErrorInvalidParameter exception if not.
+  void CheckRange(double value, double minvalue, double maxvalue, char const* name = "")
+  throw (cSDHErrorInvalidParameter*);
 
 
-    //! Return a ptr to a (static) string describing error code \a error_code
-    static char const* GetStringFromErrorCode( eErrorCode error_code );
+  //! Check if any value[i] in array \a values is in [\a minvalue[i] .. \a maxvalue[i]]. Throw a cSDHErrorInvalidParameter exception if not.
+  void CheckRange(double* values, double* minvalues, double* maxvalues, char const* name = "")
+  throw (cSDHErrorInvalidParameter*);
 
 
-    //! Return a ptr to a (static) string describing grasp id \a grasp_id
-    static char const* GetStringFromGraspId( eGraspId grasp_id );
+  //! Return a ptr to a (static) string describing error code \a error_code
+  static char const* GetStringFromErrorCode(eErrorCode error_code);
 
 
-    //! Return a ptr to a (static) string describing controller type \a controller_Type
-    static char const* GetStringFromControllerType( eControllerType controller_type );
+  //! Return a ptr to a (static) string describing grasp id \a grasp_id
+  static char const* GetStringFromGraspId(eGraspId grasp_id);
 
 
-    //! Return the number of axes of the %SDH
-    int GetNumberOfAxes( void );
+  //! Return a ptr to a (static) string describing controller type \a controller_Type
+  static char const* GetStringFromControllerType(eControllerType controller_type);
 
 
-    //! Return the number of fingers of the %SDH
-    int GetNumberOfFingers( void );
+  //! Return the number of axes of the %SDH
+  int GetNumberOfAxes(void);
 
 
-    //! Return the number of temperature sensors of the %SDH
-    int GetNumberOfTemperatureSensors( void );
+  //! Return the number of fingers of the %SDH
+  int GetNumberOfFingers(void);
 
 
-    //! Return the last known state of the %SDH firmware
-    eErrorCode GetFirmwareState( void );
+  //! Return the number of temperature sensors of the %SDH
+  int GetNumberOfTemperatureSensors(void);
 
 
-    //! Return the #eps value
-    double GetEps( void );
+  //! Return the last known state of the %SDH firmware
+  eErrorCode GetFirmwareState(void);
 
 
-    //! Return simple vector of number of axes epsilon values
-    cSimpleVector const & GetEpsVector( void );
+  //! Return the #eps value
+  double GetEps(void);
 
 
-    //! Return true if connection to %SDH firmware/hardware is open
-    virtual bool IsOpen( void ) = 0;
+  //! Return simple vector of number of axes epsilon values
+  cSimpleVector const & GetEpsVector(void);
 
-    //! change the stream to use for debug messages
-    virtual void SetDebugOutput( std::ostream* debuglog )
-    {
-        cdbg.SetOutput( debuglog );
-    }
+
+  //! Return true if connection to %SDH firmware/hardware is open
+  virtual bool IsOpen(void) = 0;
+
+  //! change the stream to use for debug messages
+  virtual void SetDebugOutput(std::ostream* debuglog)
+  {
+    cdbg.SetOutput(debuglog);
+  }
 protected:
-    //! debug stream to print colored debug messages
-    cDBG cdbg;
+  //! debug stream to print colored debug messages
+  cDBG cdbg;
 
-    //! debug level of this object
-    int debug_level;
+  //! debug level of this object
+  int debug_level;
 
-    //! A mapping from #eErrorCode error code enums to strings with human readable error messages
-    static char const* firmware_error_codes[];
-
-
-    //! A mapping from #eGraspId grasp id enums to strings with human readable grasp id names
-    static char const* grasp_id_name[];
+  //! A mapping from #eErrorCode error code enums to strings with human readable error messages
+  static char const* firmware_error_codes[];
 
 
-    //! A mapping from #eControllerType controller type enums to strings with human readable controller type names
-    static char const* controller_type_name[];
-    //---------------------
+  //! A mapping from #eGraspId grasp id enums to strings with human readable grasp id names
+  static char const* grasp_id_name[];
 
-    //! The number of axes
-    int NUMBER_OF_AXES;
 
-    //! The number of fingers
-    int NUMBER_OF_FINGERS;
+  //! A mapping from #eControllerType controller type enums to strings with human readable controller type names
+  static char const* controller_type_name[];
+  //---------------------
 
-    //! The number of temperature sensors
-    int NUMBER_OF_TEMPERATURE_SENSORS;
+  //! The number of axes
+  int NUMBER_OF_AXES;
 
-    //! Bit field with the bits for all axes set
-    int all_axes_used;
+  //! The number of fingers
+  int NUMBER_OF_FINGERS;
 
-    //! the last known state of the %SDH firmware
-    eErrorCode firmware_state;
+  //! The number of temperature sensors
+  int NUMBER_OF_TEMPERATURE_SENSORS;
 
-    /*!
-      \brief epsilon value (max absolute deviation of reported values from actual hardware values)
-      (needed since %SDH firmware limits number of digits reported)
-    */
-    double eps;
+  //! Bit field with the bits for all axes set
+  int all_axes_used;
 
-    //! simple vector of 7 epsilon values
-    cSimpleVector eps_v;
+  //! the last known state of the %SDH firmware
+  eErrorCode firmware_state;
 
-    //! simple vector of 7 0 values ???
-    //cSimpleVector zeros_v;
+  /*!
+    \brief epsilon value (max absolute deviation of reported values from actual hardware values)
+    (needed since %SDH firmware limits number of digits reported)
+  */
+  double eps;
 
-    //! simple vector of 7 1 values ???
-    //cSimpleVector ones_v;
+  //! simple vector of 7 epsilon values
+  cSimpleVector eps_v;
 
-    //! Minimum allowed axis angles (in internal units (degrees))
-    cSimpleVector min_angle_v;
+  //! simple vector of 7 0 values ???
+  //cSimpleVector zeros_v;
 
-    //! Maximum allowed axis angles (in internal units (degrees))
-    cSimpleVector max_angle_v;
+  //! simple vector of 7 1 values ???
+  //cSimpleVector ones_v;
+
+  //! Minimum allowed axis angles (in internal units (degrees))
+  cSimpleVector min_angle_v;
+
+  //! Maximum allowed axis angles (in internal units (degrees))
+  cSimpleVector max_angle_v;
 
 };
 

--- a/schunk_sdh/common/include/schunk_sdh/sdhexception.h
+++ b/schunk_sdh/common/include/schunk_sdh/sdhexception.h
@@ -79,7 +79,8 @@ class VCC_EXPORT cMsg
 protected:
 
   //! anonymous enum instead of define macros
-  enum {
+  enum
+  {
     eMAX_MSG = 512 //!< maximum length in bytes of a message to store
   };
 
@@ -91,11 +92,11 @@ public:
 
 
   //! Copy constructor, copy message content of other object to this object
-  cMsg( cMsg const & other );
+  cMsg(cMsg const & other);
 
 
   //! Constructor with printf like format, argument parameters
-  cMsg( char const* fmt, ... ) SDH__attribute__((format (printf, 2, 3)));
+  cMsg(char const* fmt, ...) SDH__attribute__((format(printf, 2, 3)));
 
   /*
     Remark:
@@ -190,7 +191,7 @@ public:
       \endcode
 
   */
-  cSDHLibraryException( char const * _type, cMsg const & _msg );
+  cSDHLibraryException(char const * _type, cMsg const & _msg);
 
   /*!
       Return the #msg member
@@ -206,12 +207,12 @@ public:
 class VCC_EXPORT cSDHErrorCommunication: public cSDHLibraryException
 {
 public:
-  cSDHErrorCommunication( cMsg const & _msg )
-    : cSDHLibraryException( "cSDHErrorCommunication", _msg )
+  cSDHErrorCommunication(cMsg const & _msg)
+    : cSDHLibraryException("cSDHErrorCommunication", _msg)
   {}
 
-  cSDHErrorCommunication( char const* _type, cMsg const & _msg )
-      : cSDHLibraryException( _type, _msg )
+  cSDHErrorCommunication(char const* _type, cMsg const & _msg)
+    : cSDHLibraryException(_type, _msg)
   {}
 };
 //-----------------------------------------------------------------

--- a/schunk_sdh/common/include/schunk_sdh/sdhserial.h
+++ b/schunk_sdh/common/include/schunk_sdh/sdhserial.h
@@ -90,839 +90,839 @@ struct sSDHBinaryResponse;
 */
 class VCC_EXPORT cSDHSerial : public cSDHBase
 {
-    friend struct sSDHBinaryRequest;
-    friend struct sSDHBinaryResponse;
+  friend struct sSDHBinaryRequest;
+  friend struct sSDHBinaryResponse;
 
 protected:
-    /*!
-        \brief additional time in seconds to wait for sequential execution of m
-         command (as these are always executed non-sequentially by the
-         %SDH firmware
-    */
-    double m_sequtime;
+  /*!
+      \brief additional time in seconds to wait for sequential execution of m
+       command (as these are always executed non-sequentially by the
+       %SDH firmware
+  */
+  double m_sequtime;
 
-    //! String to use as "End Of Line" marker when sending to %SDH
-    char const* EOL;
+  //! String to use as "End Of Line" marker when sending to %SDH
+  char const* EOL;
 
-    //! The communication object to the serial device (RS232 port or ESD CAN net)
-    cSerialBase* com;
+  //! The communication object to the serial device (RS232 port or ESD CAN net)
+  cSerialBase* com;
 
 
-    //! Space for the replies from the %SDH
-    cSimpleStringList reply;
+  //! Space for the replies from the %SDH
+  cSimpleStringList reply;
 
-    //! number of remaining reply lines of a previous (non-sequential) command
-    int nb_lines_to_ignore;
+  //! number of remaining reply lines of a previous (non-sequential) command
+  int nb_lines_to_ignore;
 
 public:
-    //#################################################################
-    /*!
-      \anchor sdhlibrary_cpp_csdhserial_internal
-       \name   Internal methods
+  //#################################################################
+  /*!
+    \anchor sdhlibrary_cpp_csdhserial_internal
+     \name   Internal methods
 
-       @{
-    */
+     @{
+  */
 
-    //-----------------------------------------------------------------
-    /*!
-      \brief Constructor of cSDHSerial.
+  //-----------------------------------------------------------------
+  /*!
+    \brief Constructor of cSDHSerial.
 
-       \param _debug_level : debug level of the created object.
-                             If the \a debug_level of an object is > 0 then
-                             it will output debug messages.
-                             (forwared to constructor of base class)
-       <hr>
-    */
-    cSDHSerial( int _debug_level=0 );
+     \param _debug_level : debug level of the created object.
+                           If the \a debug_level of an object is > 0 then
+                           it will output debug messages.
+                           (forwared to constructor of base class)
+     <hr>
+  */
+  cSDHSerial(int _debug_level = 0);
 
 
-    //-----------------------------------------------------------------
-    /*!
-      virtual destructor to make compiler happy
-    */
-    virtual ~cSDHSerial()
-    {}
+  //-----------------------------------------------------------------
+  /*!
+    virtual destructor to make compiler happy
+  */
+  virtual ~cSDHSerial()
+  {}
 
 
-    //-----------------------------------------------------------------
-    /*!
-       Open the serial device and check connection to %SDH by querying
-       the %SDH firmware version
-
-       \param _com - ptr to the serial device to use
-
-       This may throw an exception on failure.
-
-       The serial port on the PC-side can be opened successfully even
-       if no %SDH is attached. Therefore this routine tries to read the
-       %SDH firmware version with a 1s timeout after the port is
-       opened. If the %SDH does not reply in time then
-       - an error message is printed on stderr,
-       - the port is closed
-       - and a cSerialBaseException* exception is thrown.
-
-       <hr>
-    */
-    void Open( cSerialBase* _com )
-        throw(cSDHLibraryException*);
-
-
-    /*!
-        Close connection to serial port.
-    */
-    void Close()
-        throw (cSDHLibraryException*);
-
-
-    /*!
-        Return true if connection to %SDH firmware/hardware is open
-    */
-    virtual bool IsOpen( void );
-
-
-    /*!
-        Send command string s+EOL to com and read reply according to nb_lines.
-
-        If nb_lines == All then reply lines are read until a line
-        without "@" prefix is found.
-        If nb_lines != All it is the number of lines to read.
-
-        firmware_state is set according to reply (if read)
-        nb_lines_total contains the total number of lines replied for
-        the s command. If fewer lines are read then
-        nb_lines_total-nb_lines will be remembered to be ignored
-        before the next command can be sent.
-
-        Return a list of all read lines of the reply from the %SDH hardware.
-    */
-    void Send( char const* s, int nb_lines=All, int nb_lines_total=All, int max_retries=3 )
-        throw( cSDHLibraryException* );
-
-
-    /*!
-        Try to extract the state of the %SDH firmware from the last reply
-    */
-    void ExtractFirmwareState()
-        throw( cSDHErrorCommunication* );
-
-
-    /*!
-        Return duration of the execution of a %SDH command as reported by line
-    */
-    double GetDuration( char* line )
-        throw( cSDHErrorCommunication* );
-
-
-    /*!
-    Send get_duration command. Returns the calculated duration of the
-    currently configured movement (target positions, velocities,
-    accelerations and velocity profile.
-
-    return the expected duration of the execution of the command in seconds
-    */
-    double get_duration( void );
-
-    /*!
-      Read all pending lines from %SDH to resync execution of PC and %SDH.
-     */
-    void Sync( )
-        throw( cSDHErrorCommunication* );
-
-    /*!
-      Read all available bytes within \a timeout_s seconds to resync execution of PC and %SDH.
-     */
-    void BinarySync( double timeout_s = 0.5 )
-        throw( cSDHErrorCommunication* );
-
-    /*!
-      Read an unknown number of lines from %SDH to resync execution of PC and %SDH.
-     */
-    void SyncUnknown( )
-        throw( cSDHErrorCommunication* );
-
-
-    /*!
-        Get/Set values.
-
-        - If axis is All and value is None then a
-          NUMBER_OF_AXES-list of the actual values
-          read from the %SDH is returned
-        - If axis is a single number and value is None then the
-          actual value for that axis is read from the %SDH and is returned
-        - If axis and value are single numbers then that value
-          is set for that axis and returned.
-        - If axis is All and value is a NUMBER_OF_AXES-vector then all axes
-          values are set accordingly, a NUMBER_OF_AXES-list is returned.
-    */
-    cSimpleVector AxisCommand( char const* command, int axis=All, double* value=NULL )
-        throw (cSDHLibraryException*);
-
-    /*!
-        Get/Set values using binary mode.
-
-        - If axis is All and value is None then a
-          NUMBER_OF_AXES-list of the actual values
-          read from the %SDH is returned
-        - If axis is a single number and value is None then the
-          actual value for that axis is read from the %SDH and is returned
-        - If axis and value are single numbers then that value
-          is set for that axis and returned.
-        - If axis is All and value is a NUMBER_OF_AXES-vector then all axes
-          values are set accordingly, a NUMBER_OF_AXES-list is returned.
-    */
-    cSimpleVector BinaryAxisCommand( eCommandCode command, int axis=All, double* value=NULL )
-        throw (cSDHLibraryException*);
-
-
-    //  end of doxygen name group sdhlibrary_cpp_csdhserial_internal
-    //! @}
-    //################################################################
-
-    //################################################################
-    /*!
-      \anchor sdhlibrary_cpp_csdhserial_setup_commands
-       \name   Setup and configuration methods
-       @{
-    */
-
-    //-----------------------------------------------------------------
-    /*!
-        Get/Set PID controller parameters
-
-        - axis must be a single number: the index of the axis to get/set
-        - If p,i,d are None then a list of the actually
-          set PID controller parameters of the axis is returned
-        - If p,i,d are numbers then the PID controller parameters for
-          that axis are set (and returned).
-
-        \bug With SDH firmware 0.0.2.9 pid() might not respond
-             pid values correctly in case these were changed before.
-             With SDH firmwares 0.0.2.10 and newer this now works.
-             <br><b>=> Resolved in SDH firmware 0.0.2.10</b>
-    */
-    cSimpleVector pid( int axis, double* p=NULL, double* i=NULL, double* d=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Get/Set kv parameter
-
-        - If axis is All and kv is None then a
-          NUMBER_OF_AXES-list of the actually set kv parameters is returned
-        - If axis is a single number and kv is None then the
-          kv parameter for that axis is returned.
-        - If axis and kv are single numbers then the kv parameter
-          for that axis is set (and returned).
-        - If axis is All and kv is a NUMBER_OF_AXES-vector then all axes
-          kv parameters are set accordingly, NUMBER_OF_AXES-list is returned.
-
-        \bug With SDH firmware 0.0.2.9 kv() might not respond
-             kv value correctly in case it was changed before.
-             With SDH firmwares 0.0.2.10 and newer this now works.
-             <br><b>=> Resolved in SDH firmware 0.0.2.10</b>
-    */
-    cSimpleVector kv( int axis=All, double* kv=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Get/Set actual motor current limit for m command
-
-        - If axis is All and limit is None then a NUMBER_OF_AXES-list
-          of the actually set motor current limits is returned
-        - If axis is a single number and limit is None then the
-          motor current limit for that axis is returned.
-        - If axis and limit are single numbers then the motor current limit
-          for that axis is set (and returned).
-        - If axis is All and limit is a NUMBER_OF_AXES-vector then
-          all axes motor current limits are set accordingly, the NUMBER_OF_AXES-list is returned.
-    */
-    cSimpleVector ilim( int axis=All, double* limit=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Get/Set actual power state
-
-        - If axis is All and flag is None then a NUMBER_OF_AXES-list
-          of the actually set power states is returned
-        - If axis is a single number and flag is None then the
-          power state for that axis is returned.
-        - If axis is a single number and flag is a single number or a
-          boolean value then the power state
-          for that axis is set (and returned).
-        - If axis is All and flag is a NUMBER_OF_AXES-vector then all axes
-          power states are set accordingly, the NUMBER_OF_AXES-list is returned.
-        - If axis is All and flag is a a single number or a boolean
-          value then all axes power states are set to that value, the
-          NUMBER_OF_AXES-list is returned.
-    */
-    cSimpleVector power( int axis=All, double* flag=NULL )
-        throw (cSDHLibraryException*);
-
-    //  end of doxygen name group sdhlibrary_cpp_csdhserial_setup_commands
-    //! @}
-    //#################################################################
-
-
-    //#################################################################
-    /*!
-      \anchor sdhlibrary_cpp_csdhserial_misc_commands
-       \name   Misc. methods
-       @{
-    */
-
-    //-----------------------------------------------------------------
-    /*!
-        Enable/disable SCHUNK demo
-    */
-    void demo( bool onoff );
-
-    //-----------------------------------------------------------------
-    /*!
-        Set named property
-
-        Valid propnames are:
-        - "user_errors"
-        - "terminal"
-        - "debug"
-    */
-    int property( char const* propname, int value );
-
-    //-----------------------------------------------------------------
-    /*!
-    */
-    int user_errors( int value );
-
-    //-----------------------------------------------------------------
-    /*!
-    */
-    int terminal( int value );
-
-    //-----------------------------------------------------------------
-    /*!
-    */
-    int debug( int value );
-
-    //-----------------------------------------------------------------
-
-    //  end of doxygen name group sdhlibrary_cpp_csdhserial_misc_commands
-    //! @}
-    //#################################################################
-
-    //#################################################################
-    /*!
-      \anchor sdhlibrary_cpp_csdhserial_movement_commands
-       \name   Movement methods
-       @{
-    */
-
-    //-----------------------------------------------------------------
-    /*!
-        Get/Set target velocity. (NOT the actual velocity!)
-
-        The default velocity is 40 deg/s for axes 0-6 in eCT_POSE controller type.
-        The default velocity is 0.0 deg/s for axes 0-6 in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller types.
-
-        - If axis is All and velocity is None then a NUMBER_OF_AXES-list
-          of the actually set target velocities is returned
-        - If axis is a single number and velocity is None then the
-          target velocity for that axis is returned.
-        - If axis and velocity are single numbers then the target
-          velocity for that axis is set (and returned).
-        - If axis is All and velocity is a NUMBER_OF_AXES-vector
-          then all axes target velocities are set accordingly, the NUMBER_OF_AXES-list
-          is returned.
-
-        Velocities are set/reported in degrees per second.
-
-        \bug With %SDH firmware < 0.0.1.0 axis 0 can go no faster than 14 deg/s
-        <br><b>=> Resolved in %SDH firmware 0.0.1.0</b>
-
-
-    */
-    cSimpleVector v( int axis=All, double* velocity=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Set target velocity and get actual velocity!)
-
-        The default velocity is 40 deg/s for axes 0-6 in eCT_POSE controller type.
-        The default velocity is 0.0 deg/s for axes 0-6 in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller types.
-
-        - If axis is All and velocity is None then a NUMBER_OF_AXES-list
-          of the actual velocities is returned
-        - If axis is a single number and velocity is None then the
-          actual velocity for that axis is returned.
-        - If axis and velocity are single numbers then the target
-          velocity for that axis is set and the actual velocity is returned.
-        - If axis is All and velocity is a NUMBER_OF_AXES-vector
-          then all axes target velocities are set accordingly, the NUMBER_OF_AXES-list
-          of actual velocities is returned.
-
-        Velocities are set/reported in degrees per second.
-
-        \bug With %SDH firmware < 0.0.1.0 axis 0 can go no faster than 14 deg/s
-        <br><b>=> Resolved in %SDH firmware 0.0.1.0</b>
-    */
-    cSimpleVector tvav( int axis=All, double* velocity=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Get velocity limits.
-
-        - If axis is All then a NUMBER_OF_AXES-list
-          of the velocity limits is returned
-        - If axis is a single number then the
-          velocity limit for that axis is returned.
-
-        dummy parameter is just needed to make this function have the
-        same signature as e.g. v(), so it can be used as a function
-        pointer.
-
-        Velocity limits are reported in degrees per second.
-    */
-    cSimpleVector vlim( int axis=All, double* dummy=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Get acceleration limits.
-
-        - If axis is All then a NUMBER_OF_AXES-list
-          of the acceleration limits is returned
-        - If axis is a single number then the
-          acceleration limit for that axis is returned.
-
-        dummy parameter is just needed to make this function have the
-        same signature as e.g. v(), so it can be used as a function
-        pointer.
-
-        Acceleration limits are reported in degrees per (second*second).
-    */
-    cSimpleVector alim( int axis=All, double* dummy=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Get/Set target acceleration for axis. (NOT the actual acceleration!)
-
-        - If axis is All and acceleration is None then a NUMBER_OF_AXES-list
-          of the actually set target accelerations is returned
-        - If axis is a single number and acceleration is None then the
-          target acceleration for that axis is returned.
-        - If axis and acceleration are single numbers then the target
-          acceleration for that axis is set (and returned).
-        - If axis is All and acceleration is a NUMBER_OF_AXES-vector
-          then all axes target accelerations are set accordingly, the NUMBER_OF_AXES-list
-          is returned.
-
-        Accelerations are set/reported in degrees per second squared.
-    */
-    cSimpleVector a( int axis=All, double* acceleration=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Get/Set target angle for axis. (NOT the actual angle!)
-
-        - If axis is All and angle is None then a NUMBER_OF_AXES-list
-          of the actually set target angles is returned
-        - If axis is a single number and angle is None then the
-          target angle for that axis is returned.
-        - If axis and angle are single numbers then the target
-          angle for that axis is set (and returned).
-        - If axis is All and angle is a NUMBER_OF_AXES-vector
-          then all axes target angles are set accordingly, the NUMBER_OF_AXES-list
-          is returned.
-
-        Angles are set/reported in degrees.
-    */
-    cSimpleVector p( int axis=All, double* angle=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Set target angle and get actual angle for axis.
-
-        - If axis is All and angle is None then a NUMBER_OF_AXES-list
-          of the actual angles is returned
-        - If axis is a single number and angle is None then the
-          actual angle for that axis is returned.
-        - If axis and angle are single numbers then the target
-          angle for that axis is set and the actual angles are returned.
-        - If axis is All and angle is a NUMBER_OF_AXES-vector
-          then all axes target angles are set accordingly, the NUMBER_OF_AXES-list
-          of actual angles is returned.
-
-        Angles are set/reported in degrees.
-    */
-    cSimpleVector tpap( int axis=All, double* angle=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Send move command. Moves all enabled axes to their previously
-        set target angle. The movement duration is determined by
-        that axis that takes longest with its actually set velocity.
-        The actual velocity of all other axes is set so that all axes
-        begin and end their movements synchronously.
-
-        If sequ is True then wait until %SDH hardware fully executed
-        the command.  Else return immediately and do not wait until %SDH
-        hardware fully executed the command.
-
-        return the expected duration of the execution of the command in seconds
-    */
-    double m( bool sequ )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Stop sdh.
-
-        Will NOT interrupt a previous "selgrip" or "grip" command, only an "m" command!
-    */
-    void stop( void )
-        throw(cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get/set velocity profile.
-
-        If \a velocity_profile is < 0 then the actually set velocity profile is
-        read from the %SDH firmware and returned. Else the given velocity_profile type
-        is set in the %SDH firmware if valid.
-    */
-    eVelocityProfile vp( eVelocityProfile velocity_profile = eVP_INVALID )
-        throw (cSDHLibraryException*);
-
-
-    //-----------------------------------------------------------------
-    /*!
-        Get/set controller type.
-
-        If \a controller is < 0 then the actually set controller is
-        read from the %SDH firmware and returned. Else the given controller type
-        is set in the %SDH firmware if valid.
-    */
-    eControllerType con( eControllerType controller )
-        throw (cSDHLibraryException*);
-
-    //  end of doxygen name group sdhlibrary_cpp_csdhserial_movement_commands
-    //! @}
-    //#################################################################
-
-    //#################################################################
-    /*!
-      \anchor sdhlibrary_cpp_csdhserial_diagnosis_commands
-       \name   Diagnostic and identification methods
-       @{
-    */
-
-    //-----------------------------------------------------------------
-    /*!
-        Get actual angle/s of axis/axes.
-
-        - If axis is All then a NUMBER_OF_AXES-vector of the actual
-          axis angles is returned
-        - If axis is a single number then the
-          actual angle of that axis is returned.
-
-        Angles are reported in degrees.
-
-        \remark
-          \a dummy ptr is never used, but needed nonetheless to make
+  //-----------------------------------------------------------------
+  /*!
+     Open the serial device and check connection to %SDH by querying
+     the %SDH firmware version
+
+     \param _com - ptr to the serial device to use
+
+     This may throw an exception on failure.
+
+     The serial port on the PC-side can be opened successfully even
+     if no %SDH is attached. Therefore this routine tries to read the
+     %SDH firmware version with a 1s timeout after the port is
+     opened. If the %SDH does not reply in time then
+     - an error message is printed on stderr,
+     - the port is closed
+     - and a cSerialBaseException* exception is thrown.
+
+     <hr>
+  */
+  void Open(cSerialBase* _com)
+  throw(cSDHLibraryException*);
+
+
+  /*!
+      Close connection to serial port.
+  */
+  void Close()
+  throw (cSDHLibraryException*);
+
+
+  /*!
+      Return true if connection to %SDH firmware/hardware is open
+  */
+  virtual bool IsOpen(void);
+
+
+  /*!
+      Send command string s+EOL to com and read reply according to nb_lines.
+
+      If nb_lines == All then reply lines are read until a line
+      without "@" prefix is found.
+      If nb_lines != All it is the number of lines to read.
+
+      firmware_state is set according to reply (if read)
+      nb_lines_total contains the total number of lines replied for
+      the s command. If fewer lines are read then
+      nb_lines_total-nb_lines will be remembered to be ignored
+      before the next command can be sent.
+
+      Return a list of all read lines of the reply from the %SDH hardware.
+  */
+  void Send(char const* s, int nb_lines = All, int nb_lines_total = All, int max_retries = 3)
+  throw(cSDHLibraryException*);
+
+
+  /*!
+      Try to extract the state of the %SDH firmware from the last reply
+  */
+  void ExtractFirmwareState()
+  throw(cSDHErrorCommunication*);
+
+
+  /*!
+      Return duration of the execution of a %SDH command as reported by line
+  */
+  double GetDuration(char* line)
+  throw(cSDHErrorCommunication*);
+
+
+  /*!
+  Send get_duration command. Returns the calculated duration of the
+  currently configured movement (target positions, velocities,
+  accelerations and velocity profile.
+
+  return the expected duration of the execution of the command in seconds
+  */
+  double get_duration(void);
+
+  /*!
+    Read all pending lines from %SDH to resync execution of PC and %SDH.
+   */
+  void Sync()
+  throw(cSDHErrorCommunication*);
+
+  /*!
+    Read all available bytes within \a timeout_s seconds to resync execution of PC and %SDH.
+   */
+  void BinarySync(double timeout_s = 0.5)
+  throw(cSDHErrorCommunication*);
+
+  /*!
+    Read an unknown number of lines from %SDH to resync execution of PC and %SDH.
+   */
+  void SyncUnknown()
+  throw(cSDHErrorCommunication*);
+
+
+  /*!
+      Get/Set values.
+
+      - If axis is All and value is None then a
+        NUMBER_OF_AXES-list of the actual values
+        read from the %SDH is returned
+      - If axis is a single number and value is None then the
+        actual value for that axis is read from the %SDH and is returned
+      - If axis and value are single numbers then that value
+        is set for that axis and returned.
+      - If axis is All and value is a NUMBER_OF_AXES-vector then all axes
+        values are set accordingly, a NUMBER_OF_AXES-list is returned.
+  */
+  cSimpleVector AxisCommand(char const* command, int axis = All, double* value = NULL)
+  throw (cSDHLibraryException*);
+
+  /*!
+      Get/Set values using binary mode.
+
+      - If axis is All and value is None then a
+        NUMBER_OF_AXES-list of the actual values
+        read from the %SDH is returned
+      - If axis is a single number and value is None then the
+        actual value for that axis is read from the %SDH and is returned
+      - If axis and value are single numbers then that value
+        is set for that axis and returned.
+      - If axis is All and value is a NUMBER_OF_AXES-vector then all axes
+        values are set accordingly, a NUMBER_OF_AXES-list is returned.
+  */
+  cSimpleVector BinaryAxisCommand(eCommandCode command, int axis = All, double* value = NULL)
+  throw (cSDHLibraryException*);
+
+
+  //  end of doxygen name group sdhlibrary_cpp_csdhserial_internal
+  //! @}
+  //################################################################
+
+  //################################################################
+  /*!
+    \anchor sdhlibrary_cpp_csdhserial_setup_commands
+     \name   Setup and configuration methods
+     @{
+  */
+
+  //-----------------------------------------------------------------
+  /*!
+      Get/Set PID controller parameters
+
+      - axis must be a single number: the index of the axis to get/set
+      - If p,i,d are None then a list of the actually
+        set PID controller parameters of the axis is returned
+      - If p,i,d are numbers then the PID controller parameters for
+        that axis are set (and returned).
+
+      \bug With SDH firmware 0.0.2.9 pid() might not respond
+           pid values correctly in case these were changed before.
+           With SDH firmwares 0.0.2.10 and newer this now works.
+           <br><b>=> Resolved in SDH firmware 0.0.2.10</b>
+  */
+  cSimpleVector pid(int axis, double* p = NULL, double* i = NULL, double* d = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Get/Set kv parameter
+
+      - If axis is All and kv is None then a
+        NUMBER_OF_AXES-list of the actually set kv parameters is returned
+      - If axis is a single number and kv is None then the
+        kv parameter for that axis is returned.
+      - If axis and kv are single numbers then the kv parameter
+        for that axis is set (and returned).
+      - If axis is All and kv is a NUMBER_OF_AXES-vector then all axes
+        kv parameters are set accordingly, NUMBER_OF_AXES-list is returned.
+
+      \bug With SDH firmware 0.0.2.9 kv() might not respond
+           kv value correctly in case it was changed before.
+           With SDH firmwares 0.0.2.10 and newer this now works.
+           <br><b>=> Resolved in SDH firmware 0.0.2.10</b>
+  */
+  cSimpleVector kv(int axis = All, double* kv = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Get/Set actual motor current limit for m command
+
+      - If axis is All and limit is None then a NUMBER_OF_AXES-list
+        of the actually set motor current limits is returned
+      - If axis is a single number and limit is None then the
+        motor current limit for that axis is returned.
+      - If axis and limit are single numbers then the motor current limit
+        for that axis is set (and returned).
+      - If axis is All and limit is a NUMBER_OF_AXES-vector then
+        all axes motor current limits are set accordingly, the NUMBER_OF_AXES-list is returned.
+  */
+  cSimpleVector ilim(int axis = All, double* limit = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Get/Set actual power state
+
+      - If axis is All and flag is None then a NUMBER_OF_AXES-list
+        of the actually set power states is returned
+      - If axis is a single number and flag is None then the
+        power state for that axis is returned.
+      - If axis is a single number and flag is a single number or a
+        boolean value then the power state
+        for that axis is set (and returned).
+      - If axis is All and flag is a NUMBER_OF_AXES-vector then all axes
+        power states are set accordingly, the NUMBER_OF_AXES-list is returned.
+      - If axis is All and flag is a a single number or a boolean
+        value then all axes power states are set to that value, the
+        NUMBER_OF_AXES-list is returned.
+  */
+  cSimpleVector power(int axis = All, double* flag = NULL)
+  throw (cSDHLibraryException*);
+
+  //  end of doxygen name group sdhlibrary_cpp_csdhserial_setup_commands
+  //! @}
+  //#################################################################
+
+
+  //#################################################################
+  /*!
+    \anchor sdhlibrary_cpp_csdhserial_misc_commands
+     \name   Misc. methods
+     @{
+  */
+
+  //-----------------------------------------------------------------
+  /*!
+      Enable/disable SCHUNK demo
+  */
+  void demo(bool onoff);
+
+  //-----------------------------------------------------------------
+  /*!
+      Set named property
+
+      Valid propnames are:
+      - "user_errors"
+      - "terminal"
+      - "debug"
+  */
+  int property(char const* propname, int value);
+
+  //-----------------------------------------------------------------
+  /*!
+  */
+  int user_errors(int value);
+
+  //-----------------------------------------------------------------
+  /*!
+  */
+  int terminal(int value);
+
+  //-----------------------------------------------------------------
+  /*!
+  */
+  int debug(int value);
+
+  //-----------------------------------------------------------------
+
+  //  end of doxygen name group sdhlibrary_cpp_csdhserial_misc_commands
+  //! @}
+  //#################################################################
+
+  //#################################################################
+  /*!
+    \anchor sdhlibrary_cpp_csdhserial_movement_commands
+     \name   Movement methods
+     @{
+  */
+
+  //-----------------------------------------------------------------
+  /*!
+      Get/Set target velocity. (NOT the actual velocity!)
+
+      The default velocity is 40 deg/s for axes 0-6 in eCT_POSE controller type.
+      The default velocity is 0.0 deg/s for axes 0-6 in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller types.
+
+      - If axis is All and velocity is None then a NUMBER_OF_AXES-list
+        of the actually set target velocities is returned
+      - If axis is a single number and velocity is None then the
+        target velocity for that axis is returned.
+      - If axis and velocity are single numbers then the target
+        velocity for that axis is set (and returned).
+      - If axis is All and velocity is a NUMBER_OF_AXES-vector
+        then all axes target velocities are set accordingly, the NUMBER_OF_AXES-list
+        is returned.
+
+      Velocities are set/reported in degrees per second.
+
+      \bug With %SDH firmware < 0.0.1.0 axis 0 can go no faster than 14 deg/s
+      <br><b>=> Resolved in %SDH firmware 0.0.1.0</b>
+
+
+  */
+  cSimpleVector v(int axis = All, double* velocity = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Set target velocity and get actual velocity!)
+
+      The default velocity is 40 deg/s for axes 0-6 in eCT_POSE controller type.
+      The default velocity is 0.0 deg/s for axes 0-6 in eCT_VELOCITY and eCT_VELOCITY_ACCELERATION controller types.
+
+      - If axis is All and velocity is None then a NUMBER_OF_AXES-list
+        of the actual velocities is returned
+      - If axis is a single number and velocity is None then the
+        actual velocity for that axis is returned.
+      - If axis and velocity are single numbers then the target
+        velocity for that axis is set and the actual velocity is returned.
+      - If axis is All and velocity is a NUMBER_OF_AXES-vector
+        then all axes target velocities are set accordingly, the NUMBER_OF_AXES-list
+        of actual velocities is returned.
+
+      Velocities are set/reported in degrees per second.
+
+      \bug With %SDH firmware < 0.0.1.0 axis 0 can go no faster than 14 deg/s
+      <br><b>=> Resolved in %SDH firmware 0.0.1.0</b>
+  */
+  cSimpleVector tvav(int axis = All, double* velocity = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Get velocity limits.
+
+      - If axis is All then a NUMBER_OF_AXES-list
+        of the velocity limits is returned
+      - If axis is a single number then the
+        velocity limit for that axis is returned.
+
+      dummy parameter is just needed to make this function have the
+      same signature as e.g. v(), so it can be used as a function
+      pointer.
+
+      Velocity limits are reported in degrees per second.
+  */
+  cSimpleVector vlim(int axis = All, double* dummy = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Get acceleration limits.
+
+      - If axis is All then a NUMBER_OF_AXES-list
+        of the acceleration limits is returned
+      - If axis is a single number then the
+        acceleration limit for that axis is returned.
+
+      dummy parameter is just needed to make this function have the
+      same signature as e.g. v(), so it can be used as a function
+      pointer.
+
+      Acceleration limits are reported in degrees per (second*second).
+  */
+  cSimpleVector alim(int axis = All, double* dummy = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Get/Set target acceleration for axis. (NOT the actual acceleration!)
+
+      - If axis is All and acceleration is None then a NUMBER_OF_AXES-list
+        of the actually set target accelerations is returned
+      - If axis is a single number and acceleration is None then the
+        target acceleration for that axis is returned.
+      - If axis and acceleration are single numbers then the target
+        acceleration for that axis is set (and returned).
+      - If axis is All and acceleration is a NUMBER_OF_AXES-vector
+        then all axes target accelerations are set accordingly, the NUMBER_OF_AXES-list
+        is returned.
+
+      Accelerations are set/reported in degrees per second squared.
+  */
+  cSimpleVector a(int axis = All, double* acceleration = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Get/Set target angle for axis. (NOT the actual angle!)
+
+      - If axis is All and angle is None then a NUMBER_OF_AXES-list
+        of the actually set target angles is returned
+      - If axis is a single number and angle is None then the
+        target angle for that axis is returned.
+      - If axis and angle are single numbers then the target
+        angle for that axis is set (and returned).
+      - If axis is All and angle is a NUMBER_OF_AXES-vector
+        then all axes target angles are set accordingly, the NUMBER_OF_AXES-list
+        is returned.
+
+      Angles are set/reported in degrees.
+  */
+  cSimpleVector p(int axis = All, double* angle = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Set target angle and get actual angle for axis.
+
+      - If axis is All and angle is None then a NUMBER_OF_AXES-list
+        of the actual angles is returned
+      - If axis is a single number and angle is None then the
+        actual angle for that axis is returned.
+      - If axis and angle are single numbers then the target
+        angle for that axis is set and the actual angles are returned.
+      - If axis is All and angle is a NUMBER_OF_AXES-vector
+        then all axes target angles are set accordingly, the NUMBER_OF_AXES-list
+        of actual angles is returned.
+
+      Angles are set/reported in degrees.
+  */
+  cSimpleVector tpap(int axis = All, double* angle = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Send move command. Moves all enabled axes to their previously
+      set target angle. The movement duration is determined by
+      that axis that takes longest with its actually set velocity.
+      The actual velocity of all other axes is set so that all axes
+      begin and end their movements synchronously.
+
+      If sequ is True then wait until %SDH hardware fully executed
+      the command.  Else return immediately and do not wait until %SDH
+      hardware fully executed the command.
+
+      return the expected duration of the execution of the command in seconds
+  */
+  double m(bool sequ)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Stop sdh.
+
+      Will NOT interrupt a previous "selgrip" or "grip" command, only an "m" command!
+  */
+  void stop(void)
+  throw(cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get/set velocity profile.
+
+      If \a velocity_profile is < 0 then the actually set velocity profile is
+      read from the %SDH firmware and returned. Else the given velocity_profile type
+      is set in the %SDH firmware if valid.
+  */
+  eVelocityProfile vp(eVelocityProfile velocity_profile = eVP_INVALID)
+  throw (cSDHLibraryException*);
+
+
+  //-----------------------------------------------------------------
+  /*!
+      Get/set controller type.
+
+      If \a controller is < 0 then the actually set controller is
+      read from the %SDH firmware and returned. Else the given controller type
+      is set in the %SDH firmware if valid.
+  */
+  eControllerType con(eControllerType controller)
+  throw (cSDHLibraryException*);
+
+  //  end of doxygen name group sdhlibrary_cpp_csdhserial_movement_commands
+  //! @}
+  //#################################################################
+
+  //#################################################################
+  /*!
+    \anchor sdhlibrary_cpp_csdhserial_diagnosis_commands
+     \name   Diagnostic and identification methods
+     @{
+  */
+
+  //-----------------------------------------------------------------
+  /*!
+      Get actual angle/s of axis/axes.
+
+      - If axis is All then a NUMBER_OF_AXES-vector of the actual
+        axis angles is returned
+      - If axis is a single number then the
+        actual angle of that axis is returned.
+
+      Angles are reported in degrees.
+
+      \remark
+        \a dummy ptr is never used, but needed nonetheless to make
+        the signature of the function the same as for the other
+        axis-access functions. This way a pointer to it can be used as
+        a pointer to the other functions, which is needed by the
+        generic cSDH::SetAxisValue and cSDH::GetAxisValue functions.
+  */
+  cSimpleVector pos(int axis = All, double* dummy = NULL)
+  throw (cSDHLibraryException*);
+
+  /*!
+      Save actual angle/s to non volatile memory. (Usefull for axes that dont have an absolute encoder)
+
+      - If value is None then an exception is thrown since
+        this is NOT usefull if any axis has an absolute encoder that
+        the LLC knows about since these positions will be invalidated at the next start
+      - If axis and value are single numbers then that axis is saved.
+      - If axis is All and value is a NUMBER_OF_AXES-vector
+        then all axes are saved if the corresponding value is 1.
+      - This will yield a E_RANGE_ERROR if any of the given values is not  0 or 1
+  */
+  //-----------------------------------------------------------------
+  cSimpleVector pos_save(int axis = All, double* value = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+
+  /*!
+      Do reference movements with selected axes. (Usefull for axes that dont have an absolute encoder)
+
+      each \a value must be either
+      - 0 : do not reference
+      - 1 : reference till mechanical block in positive direction
+      - 2 : reference till mechanical block in negative direction
+
+      - If \a axis and \a value are single numbers then that axis is referenced as requested
+      - If \a axis is All and \a value is a NUMBER_OF_AXES-vector
+        then all axes are referenced as requested.
+      - This will yield a E_RANGE_ERROR if any of the given values is not  0 or 1 or 2
+  */
+  cSimpleVector ref(int axis = All, double* value = NULL)
+  throw (cSDHLibraryException*);
+
+  //-----------------------------------------------------------------
+  /*!
+      Get actual angular velocity/s of axis/axes.
+
+      - If axis is All then a NUMBER_OF_AXES-vector of the actual
+        axis angular velocities is returned
+      - If axis is a single number then the
+        actual angular velocity of that axis is returned.
+
+      Angular velocities are reported in degrees/second.
+
+      \remark
+        \a dummy ptr is never used, but needed nonetheless to make
+        the signature of the function the same as for the other
+        axis-access functions. This way a pointer to it can be used as
+        a pointer to the other functions, which is needed by the
+        generic cSDH::SetAxisValue and cSDH::GetAxisValue functions.
+  */
+  cSimpleVector vel(int axis = All, double* dummy = NULL)
+  throw (cSDHLibraryException*);
+
+  /*!
+      Get current reference angular velocity/s of axis/axes.
+      The reference angular velocity is used by the eCT_VELOCITY_ACCELERATION controller type only.
+
+      - If axis is All then a NUMBER_OF_AXES-vector of the current
+        reference velocities is returned
+      - If axis is a single number then the
+        current reference angular velocity of that axis is returned.
+
+      Angular velocities are reported in degrees/second.
+
+      \remark
+        - \a dummy ptr is never used, but needed nonetheless to make
           the signature of the function the same as for the other
           axis-access functions. This way a pointer to it can be used as
           a pointer to the other functions, which is needed by the
           generic cSDH::SetAxisValue and cSDH::GetAxisValue functions.
-    */
-    cSimpleVector pos( int axis=All, double* dummy=NULL )
-        throw (cSDHLibraryException*);
-
-    /*!
-        Save actual angle/s to non volatile memory. (Usefull for axes that dont have an absolute encoder)
-
-        - If value is None then an exception is thrown since
-          this is NOT usefull if any axis has an absolute encoder that
-          the LLC knows about since these positions will be invalidated at the next start
-        - If axis and value are single numbers then that axis is saved.
-        - If axis is All and value is a NUMBER_OF_AXES-vector
-          then all axes are saved if the corresponding value is 1.
-        - This will yield a E_RANGE_ERROR if any of the given values is not  0 or 1
-    */
-    //-----------------------------------------------------------------
-    cSimpleVector pos_save( int axis=All, double* value=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-
-    /*!
-        Do reference movements with selected axes. (Usefull for axes that dont have an absolute encoder)
-
-        each \a value must be either
-        - 0 : do not reference
-        - 1 : reference till mechanical block in positive direction
-        - 2 : reference till mechanical block in negative direction
-
-        - If \a axis and \a value are single numbers then that axis is referenced as requested
-        - If \a axis is All and \a value is a NUMBER_OF_AXES-vector
-          then all axes are referenced as requested.
-        - This will yield a E_RANGE_ERROR if any of the given values is not  0 or 1 or 2
-    */
-    cSimpleVector ref( int axis=All, double* value=NULL )
-        throw (cSDHLibraryException*);
-
-    //-----------------------------------------------------------------
-    /*!
-        Get actual angular velocity/s of axis/axes.
-
-        - If axis is All then a NUMBER_OF_AXES-vector of the actual
-          axis angular velocities is returned
-        - If axis is a single number then the
-          actual angular velocity of that axis is returned.
-
-        Angular velocities are reported in degrees/second.
-
-        \remark
-          \a dummy ptr is never used, but needed nonetheless to make
-          the signature of the function the same as for the other
-          axis-access functions. This way a pointer to it can be used as
-          a pointer to the other functions, which is needed by the
-          generic cSDH::SetAxisValue and cSDH::GetAxisValue functions.
-    */
-    cSimpleVector vel( int axis=All, double* dummy=NULL )
-        throw (cSDHLibraryException*);
-
-    /*!
-        Get current reference angular velocity/s of axis/axes.
-        The reference angular velocity is used by the eCT_VELOCITY_ACCELERATION controller type only.
-
-        - If axis is All then a NUMBER_OF_AXES-vector of the current
-          reference velocities is returned
-        - If axis is a single number then the
-          current reference angular velocity of that axis is returned.
-
-        Angular velocities are reported in degrees/second.
-
-        \remark
-          - \a dummy ptr is never used, but needed nonetheless to make
-            the signature of the function the same as for the other
-            axis-access functions. This way a pointer to it can be used as
-            a pointer to the other functions, which is needed by the
-            generic cSDH::SetAxisValue and cSDH::GetAxisValue functions.
-          - the underlying rvel command of the %SDH firmware is not
-            available in %SDH firmwares prior to 0.0.2.6. For such hands
-            calling rvel will fail miserably.
-    */
-    cSimpleVector rvel( int axis, double* dummy=NULL )
-        throw (cSDHLibraryException*);
+        - the underlying rvel command of the %SDH firmware is not
+          available in %SDH firmwares prior to 0.0.2.6. For such hands
+          calling rvel will fail miserably.
+  */
+  cSimpleVector rvel(int axis, double* dummy = NULL)
+  throw (cSDHLibraryException*);
 
 
-    //-----------------------------------------------------------------
-    /*!
-        Get actual state/s of axis/axes.
+  //-----------------------------------------------------------------
+  /*!
+      Get actual state/s of axis/axes.
 
-        A state of 0 means "not moving" while 1 means "moving".
+      A state of 0 means "not moving" while 1 means "moving".
 
-        - If axis is All then a NUMBER_OF_AXES-vector of the actual
-          axis states is returned
-        - If axis is a single number then the
-          actual state of that axis is returned.
-    */
-    cSimpleVector state( int axis=All, double* dummy=NULL )
-        throw (cSDHLibraryException*);
+      - If axis is All then a NUMBER_OF_AXES-vector of the actual
+        axis states is returned
+      - If axis is a single number then the
+        actual state of that axis is returned.
+  */
+  cSimpleVector state(int axis = All, double* dummy = NULL)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Get actual temperatures of the axis motors
+  //-----------------------------------------------------------------
+  /*!
+      Get actual temperatures of the axis motors
 
-        Returns a list of the actual controller and driver temperature in degrees celsius.
+      Returns a list of the actual controller and driver temperature in degrees celsius.
 
-    */
-    cSimpleVector temp( void )
-        throw (cSDHLibraryException*);
+  */
+  cSimpleVector temp(void)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Get actual temperatures of the electronics, i.e. teh FPGA and the PCB.
-        (FPGA = Field Programmable Gate Array = the reprogrammable chip with the soft processors)
-        (PCB = Printed Circuit Board)
+  //-----------------------------------------------------------------
+  /*!
+      Get actual temperatures of the electronics, i.e. teh FPGA and the PCB.
+      (FPGA = Field Programmable Gate Array = the reprogrammable chip with the soft processors)
+      (PCB = Printed Circuit Board)
 
-        Returns a list of the actual controller and driver temperature in degrees celsius.
+      Returns a list of the actual controller and driver temperature in degrees celsius.
 
-    */
-    cSimpleVector temp_electronics( void )
-        throw (cSDHLibraryException*);
+  */
+  cSimpleVector temp_electronics(void)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Return version of %SDH firmware
+  //-----------------------------------------------------------------
+  /*!
+      Return version of %SDH firmware
 
-        \attention
-        The string returned is stored internally in this object and
-        might be overwritten by the next command to this object
-    */
-    char* ver( void )
-        throw (cSDHLibraryException*);
-    //-----------------------------------------------------------------
+      \attention
+      The string returned is stored internally in this object and
+      might be overwritten by the next command to this object
+  */
+  char* ver(void)
+  throw (cSDHLibraryException*);
+  //-----------------------------------------------------------------
 
-    /*!
-        Return date of %SDH firmware
+  /*!
+      Return date of %SDH firmware
 
-        \attention
-        The string returned is stored internally in this object and
-        might be overwritten by the next command to this object
-    */
-    char* ver_date( void )
-        throw (cSDHLibraryException*);
-    //-----------------------------------------------------------------
+      \attention
+      The string returned is stored internally in this object and
+      might be overwritten by the next command to this object
+  */
+  char* ver_date(void)
+  throw (cSDHLibraryException*);
+  //-----------------------------------------------------------------
 
-    /*!
-        Return id of %SDH
+  /*!
+      Return id of %SDH
 
-        \attention
-        The string returned is stored internally in this object and
-        might be overwritten by the next command to this object
-    */
-    char* id( void )
-        throw (cSDHLibraryException*);
+      \attention
+      The string returned is stored internally in this object and
+      might be overwritten by the next command to this object
+  */
+  char* id(void)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Return sn of %SDH
+  //-----------------------------------------------------------------
+  /*!
+      Return sn of %SDH
 
-        \attention
-        The string returned is stored internally in this object and
-        might be overwritten by the next command to this object
-    */
-    char* sn( void )
-        throw (cSDHLibraryException*);
+      \attention
+      The string returned is stored internally in this object and
+      might be overwritten by the next command to this object
+  */
+  char* sn(void)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Return soc (System On Chip) ID of %SDH
+  //-----------------------------------------------------------------
+  /*!
+      Return soc (System On Chip) ID of %SDH
 
-        \attention
-        The string returned is stored internally in this object and
-        might be overwritten by the next command to this object
-    */
-    char* soc( void )
-        throw (cSDHLibraryException*);
+      \attention
+      The string returned is stored internally in this object and
+      might be overwritten by the next command to this object
+  */
+  char* soc(void)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Return date of soc (System On Chip) ID of %SDH
+  //-----------------------------------------------------------------
+  /*!
+      Return date of soc (System On Chip) ID of %SDH
 
-        \attention
-        The string returned is stored internally in this object and
-        might be overwritten by the next command to this object
-    */
-    char* soc_date( void )
-        throw (cSDHLibraryException*);
+      \attention
+      The string returned is stored internally in this object and
+      might be overwritten by the next command to this object
+  */
+  char* soc_date(void)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Return number of axis of %SDH
-    */
-    int numaxis( void )
-        throw (cSDHLibraryException*);
+  //-----------------------------------------------------------------
+  /*!
+      Return number of axis of %SDH
+  */
+  int numaxis(void)
+  throw (cSDHLibraryException*);
 
 
-    //  end of doxygen name group sdhlibrary_cpp_csdhserial_diagnosis_commands
-    //! @}
-    //#################################################################
+  //  end of doxygen name group sdhlibrary_cpp_csdhserial_diagnosis_commands
+  //! @}
+  //#################################################################
 
-    //#################################################################
-    /*!
-      \anchor sdhlibrary_cpp_csdhserial_grip_commands
-       \name   Grip methods
-       @{
-    */
+  //#################################################################
+  /*!
+    \anchor sdhlibrary_cpp_csdhserial_grip_commands
+     \name   Grip methods
+     @{
+  */
 
-    //-----------------------------------------------------------------
-    /*!
-        Get/Set motor current limits for grip commands
+  //-----------------------------------------------------------------
+  /*!
+      Get/Set motor current limits for grip commands
 
-        - If axis is All and limit is None then a NUMBER_OF_AXES-list
-          of the actually set motor current limits is returned
-        - If axis is a single number and limit is None then the
-          motor current limit for that axis is returned.
-        - If axis and limit are single numbers then the motor current limit
-          for that axis is set (and returned).
-        - If axis is All and limit is a NUMBER_OF_AXES-vector then all axes
-          motor current limits are set accordingly, the NUMBER_OF_AXES-list is returned.
-    */
-    cSimpleVector igrip( int axis=All, double* limit=NULL )
-        throw (cSDHLibraryException*);
+      - If axis is All and limit is None then a NUMBER_OF_AXES-list
+        of the actually set motor current limits is returned
+      - If axis is a single number and limit is None then the
+        motor current limit for that axis is returned.
+      - If axis and limit are single numbers then the motor current limit
+        for that axis is set (and returned).
+      - If axis is All and limit is a NUMBER_OF_AXES-vector then all axes
+        motor current limits are set accordingly, the NUMBER_OF_AXES-list is returned.
+  */
+  cSimpleVector igrip(int axis = All, double* limit = NULL)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Get/Set motor current limits for hold commands
+  //-----------------------------------------------------------------
+  /*!
+      Get/Set motor current limits for hold commands
 
-        - If axis is All and limit is None then a NUMBER_OF_AXES-list
-          of the actually set motor current limits is returned
-        - If axis is a single number and limit is None then the
-          motor current limit for that axis is returned.
-        - If axis and limit are single numbers then the motor current limit
-          for that axis is set (and returned).
-        - If axis is All and limit is a NUMBER_OF_AXES-vector then all axes
-          motor current limits are set accordingly, the NUMBER_OF_AXES-list is returned.
-    */
-    cSimpleVector ihold( int axis=All, double* limit=NULL )
-        throw (cSDHLibraryException*);
+      - If axis is All and limit is None then a NUMBER_OF_AXES-list
+        of the actually set motor current limits is returned
+      - If axis is a single number and limit is None then the
+        motor current limit for that axis is returned.
+      - If axis and limit are single numbers then the motor current limit
+        for that axis is set (and returned).
+      - If axis is All and limit is a NUMBER_OF_AXES-vector then all axes
+        motor current limits are set accordingly, the NUMBER_OF_AXES-list is returned.
+  */
+  cSimpleVector ihold(int axis = All, double* limit = NULL)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        Send "selgrip grip" command to %SDH. Where grip is in [0..eGID_DIMENSION-1]
-        or one of the eGraspId enums.
+  //-----------------------------------------------------------------
+  /*!
+      Send "selgrip grip" command to %SDH. Where grip is in [0..eGID_DIMENSION-1]
+      or one of the eGraspId enums.
 
-        If sequ is True then wait until %SDH hardware fully executed
-        the command.  Else return immediately and do not wait until %SDH
-        hardware fully executed the command.
+      If sequ is True then wait until %SDH hardware fully executed
+      the command.  Else return immediately and do not wait until %SDH
+      hardware fully executed the command.
 
-        This seems to work with sin square velocity profile only,
-        so the velocity profile is switched to that if necessary.
+      This seems to work with sin square velocity profile only,
+      so the velocity profile is switched to that if necessary.
 
-        return the expected duration of the execution of the command in seconds
-     */
-    double selgrip( eGraspId grip, bool sequ )
-        throw (cSDHLibraryException*);
+      return the expected duration of the execution of the command in seconds
+   */
+  double selgrip(eGraspId grip, bool sequ)
+  throw (cSDHLibraryException*);
 
-    //-----------------------------------------------------------------
-    /*!
-        send "grip=close,velocity" command to %SDH
-        close    : [0.0 .. 1.0] where 0.0 is 'fully opened' and 1.0 is 'fully closed'
-        velocity : ]0.0 .. 100.0] where 0.0 (not allowed) is very slow and 100.0 is very fast
+  //-----------------------------------------------------------------
+  /*!
+      send "grip=close,velocity" command to %SDH
+      close    : [0.0 .. 1.0] where 0.0 is 'fully opened' and 1.0 is 'fully closed'
+      velocity : ]0.0 .. 100.0] where 0.0 (not allowed) is very slow and 100.0 is very fast
 
-        If sequ is True then wait until %SDH hardware fully executed
-        the command.  Else return immediately and do not wait until %SDH
-        hardware fully executed the command.
+      If sequ is True then wait until %SDH hardware fully executed
+      the command.  Else return immediately and do not wait until %SDH
+      hardware fully executed the command.
 
-        This seems to work with sin square velocity profile only,
-        so the velocity profile is switched to that if necessary.
+      This seems to work with sin square velocity profile only,
+      so the velocity profile is switched to that if necessary.
 
-        return the expected duration of the execution of the command in seconds
-    */
-    double grip( double close, double velocity, bool sequ )
-        throw (cSDHLibraryException*);
+      return the expected duration of the execution of the command in seconds
+  */
+  double grip(double close, double velocity, bool sequ)
+  throw (cSDHLibraryException*);
 
-    //  end of doxygen name group sdhlibrary_cpp_csdhserial_grip_commands
-    //! @}
-    //#################################################################
+  //  end of doxygen name group sdhlibrary_cpp_csdhserial_grip_commands
+  //! @}
+  //#################################################################
 
 }; // end of class cSDHSerial
 //=====================================================================
 
 //! Type of a pointer to a "set-axis-values" function like cSDHSerial::p, cSDHSerial::pos, ..., cSDHSerial::igrip, cSDHSerial::ihold or cSDHSerial::ilim
-typedef cSimpleVector (cSDHSerial::*pSetFunction)(int, double*);
+typedef cSimpleVector(cSDHSerial::*pSetFunction)(int, double*);
 
 //! Type of a pointer to a "get-axis-values" function like cSDHSerial::p, cSDHSerial::pos, ..., cSDHSerial::igrip, cSDHSerial::ihold or cSDHSerial::ilim
-typedef cSimpleVector (cSDHSerial::*pGetFunction)(int, double*);
+typedef cSimpleVector(cSDHSerial::*pGetFunction)(int, double*);
 
 NAMESPACE_SDH_END
 

--- a/schunk_sdh/common/include/schunk_sdh/serialbase.h
+++ b/schunk_sdh/common/include/schunk_sdh/serialbase.h
@@ -85,14 +85,14 @@ typedef void* tDeviceHandle;  //!< generic device handle for CAN devices
 */
 class VCC_EXPORT cSerialBaseException: public cSDHErrorCommunication
 {
- public:
-    cSerialBaseException( cMsg const & _msg )
-        : cSDHErrorCommunication( "cSerialBaseException", _msg )
-    {}
+public:
+  cSerialBaseException(cMsg const & _msg)
+    : cSDHErrorCommunication("cSerialBaseException", _msg)
+  {}
 
-    cSerialBaseException( char const* _type, cMsg const & _msg )
-        : cSDHErrorCommunication( _type, _msg )
-    {}
+  cSerialBaseException(char const* _type, cMsg const & _msg)
+    : cSDHErrorCommunication(_type, _msg)
+  {}
 };
 //======================================================================
 
@@ -104,179 +104,179 @@ class VCC_EXPORT cSerialBaseException: public cSDHErrorCommunication
 */
 class VCC_EXPORT cSerialBase
 {
- protected:
+protected:
 
-    //! an already read data byte of the next line
-    char ungetch;
+  //! an already read data byte of the next line
+  char ungetch;
 
-    //! Flag, true if ungetch is valid
-    bool ungetch_valid;
+  //! Flag, true if ungetch is valid
+  bool ungetch_valid;
 
-    //! timeout in seconds
-    double timeout;
+  //! timeout in seconds
+  double timeout;
 
- public:
-    //! ctor
-    cSerialBase()
+public:
+  //! ctor
+  cSerialBase()
     : // init members
-        ungetch('\0'),
-        ungetch_valid(false),
-        // setting the timeout does not make sense here. should be left to virtual SetTimeout()
-        dbg( false, "cyan", g_sdh_debug_log )
+    ungetch('\0'),
+    ungetch_valid(false),
+    // setting the timeout does not make sense here. should be left to virtual SetTimeout()
+    dbg(false, "cyan", g_sdh_debug_log)
+  {
+    // nothing more to do
+  }
+
+  //! dtor
+  virtual ~cSerialBase(void)
+  {
+    ////std::cerr << "destructing cSerialBase\n"; std::cerr.flush();
+  }
+
+  //! Open rs232 port \a port
+  /*!
+    Open the device with the parameters provided in the constructor
+  */
+  virtual void Open(void)
+  throw (cSerialBaseException*) = 0;
+
+  //! Return true if communication channel is open
+  virtual bool IsOpen(void)
+  throw() = 0;
+
+  //! Close the previously opened communication channel.
+  virtual void Close(void)
+  throw (cSerialBaseException*) = 0;
+
+  //! set the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
+  virtual void SetTimeout(double _timeout)
+  throw (cSerialBaseException*)
+  {
+    timeout = _timeout;
+  }
+
+  //! get the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
+  virtual double GetTimeout()
+  {
+    return timeout;
+  }
+
+  //! helper class to set timeout of _serial_base on construction and reset to previous value on destruction. (RAII-idiom)
+  class cSetTimeoutTemporarily
+  {
+    cSerialBase* serial_base;
+    double       old_timeout;
+  public:
+    //! CTOR: remember current timeout of \a _serial_base and set its timeout to \a new_timeout, but only if current timeout and new_timeout differ
+    cSetTimeoutTemporarily(cSerialBase* _serial_base, double new_timeout)
+      : serial_base(_serial_base),
+        old_timeout(serial_base->GetTimeout())
     {
-        // nothing more to do
+      if (new_timeout != old_timeout)
+        serial_base->SetTimeout(new_timeout);
     }
 
-    //! dtor
-    virtual ~cSerialBase( void )
+    //! DTOR: restore the remembered timeout
+    ~cSetTimeoutTemporarily()
     {
-        ////std::cerr << "destructing cSerialBase\n"; std::cerr.flush();
+      if (old_timeout != serial_base->GetTimeout())
+        serial_base->SetTimeout(old_timeout);
     }
-
-    //! Open rs232 port \a port
-    /*!
-      Open the device with the parameters provided in the constructor
-    */
-    virtual void Open( void )
-        throw (cSerialBaseException*) = 0;
-
-    //! Return true if communication channel is open
-    virtual bool IsOpen( void )
-        throw() = 0;
-
-    //! Close the previously opened communication channel.
-    virtual void Close( void )
-        throw (cSerialBaseException*) = 0;
-
-    //! set the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
-    virtual void SetTimeout( double _timeout )
-        throw (cSerialBaseException*)
-    {
-        timeout = _timeout;
-    }
-
-    //! get the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
-    virtual double GetTimeout()
-    {
-        return timeout;
-    }
-
-    //! helper class to set timeout of _serial_base on construction and reset to previous value on destruction. (RAII-idiom)
-    class cSetTimeoutTemporarily
-    {
-        cSerialBase* serial_base;
-        double       old_timeout;
-    public:
-        //! CTOR: remember current timeout of \a _serial_base and set its timeout to \a new_timeout, but only if current timeout and new_timeout differ
-        cSetTimeoutTemporarily( cSerialBase* _serial_base, double new_timeout )
-        : serial_base(_serial_base),
-          old_timeout( serial_base->GetTimeout() )
-        {
-            if ( new_timeout != old_timeout )
-                serial_base->SetTimeout( new_timeout );
-        }
-
-        //! DTOR: restore the remembered timeout
-        ~cSetTimeoutTemporarily()
-        {
-            if ( old_timeout != serial_base->GetTimeout() )
-                serial_base->SetTimeout( old_timeout );
-        }
-    };
+  };
 
 
-    //! Write data to a previously opened port.
-    /*!
-      Write \a len bytes from \a *ptr to the rs232 device
+  //! Write data to a previously opened port.
+  /*!
+    Write \a len bytes from \a *ptr to the rs232 device
 
-      \param ptr - pointer the byte array to send in memory
-      \param len - number of bytes to send
+    \param ptr - pointer the byte array to send in memory
+    \param len - number of bytes to send
 
-      \return the number of bytes actually written
-    */
-    virtual int write( char const *ptr, int len=0 )
-        throw (cSerialBaseException*) = 0;
+    \return the number of bytes actually written
+  */
+  virtual int write(char const *ptr, int len = 0)
+  throw (cSerialBaseException*) = 0;
 
-    /*!
-      Read data from device. This function waits until \a max_time_us us passed or
-      the expected number of bytes are received via serial line.
-      if (\a return_on_less_data is true (default value), the number of bytes
-      that have been received are returned and the data is stored in \a data
-      If the \a return_on_less_data is false, data is only read from serial line, if at least
-      \a size bytes are available.
-    */
-    virtual ssize_t Read( void *data, ssize_t size, long timeout_us, bool return_on_less_data )
-        throw (cSerialBaseException*) = 0;
+  /*!
+    Read data from device. This function waits until \a max_time_us us passed or
+    the expected number of bytes are received via serial line.
+    if (\a return_on_less_data is true (default value), the number of bytes
+    that have been received are returned and the data is stored in \a data
+    If the \a return_on_less_data is false, data is only read from serial line, if at least
+    \a size bytes are available.
+  */
+  virtual ssize_t Read(void *data, ssize_t size, long timeout_us, bool return_on_less_data)
+  throw (cSerialBaseException*) = 0;
 
-    //! Read a line from the device.
-    /*!
-      A line is terminated with one of the end-of-line (\a eol)
-      characters ('\n' by default) or until timeout.
-      Up to \a size-1 bytes are read and a '\0' char is appended.
+  //! Read a line from the device.
+  /*!
+    A line is terminated with one of the end-of-line (\a eol)
+    characters ('\n' by default) or until timeout.
+    Up to \a size-1 bytes are read and a '\0' char is appended.
 
-      \param line - ptr to where to store the read line
-      \param size - space available in line (bytes)
-      \param eol  - a string containing all the chars that mark an end of line
-      \param return_on_less_data - if (\a return_on_less_data is true (default value), the number of bytes
-                                   that have been received are returned and the data is stored in \a data
-                                   If the \a return_on_less_data is false, data is only read from serial line, if at least
-                                   \a size bytes are available.
+    \param line - ptr to where to store the read line
+    \param size - space available in line (bytes)
+    \param eol  - a string containing all the chars that mark an end of line
+    \param return_on_less_data - if (\a return_on_less_data is true (default value), the number of bytes
+                                 that have been received are returned and the data is stored in \a data
+                                 If the \a return_on_less_data is false, data is only read from serial line, if at least
+                                 \a size bytes are available.
 
-      A pointer to the line read is returned.
+    A pointer to the line read is returned.
 
-    */
-    virtual char* readline( char* line, int size, char const* eol = "\n", bool return_on_less_data = false )
-        throw (cSerialBaseException*);
+  */
+  virtual char* readline(char* line, int size, char const* eol = "\n", bool return_on_less_data = false)
+  throw (cSerialBaseException*);
 
-    //! A stream object to print colored debug messages
-    cDBG dbg;
+  //! A stream object to print colored debug messages
+  cDBG dbg;
 
-    //! type of the error code, DWORD on windows and int on Linux/cygwin
+  //! type of the error code, DWORD on windows and int on Linux/cygwin
 #if SDH_USE_VCC
-    typedef DWORD tErrorCode;
+  typedef DWORD tErrorCode;
 #else
-    typedef int tErrorCode;
+  typedef int tErrorCode;
 #endif
 
-    /*!
-     * Helper function that returns the last error number.
-     * - On windows GetLastError() is used
-     * - On cygwin/linux this uses errno
-     */
-    virtual tErrorCode GetErrorNumber()
-    {
+  /*!
+   * Helper function that returns the last error number.
+   * - On windows GetLastError() is used
+   * - On cygwin/linux this uses errno
+   */
+  virtual tErrorCode GetErrorNumber()
+  {
 #if SDH_USE_VCC
-        return GetLastError();
+    return GetLastError();
 #else
-        return errno;
+    return errno;
 #endif
-    }
+  }
 
-    /*!
-     * Helper function that returns an error message for error code dw.
-     * - On windows FormatMessageA() is used
-     * - On cygwin/linux this uses errno
-     *
-     * \remark The string returned will be overwritten by the next call to the function
-     */
-    virtual char const* GetErrorMessage( tErrorCode dw );
+  /*!
+   * Helper function that returns an error message for error code dw.
+   * - On windows FormatMessageA() is used
+   * - On cygwin/linux this uses errno
+   *
+   * \remark The string returned will be overwritten by the next call to the function
+   */
+  virtual char const* GetErrorMessage(tErrorCode dw);
 
-    //! return the last error message as string. The string returned will be overwritten by the next call to the function
-    char const* GetLastErrorMessage( void )
-    {
-        return GetErrorMessage( GetErrorNumber() );
-    }
+  //! return the last error message as string. The string returned will be overwritten by the next call to the function
+  char const* GetLastErrorMessage(void)
+  {
+    return GetErrorMessage(GetErrorNumber());
+  }
 
-    /*!
-     *  function that returns true if a CRC16 is used to protect binary communication.
-     *
-     *  The default is false since only RS232 communication needs this.
-     */
-    virtual bool UseCRC16()
-    {
-        return false;
-    }
-    //----------------------------------------------------------------------
+  /*!
+   *  function that returns true if a CRC16 is used to protect binary communication.
+   *
+   *  The default is false since only RS232 communication needs this.
+   */
+  virtual bool UseCRC16()
+  {
+    return false;
+  }
+  //----------------------------------------------------------------------
 
 };
 //======================================================================

--- a/schunk_sdh/common/include/schunk_sdh/simplestringlist.h
+++ b/schunk_sdh/common/include/schunk_sdh/simplestringlist.h
@@ -71,60 +71,61 @@ class VCC_EXPORT cSimpleStringList
 {
 public:
 
-    //! the index of the current line. For empty cSimpleStringLists this is -1.
-    int current_line;
+  //! the index of the current line. For empty cSimpleStringLists this is -1.
+  int current_line;
 
 
-    //! anonymous enum instead of define macros
-    enum {
-        eMAX_LINES = 256,
-        eMAX_CHARS = 256,
-    };
+  //! anonymous enum instead of define macros
+  enum
+  {
+    eMAX_LINES = 256,
+    eMAX_CHARS = 256,
+  };
 
-    //! Default constructor: init members
-    cSimpleStringList();
-
-
-    //! Return the current line
-    char* CurrentLine();
+  //! Default constructor: init members
+  cSimpleStringList();
 
 
-    //! Return the next line, this increases current_line
-    char* NextLine();
+  //! Return the current line
+  char* CurrentLine();
 
 
-    //! Return number of lines stored
-    int Length() const;
+  //! Return the next line, this increases current_line
+  char* NextLine();
 
 
-    //! return ptr to line with index.
-    /*!
-      if index < 0 then the numbering starts from the end,
-      thus [-1] gives the last line, [-2] the next to last, ...
-    */
-    char* operator[]( int index );
-
-    //! return ptr to line with index.
-    /*!
-      if index < 0 then the numbering starts from the end,
-      thus [-1] gives the last line, [-2] the next to last, ...
-    */
-    char const* operator[]( int index ) const;
+  //! Return number of lines stored
+  int Length() const;
 
 
-    //! reset list
-    void Reset();
+  //! return ptr to line with index.
+  /*!
+    if index < 0 then the numbering starts from the end,
+    thus [-1] gives the last line, [-2] the next to last, ...
+  */
+  char* operator[](int index);
+
+  //! return ptr to line with index.
+  /*!
+    if index < 0 then the numbering starts from the end,
+    thus [-1] gives the last line, [-2] the next to last, ...
+  */
+  char const* operator[](int index) const;
+
+
+  //! reset list
+  void Reset();
 
 protected:
-    //! a fixed length array of lines with fixed length
-    char line[ eMAX_LINES ][ eMAX_CHARS ];
+  //! a fixed length array of lines with fixed length
+  char line[ eMAX_LINES ][ eMAX_CHARS ];
 
 }; // cSimpleStringList
 //-----------------------------------------------------------------
 
 
 //! Output of cSimpleStringList objects in 'normal' output streams.
-VCC_EXPORT std::ostream& operator<<( std::ostream& stream, cSimpleStringList const& ssl );
+VCC_EXPORT std::ostream& operator<<(std::ostream& stream, cSimpleStringList const& ssl);
 
 
 //-----------------------------------------------------------------

--- a/schunk_sdh/common/include/schunk_sdh/simpletime.h
+++ b/schunk_sdh/common/include/schunk_sdh/simpletime.h
@@ -85,99 +85,99 @@ class VCC_EXPORT cSimpleTime
 {
 protected:
 #if SDH_USE_VCC
-    struct _timeb timebuffer;
+  struct _timeb timebuffer;
 #else
-    struct timeval a_time;
+  struct timeval a_time;
 #endif
 
 public:
-    //! Constructor: store current time ("now") internally.
-    cSimpleTime()
-    {
-        StoreNow();
-    }
-    //----------------------------------------------------------------------
+  //! Constructor: store current time ("now") internally.
+  cSimpleTime()
+  {
+    StoreNow();
+  }
+  //----------------------------------------------------------------------
 
 
-    //! Store current time internally.
-    void StoreNow( void )
-    {
+  //! Store current time internally.
+  void StoreNow(void)
+  {
 #if SDH_USE_VCC
-         _ftime64_s( &timebuffer );
+    _ftime64_s(&timebuffer);
 
 #else
-         gettimeofday( &a_time, NULL );
+    gettimeofday(&a_time, NULL);
 #endif
-    }
-    //----------------------------------------------------------------------
+  }
+  //----------------------------------------------------------------------
 
-    //! Return time in seconds elapsed between the time stored in the object and now.
-    double Elapsed( void ) const
-    {
-        cSimpleTime now;
+  //! Return time in seconds elapsed between the time stored in the object and now.
+  double Elapsed(void) const
+  {
+    cSimpleTime now;
 
-        return Elapsed( now );
-    }
-    //----------------------------------------------------------------------
+    return Elapsed(now);
+  }
+  //----------------------------------------------------------------------
 
 
-    //! Return time in micro seconds elapsed between the time stored in the object and now.
-    long Elapsed_us( void ) const
-    {
-        cSimpleTime now;
+  //! Return time in micro seconds elapsed between the time stored in the object and now.
+  long Elapsed_us(void) const
+  {
+    cSimpleTime now;
 
-        return Elapsed_us( now );
-    }
-    //----------------------------------------------------------------------
+    return Elapsed_us(now);
+  }
+  //----------------------------------------------------------------------
 
 
 #if SDH_USE_VCC
-    //! Return time in seconds elapsed between the time stored in the object and \a other.
-    double Elapsed( cSimpleTime const& other ) const
-    {
-        double seconds = double( other.timebuffer.time - timebuffer.time);
-        double msec = double( other.timebuffer.millitm - timebuffer.millitm );
+  //! Return time in seconds elapsed between the time stored in the object and \a other.
+  double Elapsed(cSimpleTime const& other) const
+  {
+    double seconds = double(other.timebuffer.time - timebuffer.time);
+    double msec = double(other.timebuffer.millitm - timebuffer.millitm);
 
-        return seconds + msec / 1000.0;
-    }
-    //----------------------------------------------------------------------
+    return seconds + msec / 1000.0;
+  }
+  //----------------------------------------------------------------------
 
-    //! Return time in micro seconds elapsed between the time stored in the object and \a other.
-    long Elapsed_us( cSimpleTime const& other ) const
-    {
-        long seconds = long( other.timebuffer.time - timebuffer.time);
-        long msec    = long( other.timebuffer.millitm - timebuffer.millitm );
+  //! Return time in micro seconds elapsed between the time stored in the object and \a other.
+  long Elapsed_us(cSimpleTime const& other) const
+  {
+    long seconds = long(other.timebuffer.time - timebuffer.time);
+    long msec    = long(other.timebuffer.millitm - timebuffer.millitm);
 
-        return seconds * 1000000 + msec * 1000;
-    }
-    //----------------------------------------------------------------------
+    return seconds * 1000000 + msec * 1000;
+  }
+  //----------------------------------------------------------------------
 #else
-    //! Return time in seconds elapsed between the time stored in the object and \a other.
-    double Elapsed( cSimpleTime const& other ) const
-    {
-        double seconds = double( other.a_time.tv_sec - a_time.tv_sec );
-        double usec = double( other.a_time.tv_usec - a_time.tv_usec );
+  //! Return time in seconds elapsed between the time stored in the object and \a other.
+  double Elapsed(cSimpleTime const& other) const
+  {
+    double seconds = double(other.a_time.tv_sec - a_time.tv_sec);
+    double usec = double(other.a_time.tv_usec - a_time.tv_usec);
 
-        return seconds + usec / 1000000.0;
-    }
-    //----------------------------------------------------------------------
+    return seconds + usec / 1000000.0;
+  }
+  //----------------------------------------------------------------------
 
-    //! Return time in micro seconds elapsed between the time stored in the object and \a other.
-    long Elapsed_us( cSimpleTime const& other ) const
-    {
-        long seconds = other.a_time.tv_sec - a_time.tv_sec;
-        long usec    = other.a_time.tv_usec - a_time.tv_usec;
+  //! Return time in micro seconds elapsed between the time stored in the object and \a other.
+  long Elapsed_us(cSimpleTime const& other) const
+  {
+    long seconds = other.a_time.tv_sec - a_time.tv_sec;
+    long usec    = other.a_time.tv_usec - a_time.tv_usec;
 
-        return seconds * 1000000 + usec;
-    }
-    //----------------------------------------------------------------------
+    return seconds * 1000000 + usec;
+  }
+  //----------------------------------------------------------------------
 
 
-    //! Return the time stored as C struct timeval
-    timeval Timeval( void )
-    {
-        return a_time;
-    }
+  //! Return the time stored as C struct timeval
+  timeval Timeval(void)
+  {
+    return a_time;
+  }
 #endif
 };
 

--- a/schunk_sdh/common/include/schunk_sdh/simplevector.h
+++ b/schunk_sdh/common/include/schunk_sdh/simplevector.h
@@ -74,8 +74,8 @@ NAMESPACE_SDH_START
 class VCC_EXPORT cSimpleVectorException: public cSDHLibraryException
 {
 public:
-  cSimpleVectorException( cMsg const & _msg )
-    : cSDHLibraryException( "cSimpleVectorException", _msg )
+  cSimpleVectorException(cMsg const & _msg)
+    : cSDHLibraryException("cSimpleVectorException", _msg)
   {}
 };
 //======================================================================
@@ -91,60 +91,60 @@ public:
 class VCC_EXPORT cSimpleVector
 {
 public:
-    //! anonymous enum (instead of define like macros)
-    enum
-    {
-      eNUMBER_OF_ELEMENTS = 7 //!< number of elements in vector
-    };
+  //! anonymous enum (instead of define like macros)
+  enum
+  {
+    eNUMBER_OF_ELEMENTS = 7 //!< number of elements in vector
+  };
 
-    //! Default constructor: init members to zero
-    cSimpleVector()
-        throw (cSimpleVectorException*);
-
-
-    //! Constructor: init members from \a nb_values comma separated values in the give string \a str
-    cSimpleVector( int nb_values, char const* str )
-        throw (cSimpleVectorException*);
+  //! Default constructor: init members to zero
+  cSimpleVector()
+  throw (cSimpleVectorException*);
 
 
-    //! Constructor: init members from \a nb_values comma separated values in the give string \a str
-    cSimpleVector( int nb_values, int start_index, char const* str )
-        throw (cSimpleVectorException*);
-
-    //! Constructor: init members beginning with \a start_index from \a nb_values in arrray \a values
-    cSimpleVector( int nb_values, int start_index, float* values )
-        throw (cSimpleVectorException*);
+  //! Constructor: init members from \a nb_values comma separated values in the give string \a str
+  cSimpleVector(int nb_values, char const* str)
+  throw (cSimpleVectorException*);
 
 
-    //! init \a nb_values starting from index \a start_index from comma separated values in \a str
-    void FromString( int nb_values, int start_index, char const* str )
-        throw (cSimpleVectorException*);
+  //! Constructor: init members from \a nb_values comma separated values in the give string \a str
+  cSimpleVector(int nb_values, int start_index, char const* str)
+  throw (cSimpleVectorException*);
+
+  //! Constructor: init members beginning with \a start_index from \a nb_values in arrray \a values
+  cSimpleVector(int nb_values, int start_index, float* values)
+  throw (cSimpleVectorException*);
 
 
-    //! index operator, return a reference to the \a index-th element of this
-    double& operator[]( unsigned int index );
+  //! init \a nb_values starting from index \a start_index from comma separated values in \a str
+  void FromString(int nb_values, int start_index, char const* str)
+  throw (cSimpleVectorException*);
 
 
-    //! Interpret object as x/y/z vector: return x = the first element, if that is valid.
-    double& x(void);
+  //! index operator, return a reference to the \a index-th element of this
+  double& operator[](unsigned int index);
 
 
-    //! Interpret object as x/y/z vector: return x = the first element, if that is valid.
-    double& y(void);
+  //! Interpret object as x/y/z vector: return x = the first element, if that is valid.
+  double& x(void);
 
 
-    //! Interpret object as x/y/z vector: return x = the first element, if that is valid.
-    double& z(void);
+  //! Interpret object as x/y/z vector: return x = the first element, if that is valid.
+  double& y(void);
 
-    //! Return true if vector element \a index is valid (has been accessed at least once)
-    bool Valid( unsigned int index ) const;
+
+  //! Interpret object as x/y/z vector: return x = the first element, if that is valid.
+  double& z(void);
+
+  //! Return true if vector element \a index is valid (has been accessed at least once)
+  bool Valid(unsigned int index) const;
 
 protected:
 
-    double value[ eNUMBER_OF_ELEMENTS ];
+  double value[ eNUMBER_OF_ELEMENTS ];
 
-    //! bit mask which values in #value are valid
-    int valid;
+  //! bit mask which values in #value are valid
+  int valid;
 
 }; // cSimpleVector
 //-----------------------------------------------------------------

--- a/schunk_sdh/common/include/schunk_sdh/tcpserial.h
+++ b/schunk_sdh/common/include/schunk_sdh/tcpserial.h
@@ -75,9 +75,9 @@ NAMESPACE_SDH_START
 class VCC_EXPORT cTCPSerialException: public cSerialBaseException
 {
 public:
-    cTCPSerialException( cMsg const & _msg )
-        : cSerialBaseException( "cTCPSerialException", _msg )
-    {}
+  cTCPSerialException(cMsg const & _msg)
+    : cSerialBaseException("cTCPSerialException", _msg)
+  {}
 };
 //======================================================================
 
@@ -90,94 +90,94 @@ class VCC_EXPORT cTCPSerial : public cSerialBase
 
 protected:
 
-    std::string tcp_adr;
+  std::string tcp_adr;
 
-    //! the TCP port to use
-    int tcp_port;
+  //! the TCP port to use
+  int tcp_port;
 
-    //! the file descriptor of the socket
+  //! the file descriptor of the socket
 #if SDH_USE_VCC
-    SOCKET fd;
+  SOCKET fd;
 #else
-    int    fd;
-    static const int INVALID_SOCKET = -1;
+  int    fd;
+  static const int INVALID_SOCKET = -1;
 #endif
 private:
-    //! timeout for setsockopt
-    struct  timeval timeout_timeval;
-    //! cached timeout in us for read()
-    long    timeout_us;
+  //! timeout for setsockopt
+  struct  timeval timeout_timeval;
+  //! cached timeout in us for read()
+  long    timeout_us;
 
 public:
-    static double const TIMEOUT_WAIT_FOR_EVER_S;
-    static double const TIMEOUT_RETURN_IMMEDITELY_S;
-    static long const   TIMEOUT_WAIT_FOR_EVER_US;
-    static long const   TIMEOUT_RETURN_IMMEDITELY_US;
+  static double const TIMEOUT_WAIT_FOR_EVER_S;
+  static double const TIMEOUT_RETURN_IMMEDITELY_S;
+  static long const   TIMEOUT_WAIT_FOR_EVER_US;
+  static long const   TIMEOUT_RETURN_IMMEDITELY_US;
 
-    /*!
-      Constructor: constructs an object to communicate with an %SDH via TCP on \a _tcp_adr and \a _tcp_port.
-      \param _tcp_adr  - a string describing the hostname or IP address of the SDH
-      \param _tcp_port - the port number on the SDH
-      \param _timeout  - the timeout when receiving / sending data:
-                         -  < 0.0 : no timeout = wait for ever
-                         - == 0.0 : zero timeout = return immediately
-                         -  > 0.0 : timeout in seconds
-     */
-    cTCPSerial( char const* _tcp_adr, int _tcp_port, double _timeout )
-        throw (cTCPSerialException*);
+  /*!
+    Constructor: constructs an object to communicate with an %SDH via TCP on \a _tcp_adr and \a _tcp_port.
+    \param _tcp_adr  - a string describing the hostname or IP address of the SDH
+    \param _tcp_port - the port number on the SDH
+    \param _timeout  - the timeout when receiving / sending data:
+                       -  < 0.0 : no timeout = wait for ever
+                       - == 0.0 : zero timeout = return immediately
+                       -  > 0.0 : timeout in seconds
+   */
+  cTCPSerial(char const* _tcp_adr, int _tcp_port, double _timeout)
+  throw (cTCPSerialException*);
 
-    /*!
-      Open the device as configured by the parameters given to the constructor
-    */
-    void Open( void )
-        throw (cTCPSerialException*);
+  /*!
+    Open the device as configured by the parameters given to the constructor
+  */
+  void Open(void)
+  throw (cTCPSerialException*);
 
-    //! Return true if interface to CAN ESD is open
-    bool IsOpen( void )
-        throw();
+  //! Return true if interface to CAN ESD is open
+  bool IsOpen(void)
+  throw();
 
-    //! Close the previously opened CAN ESD interface port.
-    void Close( void )
-        throw (cTCPSerialException*);
+  //! Close the previously opened CAN ESD interface port.
+  void Close(void)
+  throw (cTCPSerialException*);
 
-    //! Write data to a previously opened port.
-    /*!
-      Write \a len bytes from \a *ptr to the CAN device
+  //! Write data to a previously opened port.
+  /*!
+    Write \a len bytes from \a *ptr to the CAN device
 
-      \param ptr - pointer the byte array to send in memory
-      \param len - number of bytes to send
+    \param ptr - pointer the byte array to send in memory
+    \param len - number of bytes to send
 
-      \return the number of bytes actually written
-    */
-    int write( char const *ptr, int len=0 )
-        throw (cTCPSerialException*);
+    \return the number of bytes actually written
+  */
+  int write(char const *ptr, int len = 0)
+  throw (cTCPSerialException*);
 
-    /*!
-      Read data from device. This function waits until \a max_time_us us passed or
-      the expected number of bytes are received via serial line.
-      if (\a return_on_less_data is true (default value), the number of bytes
-      that have been received are returned and the data is stored in \a data
-      If the \a return_on_less_data is false, data is only read from serial line, if at least
-      \a size bytes are available.
-    */
-    ssize_t Read( void *data, ssize_t size, long timeout_us, bool return_on_less_data )
-        throw (cTCPSerialException*);
+  /*!
+    Read data from device. This function waits until \a max_time_us us passed or
+    the expected number of bytes are received via serial line.
+    if (\a return_on_less_data is true (default value), the number of bytes
+    that have been received are returned and the data is stored in \a data
+    If the \a return_on_less_data is false, data is only read from serial line, if at least
+    \a size bytes are available.
+  */
+  ssize_t Read(void *data, ssize_t size, long timeout_us, bool return_on_less_data)
+  throw (cTCPSerialException*);
 
-    //! set the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
-    void SetTimeout( double _timeout )
-        throw (cSerialBaseException*);
+  //! set the timeout for next #readline() calls (negative value means: no timeout, wait for ever)
+  void SetTimeout(double _timeout)
+  throw (cSerialBaseException*);
 
-    /*!
-     * Overloaded helper function that returns the last TCP error number.
-     */
-    virtual tErrorCode GetErrorNumber()
-    {
+  /*!
+   * Overloaded helper function that returns the last TCP error number.
+   */
+  virtual tErrorCode GetErrorNumber()
+  {
 #if SDH_USE_VCC
-        return WSAGetLastError();
+    return WSAGetLastError();
 #else
-        return errno;
+    return errno;
 #endif
-    }
+  }
 };
 //======================================================================
 

--- a/schunk_sdh/common/include/schunk_sdh/unit_converter.h
+++ b/schunk_sdh/common/include/schunk_sdh/unit_converter.h
@@ -75,127 +75,127 @@ NAMESPACE_SDH_START
 class VCC_EXPORT cUnitConverter
 {
 public:
-    /*!
-      Constructor of cUnitConverter class.
+  /*!
+    Constructor of cUnitConverter class.
 
-       At construction time the conversion parameters - a \a factor
-       and an \a offset - must be provided along with elements that
-       describe the unit of a value
+     At construction time the conversion parameters - a \a factor
+     and an \a offset - must be provided along with elements that
+     describe the unit of a value
 
-       \param _kind   - a string describing the kind of unit to be converted (something like "angle" or "time")
-       \param _name   - the name of the external unit (something like "degrees" or "milliseconds")
-       \param _symbol - the symbol of the external unit (something like "deg" or "ms")
-       \param _factor - the conversion factor from internal to external units
-       \param _offset - the conversion offset from internal to external units
-       \param _decimal_places - A usefull number of decimal places for printing values in the external unit system
+     \param _kind   - a string describing the kind of unit to be converted (something like "angle" or "time")
+     \param _name   - the name of the external unit (something like "degrees" or "milliseconds")
+     \param _symbol - the symbol of the external unit (something like "deg" or "ms")
+     \param _factor - the conversion factor from internal to external units
+     \param _offset - the conversion offset from internal to external units
+     \param _decimal_places - A usefull number of decimal places for printing values in the external unit system
 
-       \attention
-         The strings given _kind, _name and _symbol are \b NOT copied,
-         just their address is stored <hr>
-    */
-    cUnitConverter( char const* _kind, char const* _name, char const* _symbol, double _factor = 1.0, double _offset = 0.0, int _decimal_places=1 );
+     \attention
+       The strings given _kind, _name and _symbol are \b NOT copied,
+       just their address is stored <hr>
+  */
+  cUnitConverter(char const* _kind, char const* _name, char const* _symbol, double _factor = 1.0, double _offset = 0.0, int _decimal_places = 1);
 
-    //----------------------------------------------------------------------
-    /*!
-        Convert single value \a internal given in internal units into external units.
-        Returns \a internal * #factor + #offset
-    */
-    double ToExternal( double internal ) const;
+  //----------------------------------------------------------------------
+  /*!
+      Convert single value \a internal given in internal units into external units.
+      Returns \a internal * #factor + #offset
+  */
+  double ToExternal(double internal) const;
 
-    //----------------------------------------------------------------------
-    /*!
-        Convert values in simple array \a internal, each given in
-        internal units into external units.  Returns a simple array
-        with each valid element converted with \a internal[i] *
-        #factor + #offset
+  //----------------------------------------------------------------------
+  /*!
+      Convert values in simple array \a internal, each given in
+      internal units into external units.  Returns a simple array
+      with each valid element converted with \a internal[i] *
+      #factor + #offset
 
-        Only valid entries of the \a internal vector are converted.
-    */
-    cSimpleVector ToExternal( cSimpleVector& internal ) const;
-
-
-    //----------------------------------------------------------------------
-    /*!
-        Convert values in vector \a internal, each given in
-        internal units into external units.  Returns a vector
-        with each element converted with \a internal[i] *
-        #factor + #offset
-    */
-    std::vector<double> ToExternal( std::vector<double> const& internal ) const;
+      Only valid entries of the \a internal vector are converted.
+  */
+  cSimpleVector ToExternal(cSimpleVector& internal) const;
 
 
-    //----------------------------------------------------------------------
-    /*!
-        Convert value \a external given in external units into internal units.
-        Returns (\a external - #offset) / #factor
-    */
-    double ToInternal( double external ) const;
-
-    //----------------------------------------------------------------------
-    /*!
-        Convert values in simple array \a external, each given in
-        external units into internal units.  Returns a simple array
-        with each valid element converted with \a external[i] *
-        #factor + #offset
-
-        Only valid entries of the \a external vector are converted.
-    */
-    cSimpleVector ToInternal( cSimpleVector& external ) const;
+  //----------------------------------------------------------------------
+  /*!
+      Convert values in vector \a internal, each given in
+      internal units into external units.  Returns a vector
+      with each element converted with \a internal[i] *
+      #factor + #offset
+  */
+  std::vector<double> ToExternal(std::vector<double> const& internal) const;
 
 
-    //----------------------------------------------------------------------
-    /*!
-        Convert values in vector \a external, each given in
-        external units into internal units.  Returns a vector
-        with each valid element converted with \a external[i] *
-        #factor + #offset
-    */
-    std::vector<double> ToInternal( std::vector<double> const& external ) const;
+  //----------------------------------------------------------------------
+  /*!
+      Convert value \a external given in external units into internal units.
+      Returns (\a external - #offset) / #factor
+  */
+  double ToInternal(double external) const;
 
-    //----------------------------------------------------------------------
-    //! Return the kind of unit converted (something like "angle" or "time")
-    char const* GetKind( void ) const;
+  //----------------------------------------------------------------------
+  /*!
+      Convert values in simple array \a external, each given in
+      external units into internal units.  Returns a simple array
+      with each valid element converted with \a external[i] *
+      #factor + #offset
 
-    //----------------------------------------------------------------------
-    //! Return the name of the external unit (something like "degrees" or "milliseconds")
-    char const* GetName( void ) const;
+      Only valid entries of the \a external vector are converted.
+  */
+  cSimpleVector ToInternal(cSimpleVector& external) const;
 
-    //----------------------------------------------------------------------
-    //! Return the symbol of the external unit (something like "deg" or "ms")
-    char const* GetSymbol( void ) const;
 
-    //----------------------------------------------------------------------
+  //----------------------------------------------------------------------
+  /*!
+      Convert values in vector \a external, each given in
+      external units into internal units.  Returns a vector
+      with each valid element converted with \a external[i] *
+      #factor + #offset
+  */
+  std::vector<double> ToInternal(std::vector<double> const& external) const;
 
-    //! Return the conversion factor from internal to external units
-    double GetFactor( void ) const;
+  //----------------------------------------------------------------------
+  //! Return the kind of unit converted (something like "angle" or "time")
+  char const* GetKind(void) const;
 
-    //----------------------------------------------------------------------
-    //! Return the conversion offset from internal to external units
-    double GetOffset( void ) const;
+  //----------------------------------------------------------------------
+  //! Return the name of the external unit (something like "degrees" or "milliseconds")
+  char const* GetName(void) const;
 
-    //----------------------------------------------------------------------
-    //! Return the number of decimal places for printing values in the external unit system
-    int GetDecimalPlaces( void ) const;
+  //----------------------------------------------------------------------
+  //! Return the symbol of the external unit (something like "deg" or "ms")
+  char const* GetSymbol(void) const;
+
+  //----------------------------------------------------------------------
+
+  //! Return the conversion factor from internal to external units
+  double GetFactor(void) const;
+
+  //----------------------------------------------------------------------
+  //! Return the conversion offset from internal to external units
+  double GetOffset(void) const;
+
+  //----------------------------------------------------------------------
+  //! Return the number of decimal places for printing values in the external unit system
+  int GetDecimalPlaces(void) const;
 
 
 protected:
-    //! the kind of unit to be converted (something like "angle" or "time")
-    char const* kind;
+  //! the kind of unit to be converted (something like "angle" or "time")
+  char const* kind;
 
-    //! the name of the external unit (something like "degrees" or "milliseconds")
-    char const* name;
+  //! the name of the external unit (something like "degrees" or "milliseconds")
+  char const* name;
 
-    //! the symbol of the external unit (something like "deg" or "ms")
-    char const* symbol;
+  //! the symbol of the external unit (something like "deg" or "ms")
+  char const* symbol;
 
-    //! the conversion factor from internal to external units
-    double factor;
+  //! the conversion factor from internal to external units
+  double factor;
 
-    //! the conversion offset from internal to external units
-    double offset;
+  //! the conversion offset from internal to external units
+  double offset;
 
-    //! A usefull number of decimal places for printing values in the external unit system
-    int decimal_places;
+  //! A usefull number of decimal places for printing values in the external unit system
+  int decimal_places;
 
 }; // cUnitConverter
 //======================================================================
@@ -206,7 +206,7 @@ extern cUnitConverter const uc_identity;
 
 //----------------------------------------------------------------------
 //! Type of a pointer to a function like 'double SDH::cUnitConverter::ToExternal( double ) const' or 'double SDH::cUnitConverter::ToInternal( double ) const'
-typedef double (cUnitConverter::*pDoubleUnitConverterFunction) ( double ) const;
+typedef double(cUnitConverter::*pDoubleUnitConverterFunction)(double) const;
 
 
 //! Type of a pointer to a function like 'double cUnitConverter::ToExternal( double )' or 'cUnitConverter::ToInternal( double )'

--- a/schunk_sdh/common/include/schunk_sdh/util.h
+++ b/schunk_sdh/common/include/schunk_sdh/util.h
@@ -129,13 +129,13 @@ NAMESPACE_SDH_START
 /*!
     Return True if v is in range [0 .. max[
 */
-VCC_EXPORT bool InIndex( int v, int max );
+VCC_EXPORT bool InIndex(int v, int max);
 
 
 /*!
     Return True if v is in range [min .. max]
 */
-VCC_EXPORT bool InRange( double v, double min, double max );
+VCC_EXPORT bool InRange(double v, double min, double max);
 
 
 /*!
@@ -143,7 +143,7 @@ VCC_EXPORT bool InRange( double v, double min, double max );
     v_i is in range [min_i..max_i] with
     min = (min1, min2,...) max = (max1, max2, ..)
 */
-VCC_EXPORT bool InRange( int n, double const* v, double const* min, double const* max );
+VCC_EXPORT bool InRange(int n, double const* v, double const* min, double const* max);
 
 
 /*!
@@ -151,7 +151,7 @@ VCC_EXPORT bool InRange( int n, double const* v, double const* min, double const
     min is returned, or if v > max then max is returned, else v is
     returned
 */
-VCC_EXPORT double ToRange( double v, double min, double max );
+VCC_EXPORT double ToRange(double v, double min, double max);
 
 
 /*!
@@ -159,7 +159,7 @@ VCC_EXPORT double ToRange( double v, double min, double max );
     min = (min1, min2,...) max = (max1, max2, ..)
     This modifies \a *v!
 */
-VCC_EXPORT void ToRange( int n, double* v, double const* min, double const* max );
+VCC_EXPORT void ToRange(int n, double* v, double const* min, double const* max);
 
 
 /*!
@@ -167,7 +167,7 @@ VCC_EXPORT void ToRange( int n, double* v, double const* min, double const* max 
     min = (min1, min2,...) max = (max1, max2, ..)
     This modifies \a v!
 */
-VCC_EXPORT void ToRange( std::vector<double>& v, std::vector<double> const& min, std::vector<double> const& max );
+VCC_EXPORT void ToRange(std::vector<double>& v, std::vector<double> const& min, std::vector<double> const& max);
 
 
 /*!
@@ -175,38 +175,38 @@ VCC_EXPORT void ToRange( std::vector<double>& v, std::vector<double> const& min,
     min = (min1, min2,...) max = (max1, max2, ..)
     This modifies \a v!
 */
-VCC_EXPORT void ToRange( cSimpleVector& v, std::vector<double> const& min, std::vector<double> const& max );
+VCC_EXPORT void ToRange(cSimpleVector& v, std::vector<double> const& min, std::vector<double> const& max);
 
 
 /*!
     Return True if a is approximately the same as b. I.E. |a-b| < eps
 */
-VCC_EXPORT double Approx( double a, double b, double eps );
+VCC_EXPORT double Approx(double a, double b, double eps);
 
 
 /*!
     Return True if list/tuple/array a=(a1,a2,...) is approximately
     the same as b=(b1,b2,...). I.E. |a_i-b_i| < eps[i]
 */
-VCC_EXPORT bool Approx( int n, double* a, double* b, double* eps );
+VCC_EXPORT bool Approx(int n, double* a, double* b, double* eps);
 
 
 /*!
     Return d in deg converted to rad
 */
-VCC_EXPORT double DegToRad( double d );
+VCC_EXPORT double DegToRad(double d);
 
 
 /*!
     Return r in rad converted to deg
 */
-VCC_EXPORT double RadToDeg( double r );
+VCC_EXPORT double RadToDeg(double r);
 
 
 /*!
     Sleep for t seconds. (t is a double!)
 */
-VCC_EXPORT void SleepSec( double t );
+VCC_EXPORT void SleepSec(double t);
 
 
 /*!
@@ -218,16 +218,16 @@ VCC_EXPORT void SleepSec( double t );
    Applies the function object \p f to each element of the \a sequence.
  */
 template<typename Function, typename Tp>
-void apply( Function f, Tp& sequence )
+void apply(Function f, Tp& sequence)
 {
-    // concept requirements
+  // concept requirements
 
-    for ( typename Tp::iterator it = sequence.begin();
-          it < sequence.end();
-          it++ )
-    {
-        *it = f( *it );
-    }
+  for (typename Tp::iterator it = sequence.begin();
+       it < sequence.end();
+       it++)
+  {
+    *it = f(*it);
+  }
 }
 //----------------------------------------------------------------------
 
@@ -246,13 +246,13 @@ void apply( Function f, Tp& sequence )
  */
 template<typename Function, typename InputIterator>
 Function
-apply( Function f, InputIterator first, InputIterator last)
+apply(Function f, InputIterator first, InputIterator last)
 {
-    // concept requirements (not understood by gcc 3.2, thus commented out)
-    //__glibcxx_function_requires(_InputIteratorConcept<InputIterator>)
-    //  __glibcxx_requires_valid_range(first, last);
-  for ( ; first != last; ++first)
-        *first = f(*first);
+  // concept requirements (not understood by gcc 3.2, thus commented out)
+  //__glibcxx_function_requires(_InputIteratorConcept<InputIterator>)
+  //  __glibcxx_requires_valid_range(first, last);
+  for (; first != last; ++first)
+    *first = f(*first);
 }
 //----------------------------------------------------------------------
 
@@ -266,11 +266,11 @@ apply( Function f, InputIterator first, InputIterator last)
 template<typename Function, typename Tp>
 Tp map(Function f, Tp sequence)
 {
-    Tp result (sequence);
+  Tp result(sequence);
 
-    apply( f, result );
+  apply(f, result);
 
-    return result;
+  return result;
 }
 //----------------------------------------------------------------------
 
@@ -310,45 +310,45 @@ Tp map(Function f, Tp sequence)
 template<typename T>
 std::ostream& operator<<(std::ostream& stream, std::vector<T> const& v)
 {
-    char const* sep = "";
+  char const* sep = "";
 
-    typename std::vector<T>::const_iterator it;
-    for ( it = v.begin();
-          it != v.end();
-          it++ )
-    {
-        stream << sep << *it ;
-        sep = ", ";
-    }
+  typename std::vector<T>::const_iterator it;
+  for (it = v.begin();
+       it != v.end();
+       it++)
+  {
+    stream << sep << *it ;
+    sep = ", ";
+  }
 
-    return stream;
+  return stream;
 }
 //----------------------------------------------------------------------
 
 //! compare release strings
-VCC_EXPORT int CompareReleases( char const* rev1, char const* rev2 );
+VCC_EXPORT int CompareReleases(char const* rev1, char const* rev2);
 //----------------------------------------------------------------------
 
 //! helper class to set value on construction and reset to previous value on destruction. (RAII-idiom)
 template<typename T>
 class VCC_EXPORT cSetValueTemporarily
 {
-    T* value_ptr;
-    T  old_value;
+  T* value_ptr;
+  T  old_value;
 public:
-    //! CTOR: remember current value of \a _value_ptr and set it to \a new_value
-    cSetValueTemporarily( T* _value_ptr, T new_value )
-    : value_ptr( _value_ptr ),
-      old_value( *value_ptr )
-    {
-        *value_ptr = new_value;
-    }
+  //! CTOR: remember current value of \a _value_ptr and set it to \a new_value
+  cSetValueTemporarily(T* _value_ptr, T new_value)
+    : value_ptr(_value_ptr),
+      old_value(*value_ptr)
+  {
+    *value_ptr = new_value;
+  }
 
-    //! DTOR: restore the remembered value
-    ~cSetValueTemporarily()
-    {
-        *value_ptr = old_value;
-    }
+  //! DTOR: restore the remembered value
+  ~cSetValueTemporarily()
+  {
+    *value_ptr = old_value;
+  }
 };
 
 //! @}   // end of doxygen name group sdhlibrary_cpp_util_h_auxiliary

--- a/schunk_sdh/package.xml
+++ b/schunk_sdh/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
+  <build_depend>roslint</build_depend>
   <exec_depend>message_runtime</exec_depend>
 
   <depend>actionlib</depend>

--- a/schunk_sdh/ros/src/dsa_only.cpp
+++ b/schunk_sdh/ros/src/dsa_only.cpp
@@ -57,10 +57,12 @@
  *
  ****************************************************************/
 
-//##################
-//#### includes ####
+// ##################
+// #### includes ####
 // standard includes
 #include <unistd.h>
+#include <string>
+#include <vector>
 
 // ROS includes
 #include <ros/ros.h>
@@ -119,19 +121,19 @@ private:
   // actionlib server
 
   // service clients
-  //--
+  // --
 
   // other variables
   SDH::cDSA *dsa_;
-  SDH::UInt32 last_data_publish_; // time stamp of last data publishing
+  SDH::UInt32 last_data_publish_;  // time stamp of last data publishing
 
   std::string dsadevicestring_;
   int dsadevicenum_;
-  int maxerror_; // maximum error count allowed
+  int maxerror_;  // maximum error count allowed
 
   bool isDSAInitialized_;
   int error_counter_;
-  bool polling_; // try to publish on each response
+  bool polling_;  // try to publish on each response
   bool auto_publish_;
   bool use_rle_;
   bool debug_;
@@ -221,12 +223,12 @@ public:
     if (!read_vector(nh_, "dsa_reorder", dsa_reorder_))
     {
       dsa_reorder_.resize(6);
-      dsa_reorder_[0] = 2; // t1
-      dsa_reorder_[1] = 3; // t2
-      dsa_reorder_[2] = 4; // f11
-      dsa_reorder_[3] = 5; // f12
-      dsa_reorder_[4] = 0; // f21
-      dsa_reorder_[5] = 1; // f22
+      dsa_reorder_[0] = 2;  // t1
+      dsa_reorder_[1] = 3;  // t2
+      dsa_reorder_[2] = 4;  // f11
+      dsa_reorder_[3] = 5;  // f12
+      dsa_reorder_[4] = 0;  // f21
+      dsa_reorder_[5] = 1;  // f22
     }
 
     return true;
@@ -246,10 +248,9 @@ public:
 
   bool start()
   {
-
     if (isDSAInitialized_ == false)
     {
-      //Init tactile data
+      // Init tactile data
       if (!dsadevicestring_.empty())
       {
         try
@@ -302,7 +303,6 @@ public:
           if (auto_publish_)
             publishTactileData();
         }
-
       }
       catch (SDH::cSDHLibraryException* e)
       {
@@ -312,7 +312,6 @@ public:
       }
       if (error_counter_ > maxerror_)
         stop();
-
     }
     else
     {
@@ -331,7 +330,6 @@ public:
       {
         dsa_->SetFramerate(0, use_rle_);
         readDsaFrame();
-
       }
       catch (SDH::cSDHLibraryException* e)
       {
@@ -341,7 +339,6 @@ public:
       }
       if (error_counter_ > maxerror_)
         stop();
-
     }
     else
     {
@@ -354,7 +351,7 @@ public:
     if (debug_)
       ROS_DEBUG("publishTactileData %ul %ul", dsa_->GetFrame().timestamp, last_data_publish_);
     if (!isDSAInitialized_ || dsa_->GetFrame().timestamp == last_data_publish_)
-      return; // no new frame available
+      return;  // no new frame available
     last_data_publish_ = dsa_->GetFrame().timestamp;
 
     schunk_sdh::TactileSensor msg;
@@ -376,9 +373,8 @@ public:
           tm.tactile_array[tm.cells_x * y + x] = dsa_->GetTexel(m, x, y);
       }
     }
-    //publish matrix
+    // publish matrix
     topicPub_TactileSensor_.publish(msg);
-
   }
   void publishDiagnostics()
   {
@@ -410,10 +406,9 @@ public:
     topicPub_Diagnostics_.publish(diagnostics);
     if (debug_)
       ROS_DEBUG_STREAM("publishDiagnostics " << diagnostics);
-
   }
 };
-//DsaNode
+// DsaNode
 
 /*!
  * \brief Main loop of ROS node.

--- a/schunk_sdh/ros/src/dsa_only.cpp
+++ b/schunk_sdh/ros/src/dsa_only.cpp
@@ -59,7 +59,6 @@
 
 //##################
 //#### includes ####
-
 // standard includes
 #include <unistd.h>
 
@@ -79,11 +78,13 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/bind.hpp>
 
-template <typename T> bool read_vector(ros::NodeHandle &n_, const std::string &key, std::vector<T> & res){
+template<typename T>
+  bool read_vector(ros::NodeHandle &n_, const std::string &key, std::vector<T> & res)
+  {
     XmlRpc::XmlRpcValue namesXmlRpc;
     if (!n_.hasParam(key))
     {
-	return false;
+      return false;
     }
 
     n_.getParam(key, namesXmlRpc);
@@ -91,321 +92,350 @@ template <typename T> bool read_vector(ros::NodeHandle &n_, const std::string &k
     res.resize(namesXmlRpc.size());
     for (int i = 0; i < namesXmlRpc.size(); i++)
     {
-    	res[i] = (T)namesXmlRpc[i];
+      res[i] = (T)namesXmlRpc[i];
     }
     return true;
-}
+  }
 
 /*!
-* \brief Implementation of ROS node for DSA.
-*
-* Offers actionlib and direct command interface.
-*/
+ * \brief Implementation of ROS node for DSA.
+ *
+ * Offers actionlib and direct command interface.
+ */
 class DsaNode
 {
-	public:
-		/// create a handle for this node, initialize node
-		ros::NodeHandle nh_;
-	private:
-		// declaration of topics to publish
-		ros::Publisher topicPub_TactileSensor_;
-		ros::Publisher topicPub_Diagnostics_;
+public:
+  /// create a handle for this node, initialize node
+  ros::NodeHandle nh_;
+private:
+  // declaration of topics to publish
+  ros::Publisher topicPub_TactileSensor_;
+  ros::Publisher topicPub_Diagnostics_;
 
-		// topic subscribers
+  // topic subscribers
 
-		// service servers
+  // service servers
 
-		// actionlib server
+  // actionlib server
 
-		// service clients
-		//--
+  // service clients
+  //--
 
-		// other variables
-		SDH::cDSA *dsa_;
-		SDH::UInt32 last_data_publish_; // time stamp of last data publishing
+  // other variables
+  SDH::cDSA *dsa_;
+  SDH::UInt32 last_data_publish_; // time stamp of last data publishing
 
-		std::string dsadevicestring_;
-		int dsadevicenum_;
-		int maxerror_; // maximum error count allowed
+  std::string dsadevicestring_;
+  int dsadevicenum_;
+  int maxerror_; // maximum error count allowed
 
-		bool isDSAInitialized_;
-		int error_counter_;
-		bool polling_; // try to publish on each response
-		bool auto_publish_;
-		bool use_rle_;
-		bool debug_;
-		double frequency_;
+  bool isDSAInitialized_;
+  int error_counter_;
+  bool polling_; // try to publish on each response
+  bool auto_publish_;
+  bool use_rle_;
+  bool debug_;
+  double frequency_;
 
+  ros::Timer timer_dsa, timer_publish, timer_diag;
 
-		ros::Timer timer_dsa,timer_publish, timer_diag;
+  std::vector<int> dsa_reorder_;
+public:
+  /*!
+   * \brief Constructor for SdhNode class
+   *
+   * \param name Name for the actionlib server
+   */
+  DsaNode() :
+      nh_("~"), dsa_(0), last_data_publish_(0), isDSAInitialized_(false), error_counter_(0)
+  {
+    topicPub_Diagnostics_ = nh_.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 1);
+    topicPub_TactileSensor_ = nh_.advertise<schunk_sdh::TactileSensor>("tactile_data", 1);
+  }
 
-		std::vector<int> dsa_reorder_;
-	public:
-		/*!
-		* \brief Constructor for SdhNode class
-		*
-		* \param name Name for the actionlib server
-		*/
-		DsaNode():nh_("~"),dsa_(0),last_data_publish_(0),isDSAInitialized_(false),error_counter_(0)
-		{
-			topicPub_Diagnostics_ = nh_.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 1);
-			topicPub_TactileSensor_ = nh_.advertise<schunk_sdh::TactileSensor>("tactile_data", 1);
-		}
+  /*!
+   * \brief Destructor for SdhNode class
+   */
+  ~DsaNode()
+  {
+    if (isDSAInitialized_)
+      dsa_->Close();
+    if (dsa_)
+      delete dsa_;
+  }
 
-		/*!
-		* \brief Destructor for SdhNode class
-		*/
-		~DsaNode()
-		{
-			if(isDSAInitialized_)
-				dsa_->Close();
-			if(dsa_)
-				delete dsa_;
-		}
+  void shutdown()
+  {
+    timer_dsa.stop();
+    timer_publish.stop();
+    timer_diag.stop();
+    nh_.shutdown();
+  }
 
-		void shutdown(){
-		    timer_dsa.stop();
-		    timer_publish.stop();
-		    timer_diag.stop();
-		    nh_.shutdown();
-		}
+  /*!
+   * \brief Initializes node to get parameters, subscribe and publish to topics.
+   */
+  bool init()
+  {
+    // implementation of topics to publish
 
+    nh_.param("dsadevicestring", dsadevicestring_, std::string(""));
+    if (dsadevicestring_.empty())
+      return false;
 
-		/*!
-		* \brief Initializes node to get parameters, subscribe and publish to topics.
-		*/
-		bool init()
-		{
-			// implementation of topics to publish
+    nh_.param("dsadevicenum", dsadevicenum_, 0);
+    nh_.param("maxerror", maxerror_, 8);
 
-			nh_.param("dsadevicestring", dsadevicestring_, std::string(""));
-			if (dsadevicestring_.empty()) return false;
+    double publish_frequency, diag_frequency;
 
-			nh_.param("dsadevicenum", dsadevicenum_, 0);
-			nh_.param("maxerror", maxerror_, 8);
+    nh_.param("debug", debug_, false);
+    nh_.param("polling", polling_, false);
+    nh_.param("use_rle", use_rle_, true);
+    nh_.param("diag_frequency", diag_frequency, 5.0);
+    frequency_ = 30.0;
+    if (polling_)
+      nh_.param("poll_frequency", frequency_, 5.0);
+    nh_.param("publish_frequency", publish_frequency, 0.0);
 
- 			double publish_frequency, diag_frequency;
+    auto_publish_ = true;
 
-			nh_.param("debug", debug_, false);
-			nh_.param("polling", polling_, false);
-			nh_.param("use_rle", use_rle_, true);
-			nh_.param("diag_frequency", diag_frequency, 5.0);
-			frequency_ = 30.0;
-			if(polling_) nh_.param("poll_frequency", frequency_, 5.0);
-			nh_.param("publish_frequency", publish_frequency, 0.0);
+    if (polling_)
+    {
+      timer_dsa = nh_.createTimer(ros::Rate(frequency_).expectedCycleTime(), boost::bind(&DsaNode::pollDsa, this));
+    }
+    else
+    {
+      timer_dsa = nh_.createTimer(ros::Rate(frequency_ * 2.0).expectedCycleTime(),
+                                  boost::bind(&DsaNode::readDsaFrame, this));
+      if (publish_frequency > 0.0)
+      {
+        auto_publish_ = false;
+        timer_publish = nh_.createTimer(ros::Rate(publish_frequency).expectedCycleTime(),
+                                        boost::bind(&DsaNode::publishTactileData, this));
+      }
+    }
 
-			auto_publish_ = true;
+    timer_diag = nh_.createTimer(ros::Rate(diag_frequency).expectedCycleTime(),
+                                 boost::bind(&DsaNode::publishDiagnostics, this));
 
+    if (!read_vector(nh_, "dsa_reorder", dsa_reorder_))
+    {
+      dsa_reorder_.resize(6);
+      dsa_reorder_[0] = 2; // t1
+      dsa_reorder_[1] = 3; // t2
+      dsa_reorder_[2] = 4; // f11
+      dsa_reorder_[3] = 5; // f12
+      dsa_reorder_[4] = 0; // f21
+      dsa_reorder_[5] = 1; // f22
+    }
 
-			if(polling_){
-			    timer_dsa = nh_.createTimer(ros::Rate(frequency_).expectedCycleTime(),boost::bind(&DsaNode::pollDsa,  this));
- 			}else{
-			    timer_dsa = nh_.createTimer(ros::Rate(frequency_*2.0).expectedCycleTime(),boost::bind(&DsaNode::readDsaFrame,  this));
-			    if(publish_frequency > 0.0){
-				auto_publish_ = false;
-				timer_publish = nh_.createTimer(ros::Rate(publish_frequency).expectedCycleTime(),boost::bind(&DsaNode::publishTactileData, this));
-			    }
-			}
+    return true;
+  }
+  bool stop()
+  {
+    if (dsa_)
+    {
+      if (isDSAInitialized_)
+        dsa_->Close();
+      delete dsa_;
+    }
+    dsa_ = 0;
+    isDSAInitialized_ = false;
+    return true;
+  }
 
-			timer_diag = nh_.createTimer(ros::Rate(diag_frequency).expectedCycleTime(),boost::bind(&DsaNode::publishDiagnostics, this));
+  bool start()
+  {
 
-			if(!read_vector(nh_, "dsa_reorder", dsa_reorder_)){
-			    dsa_reorder_.resize(6);
-			    dsa_reorder_[0] = 2; // t1
-			    dsa_reorder_[1] = 3; // t2
-			    dsa_reorder_[2] = 4; // f11
-			    dsa_reorder_[3] = 5; // f12
-			    dsa_reorder_[4] = 0; // f21
-			    dsa_reorder_[5] = 1; // f22
-			}
+    if (isDSAInitialized_ == false)
+    {
+      //Init tactile data
+      if (!dsadevicestring_.empty())
+      {
+        try
+        {
+          dsa_ = new SDH::cDSA(0, dsadevicenum_, dsadevicestring_.c_str());
+          if (!polling_)
+            dsa_->SetFramerate(frequency_, use_rle_);
+          else
+            dsa_->SetFramerate(0, use_rle_);
 
-			return true;
-		}
-		bool stop(){
-			if(dsa_){
-			    if(isDSAInitialized_)
-				dsa_->Close();
-			    delete dsa_;
-			}
-			dsa_ = 0;
-			isDSAInitialized_ = false;
-			return true;
-		}
+          ROS_INFO("Initialized RS232 for DSA Tactile Sensors on device %s", dsadevicestring_.c_str());
+          // ROS_INFO("Set sensitivity to 1.0");
+          // for(int i=0; i<6; i++)
+          // 	dsa_->SetMatrixSensitivity(i, 1.0);
+          error_counter_ = 0;
+          isDSAInitialized_ = true;
+        }
+        catch (SDH::cSDHLibraryException* e)
+        {
+          isDSAInitialized_ = false;
+          ROS_ERROR("An exception was caught: %s", e->what());
+          delete e;
 
-		bool start()
-		{
+          shutdown();
+          return false;
+        }
+      }
+    }
 
-			if (isDSAInitialized_ == false)
-			{
-				//Init tactile data
-				if(!dsadevicestring_.empty())  {
-					try
-					{
-						dsa_ = new SDH::cDSA(0, dsadevicenum_, dsadevicestring_.c_str());
-						if(!polling_)
-						    dsa_->SetFramerate( frequency_, use_rle_ );
-                        			else
-                            			    dsa_->SetFramerate( 0, use_rle_ );
+    return true;
+  }
 
-						ROS_INFO("Initialized RS232 for DSA Tactile Sensors on device %s",dsadevicestring_.c_str());
-						// ROS_INFO("Set sensitivity to 1.0");
-						// for(int i=0; i<6; i++)
-						// 	dsa_->SetMatrixSensitivity(i, 1.0);
-						error_counter_ = 0;
-						isDSAInitialized_ = true;
-					}
-					catch (SDH::cSDHLibraryException* e)
-					{
-						isDSAInitialized_ = false;
-						ROS_ERROR("An exception was caught: %s", e->what());
-						delete e;
+  void readDsaFrame()
+  {
+    if (debug_)
+      ROS_DEBUG("readDsaFrame");
 
-						shutdown();
-						return false;
-					}
-				}
-			}
+    if (isDSAInitialized_)
+    {
+      try
+      {
+        SDH::UInt32 last_time;
+        last_time = dsa_->GetFrame().timestamp;
+        dsa_->UpdateFrame();
+        if (last_time != dsa_->GetFrame().timestamp)
+        { // new data
+          if (error_counter_ > 0)
+            --error_counter_;
+          if (auto_publish_)
+            publishTactileData();
+        }
 
-			return true;
-		}
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        delete e;
+        ++error_counter_;
+      }
+      if (error_counter_ > maxerror_)
+        stop();
 
-	void readDsaFrame()
-	{
-		if(debug_) ROS_DEBUG("readDsaFrame");
+    }
+    else
+    {
+      start();
+    }
+  }
 
-		if(isDSAInitialized_)
-		{
-			try
-			{
-				SDH::UInt32 last_time;
-				last_time = dsa_->GetFrame().timestamp;
-				dsa_->UpdateFrame();
-				if(last_time != dsa_->GetFrame().timestamp){ // new data
-				    if(error_counter_ > 0) --error_counter_;
-				    if(auto_publish_) publishTactileData();
-				}
+  void pollDsa()
+  {
+    if (debug_)
+      ROS_DEBUG("pollDsa");
 
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-				++error_counter_;
-			}
-			if(error_counter_ > maxerror_) stop();
+    if (isDSAInitialized_)
+    {
+      try
+      {
+        dsa_->SetFramerate(0, use_rle_);
+        readDsaFrame();
 
-		}else{
-		    start();
-		}
-	}
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        delete e;
+        ++error_counter_;
+      }
+      if (error_counter_ > maxerror_)
+        stop();
 
-	void pollDsa(){
-		if(debug_) ROS_DEBUG("pollDsa");
+    }
+    else
+    {
+      start();
+    }
+  }
 
-		if(isDSAInitialized_)
-		{
-			try
-			{
-				dsa_->SetFramerate( 0, use_rle_ );
-				readDsaFrame();
+  void publishTactileData()
+  {
+    if (debug_)
+      ROS_DEBUG("publishTactileData %ul %ul", dsa_->GetFrame().timestamp, last_data_publish_);
+    if (!isDSAInitialized_ || dsa_->GetFrame().timestamp == last_data_publish_)
+      return; // no new frame available
+    last_data_publish_ = dsa_->GetFrame().timestamp;
 
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-				++error_counter_;
-			}
-			if(error_counter_ > maxerror_) stop();
+    schunk_sdh::TactileSensor msg;
+    msg.header.stamp = ros::Time::now();
+    int m, x, y;
+    msg.tactile_matrix.resize(dsa_->GetSensorInfo().nb_matrices);
+    ROS_ASSERT(dsa_->GetSensorInfo().nb_matrices == dsa_reorder_.size());
+    for (unsigned int i = 0; i < dsa_reorder_.size(); i++)
+    {
+      m = dsa_reorder_[i];
+      schunk_sdh::TactileMatrix &tm = msg.tactile_matrix[i];
+      tm.matrix_id = i;
+      tm.cells_x = dsa_->GetMatrixInfo(m).cells_x;
+      tm.cells_y = dsa_->GetMatrixInfo(m).cells_y;
+      tm.tactile_array.resize(tm.cells_x * tm.cells_y);
+      for (y = 0; y < tm.cells_y; y++)
+      {
+        for (x = 0; x < tm.cells_x; x++)
+          tm.tactile_array[tm.cells_x * y + x] = dsa_->GetTexel(m, x, y);
+      }
+    }
+    //publish matrix
+    topicPub_TactileSensor_.publish(msg);
 
-		}else{
-		    start();
-		}
-	}
+  }
+  void publishDiagnostics()
+  {
+    // publishing diagnotic messages
+    diagnostic_msgs::DiagnosticArray diagnostics;
+    diagnostics.status.resize(1);
+    diagnostics.status[0].name = nh_.getNamespace();
+    diagnostics.status[0].values.resize(1);
+    diagnostics.status[0].values[0].key = "error_count";
+    diagnostics.status[0].values[0].value = boost::lexical_cast < std::string > (error_counter_);
 
-	void publishTactileData()
-	{
-	    if(debug_) ROS_DEBUG("publishTactileData %ul %ul",dsa_->GetFrame().timestamp, last_data_publish_);
-	    if(!isDSAInitialized_ || dsa_->GetFrame().timestamp == last_data_publish_) return; // no new frame available
-	    last_data_publish_ = dsa_->GetFrame().timestamp;
+    // set data to diagnostics
+    if (isDSAInitialized_)
+    {
+      diagnostics.status[0].level = 0;
+      diagnostics.status[0].message = "DSA tactile sensing initialized and running";
+    }
+    else if (error_counter_ == 0)
+    {
+      diagnostics.status[0].level = 1;
+      diagnostics.status[0].message = "DSA not initialized";
+    }
+    else
+    {
+      diagnostics.status[0].level = 2;
+      diagnostics.status[0].message = "DSA exceeded eror count";
+    }
+    // publish diagnostic message
+    topicPub_Diagnostics_.publish(diagnostics);
+    if (debug_)
+      ROS_DEBUG_STREAM("publishDiagnostics " << diagnostics);
 
-	    schunk_sdh::TactileSensor msg;
-	    msg.header.stamp = ros::Time::now();
-	    int m, x, y;
-	    msg.tactile_matrix.resize(dsa_->GetSensorInfo().nb_matrices);
-	    ROS_ASSERT(dsa_->GetSensorInfo().nb_matrices == dsa_reorder_.size());
-	    for ( unsigned int i = 0; i < dsa_reorder_.size(); i++ )
-	    {
-		    m = dsa_reorder_[i];
-		    schunk_sdh::TactileMatrix &tm = msg.tactile_matrix[i];
-		    tm.matrix_id = i;
-		    tm.cells_x = dsa_->GetMatrixInfo( m ).cells_x;
-		    tm.cells_y = dsa_->GetMatrixInfo( m ).cells_y;
-		    tm.tactile_array.resize(tm.cells_x * tm.cells_y);
-		    for ( y = 0; y < tm.cells_y; y++ )
-		    {
-			    for ( x = 0; x < tm.cells_x; x++ )
-				    tm.tactile_array[tm.cells_x*y + x] = dsa_->GetTexel( m, x, y );
-		    }
-	    }
-	    //publish matrix
-	    topicPub_TactileSensor_.publish(msg);
-
-	}
-	void publishDiagnostics()
-	{
-	    // publishing diagnotic messages
-	    diagnostic_msgs::DiagnosticArray diagnostics;
-	    diagnostics.status.resize(1);
-	    diagnostics.status[0].name = nh_.getNamespace();
-	    diagnostics.status[0].values.resize(1);
-	    diagnostics.status[0].values[0].key = "error_count";
-	    diagnostics.status[0].values[0].value = boost::lexical_cast<std::string>( error_counter_);
-
-	    // set data to diagnostics
-	    if (isDSAInitialized_)
-	    {
-		diagnostics.status[0].level = 0;
-		diagnostics.status[0].message = "DSA tactile sensing initialized and running";
-	    }
-	    else if(error_counter_ == 0)
-	    {
-		diagnostics.status[0].level = 1;
-		diagnostics.status[0].message = "DSA not initialized";
-	    }
-	    else
-	    {
-		diagnostics.status[0].level = 2;
-		diagnostics.status[0].message = "DSA exceeded eror count";
-	    }
-	    // publish diagnostic message
-	    topicPub_Diagnostics_.publish(diagnostics);
-	    if(debug_) ROS_DEBUG_STREAM("publishDiagnostics " << diagnostics);
-
-	}
-}; //DsaNode
+  }
+};
+//DsaNode
 
 /*!
-* \brief Main loop of ROS node.
-*
-* Running with a specific frequency defined by loop_rate.
-*/
+ * \brief Main loop of ROS node.
+ *
+ * Running with a specific frequency defined by loop_rate.
+ */
 int main(int argc, char** argv)
 {
-	// initialize ROS, spezify name of node
-	ros::init(argc, argv, "schunk_dsa");
+  // initialize ROS, spezify name of node
+  ros::init(argc, argv, "schunk_dsa");
 
-	DsaNode dsa_node;
+  DsaNode dsa_node;
 
-	if (!dsa_node.init()) return 0;
+  if (!dsa_node.init())
+    return 0;
 
-	dsa_node.start();
+  dsa_node.start();
 
-	ROS_INFO("...dsa node running...");
+  ROS_INFO("...dsa node running...");
 
-	ros::spin();
+  ros::spin();
 
-	ROS_INFO("...dsa node shut down...");
-	return 0;
+  ROS_INFO("...dsa node shut down...");
+  return 0;
 }
 

--- a/schunk_sdh/ros/src/dsa_only.cpp
+++ b/schunk_sdh/ros/src/dsa_only.cpp
@@ -149,8 +149,8 @@ public:
   DsaNode() :
       nh_("~"), dsa_(0), last_data_publish_(0), isDSAInitialized_(false), error_counter_(0)
   {
-    topicPub_Diagnostics_ = nh_.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 1);
-    topicPub_TactileSensor_ = nh_.advertise<schunk_sdh::TactileSensor>("tactile_data", 1);
+    topicPub_Diagnostics_ = nh_.advertise < diagnostic_msgs::DiagnosticArray > ("/diagnostics", 1);
+    topicPub_TactileSensor_ = nh_.advertise < schunk_sdh::TactileSensor > ("tactile_data", 1);
   }
 
   /*!

--- a/schunk_sdh/ros/src/dsa_only.cpp
+++ b/schunk_sdh/ros/src/dsa_only.cpp
@@ -263,7 +263,7 @@ public:
           ROS_INFO("Initialized RS232 for DSA Tactile Sensors on device %s", dsadevicestring_.c_str());
           // ROS_INFO("Set sensitivity to 1.0");
           // for(int i=0; i<6; i++)
-          // 	dsa_->SetMatrixSensitivity(i, 1.0);
+          //  dsa_->SetMatrixSensitivity(i, 1.0);
           error_counter_ = 0;
           isDSAInitialized_ = true;
         }
@@ -295,7 +295,8 @@ public:
         last_time = dsa_->GetFrame().timestamp;
         dsa_->UpdateFrame();
         if (last_time != dsa_->GetFrame().timestamp)
-        { // new data
+        {
+          // new data
           if (error_counter_ > 0)
             --error_counter_;
           if (auto_publish_)

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -492,7 +492,7 @@ public:
           ROS_INFO("Initialized RS232 for DSA Tactile Sensors on device %s", dsadevicestring_.c_str());
           // ROS_INFO("Set sensitivity to 1.0");
           // for(int i=0; i<6; i++)
-          // 	dsa_->SetMatrixSensitivity(i, 1.0);
+          //  dsa_->SetMatrixSensitivity(i, 1.0);
           isDSAInitialized_ = true;
         }
         catch (SDH::cSDHLibraryException* e)

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -59,7 +59,6 @@
 
 //##################
 //#### includes ####
-
 // standard includes
 #include <unistd.h>
 
@@ -89,804 +88,828 @@
 #include <schunk_sdh/dsa.h>
 
 /*!
-* \brief Implementation of ROS node for sdh.
-*
-* Offers actionlib and direct command interface.
-*/
+ * \brief Implementation of ROS node for sdh.
+ *
+ * Offers actionlib and direct command interface.
+ */
 class SdhNode
 {
-	public:
-		/// create a handle for this node, initialize node
-		ros::NodeHandle nh_;
-	private:
-		// declaration of topics to publish
-		ros::Publisher topicPub_JointState_;
-		ros::Publisher topicPub_ControllerState_;
-		ros::Publisher topicPub_TactileSensor_;
-		ros::Publisher topicPub_Diagnostics_;
-
-		// topic subscribers
-		ros::Subscriber subSetVelocitiesRaw_;
-
-		// service servers
-		ros::ServiceServer srvServer_Init_;
-		ros::ServiceServer srvServer_Stop_;
-		ros::ServiceServer srvServer_Recover_;
-		ros::ServiceServer srvServer_SetOperationMode_;
-
-		// actionlib server
-		actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> as_;
-		std::string action_name_;
-
-		// service clients
-		//--
-
-		// other variables
-		SDH::cSDH *sdh_;
-		SDH::cDSA *dsa_;
-		std::vector<SDH::cSDH::eAxisState> state_;
-
-		std::string sdhdevicetype_;
-		std::string sdhdevicestring_;
-		int sdhdevicenum_;
-		std::string dsadevicestring_;
-		int dsadevicenum_;
-		int baudrate_, id_read_, id_write_;
-		double timeout_;
-
-		bool isInitialized_;
-		bool isDSAInitialized_;
-		bool isError_;
-		int DOF_;
-		double pi_;
-
-		trajectory_msgs::JointTrajectory traj_;
-
-		std::vector<std::string> joint_names_;
-		std::vector<int> axes_;
-		std::vector<double> targetAngles_; // in degrees
-		std::vector<double> velocities_; // in rad/s
-		bool hasNewGoal_;
-		std::string operationMode_;
-
-	public:
-		/*!
-		* \brief Constructor for SdhNode class
-		*
-		* \param name Name for the actionlib server
-		*/
-		SdhNode(std::string name):
-			as_(nh_, name, boost::bind(&SdhNode::executeCB, this, _1),true),
-			action_name_(name)
-		{
-			pi_ = 3.1415926;
-
-			nh_ = ros::NodeHandle ("~");
-			isError_ = false;
-			// diagnostics
-			topicPub_Diagnostics_ = nh_.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 1);
-		}
-
-		/*!
-		* \brief Destructor for SdhNode class
-		*/
-		~SdhNode()
-		{
-			if(isDSAInitialized_)
-				dsa_->Close();
-			if(isInitialized_)
-				sdh_->Close();
-			delete sdh_;
-		}
-
-
-		/*!
-		* \brief Initializes node to get parameters, subscribe and publish to topics.
-		*/
-		bool init()
-		{
-			// initialize member variables
-			isInitialized_ = false;
-			isDSAInitialized_ = false;
-			hasNewGoal_ = false;
-
-			// implementation of topics to publish
-			topicPub_JointState_ = nh_.advertise<sensor_msgs::JointState>("joint_states", 1);
-			topicPub_ControllerState_ = nh_.advertise<control_msgs::JointTrajectoryControllerState>("joint_trajectory_controller/state", 1);
-			topicPub_TactileSensor_ = nh_.advertise<schunk_sdh::TactileSensor>("tactile_data", 1);
-
-			// pointer to sdh
-			sdh_ = new SDH::cSDH(false, false, 0); //(_use_radians=false, bool _use_fahrenheit=false, int _debug_level=0)
-
-			// implementation of service servers
-			srvServer_Init_ = nh_.advertiseService("init", &SdhNode::srvCallback_Init, this);
-			srvServer_Stop_ = nh_.advertiseService("stop", &SdhNode::srvCallback_Stop, this);
-			srvServer_Recover_ = nh_.advertiseService("recover", &SdhNode::srvCallback_Init, this); //HACK: There is no recover implemented yet, so we execute a init
-			srvServer_SetOperationMode_ = nh_.advertiseService("set_operation_mode", &SdhNode::srvCallback_SetOperationMode, this);
-
-			subSetVelocitiesRaw_ = nh_.subscribe("joint_group_velocity_controller/command", 1, &SdhNode::topicCallback_setVelocitiesRaw, this);
-
-			// getting hardware parameters from parameter server
-			nh_.param("sdhdevicetype", sdhdevicetype_, std::string("PCAN"));
-			nh_.param("sdhdevicestring", sdhdevicestring_, std::string("/dev/pcan0"));
-			nh_.param("sdhdevicenum", sdhdevicenum_, 0);
-
-			nh_.param("dsadevicestring", dsadevicestring_, std::string(""));
-			nh_.param("dsadevicenum", dsadevicenum_, 0);
-
-			nh_.param("baudrate", baudrate_, 1000000);
-			nh_.param("timeout", timeout_, (double)0.04);
-			nh_.param("id_read", id_read_, 43);
-			nh_.param("id_write", id_write_, 42);
-
-			// get joint_names from parameter server
-			ROS_INFO("getting joint_names from parameter server");
-			XmlRpc::XmlRpcValue joint_names_param;
-			if (nh_.hasParam("joint_names"))
-			{
-				nh_.getParam("joint_names", joint_names_param);
-			}
-			else
-			{
-				ROS_ERROR("Parameter joint_names not set, shutting down node...");
-				nh_.shutdown();
-				return false;
-			}
-			DOF_ = joint_names_param.size();
-			joint_names_.resize(DOF_);
-			for (int i = 0; i<DOF_; i++ )
-			{
-				joint_names_[i] = (std::string)joint_names_param[i];
-			}
-			std::cout << "joint_names = " << joint_names_param << std::endl;
-
-			// define axes to send to sdh
-			axes_.resize(DOF_);
-			velocities_.resize(DOF_);
-			for(int i=0; i<DOF_; i++)
-			{
-				axes_[i] = i;
-			}
-			ROS_INFO("DOF = %d",DOF_);
-
-			state_.resize(axes_.size());
-
-			nh_.param("OperationMode", operationMode_, std::string("position"));
-			return true;
-		}
-		/*!
-		* \brief Switches operation mode if possible
-		*
-		* \param mode new mode
-		*/
-		bool switchOperationMode(const std::string &mode){
-			hasNewGoal_ = false;
-			sdh_->Stop();
-
-			try{
-				if(mode == "position"){
-					sdh_->SetController(SDH::cSDH::eCT_POSE);
-				}else if(mode == "velocity"){
-					sdh_->SetController(SDH::cSDH::eCT_VELOCITY);
-				}else{
-					ROS_ERROR_STREAM("Operation mode '" << mode << "'  not supported");
-					return false;
-				}
-				sdh_->SetAxisEnable(sdh_->All, 1.0); // TODO: check if necessary
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-				return false;
-			}
-
-			operationMode_ = mode;
-			return true;
-
-		}
-
-		/*!
-		* \brief Executes the callback from the actionlib
-		*
-		* Set the current goal to aborted after receiving a new goal and write new goal to a member variable. Wait for the goal to finish and set actionlib status to succeeded.
-		* \param goal JointTrajectoryGoal
-		*/
-		void executeCB(const control_msgs::FollowJointTrajectoryGoalConstPtr &goal)
-		{
-			ROS_INFO("sdh: executeCB");
-			if (operationMode_ != "position")
-			{
-				ROS_ERROR("%s: Rejected, sdh not in position mode", action_name_.c_str());
-				as_.setAborted();
-				return;
-			}
-			if (!isInitialized_)
-			{
-				ROS_ERROR("%s: Rejected, sdh not initialized", action_name_.c_str());
-				as_.setAborted();
-				return;
-			}
-
-			if (goal->trajectory.points.empty() || goal->trajectory.points[0].positions.size() != size_t(DOF_))
-			{
-				ROS_ERROR("%s: Rejected, malformed FollowJointTrajectoryGoal", action_name_.c_str());
-				as_.setAborted();
-				return;
-			}
-			while (hasNewGoal_ == true ) usleep(10000);
-
-			std::map<std::string,int> dict;
-			for (int idx=0; idx<goal->trajectory.joint_names.size(); idx++)
-			{
-				dict[goal->trajectory.joint_names[idx]] = idx;
-			}
-
-			targetAngles_.resize(DOF_);
-			targetAngles_[0] = goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]]*180.0/pi_; // sdh_knuckle_joint
-			targetAngles_[1] = goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]]*180.0/pi_; // sdh_finger22_joint
-			targetAngles_[2] = goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]]*180.0/pi_; // sdh_finger23_joint
-			targetAngles_[3] = goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]]*180.0/pi_; // sdh_thumb2_joint
-			targetAngles_[4] = goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]]*180.0/pi_; // sdh_thumb3_joint
-			targetAngles_[5] = goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]]*180.0/pi_; // sdh_finger12_joint
-			targetAngles_[6] = goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]]*180.0/pi_; // sdh_finger13_joint
-			ROS_INFO("received position goal: [['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']] = [%f,%f,%f,%f,%f,%f,%f]",goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]],goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]],goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]],goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]],goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]],goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]],goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]]);
-
-			hasNewGoal_ = true;
-
-			usleep(500000); // needed sleep until sdh starts to change status from idle to moving
-
-			bool finished = false;
-			while(finished == false)
-			{
-				if (as_.isNewGoalAvailable())
-				{
-					ROS_WARN("%s: Aborted", action_name_.c_str());
-					as_.setAborted();
-					return;
-				}
-				for ( unsigned int i = 0; i < state_.size(); i++ )
-		 		{
-		 			ROS_DEBUG("state[%d] = %d",i,state_[i]);
-		 			if (state_[i] == 0)
-		 			{
-		 				finished = true;
-		 			}
-		 			else
-		 			{
-		 				finished = false;
-		 			}
-		 		}
-		 		usleep(10000);
-				//feedback_ =
-				//as_.send feedback_
-			}
-
-			// set the action state to succeeded
-			ROS_INFO("%s: Succeeded", action_name_.c_str());
-			//result_.result.data = "succesfully received new goal";
-			//result_.success = 1;
-			//as_.setSucceeded(result_);
-			as_.setSucceeded();
-		}
-
-		void topicCallback_setVelocitiesRaw(const std_msgs::Float64MultiArrayPtr& velocities)
-		{
-			if (!isInitialized_)
-			{
-				ROS_ERROR("%s: Rejected, sdh not initialized", action_name_.c_str());
-				return;
-			}
-			if(velocities->data.size() != velocities_.size()){
-				ROS_ERROR("Velocity array dimension mismatch");
-				return;
-			}
-			if (operationMode_ != "velocity")
-			{
-				ROS_ERROR("%s: Rejected, sdh not in velocity mode", action_name_.c_str());
-				return;
-			}
-
-			// TODO: write proper lock!
-			while (hasNewGoal_ == true ) usleep(10000);
-
-			velocities_[0] = velocities->data[0] * 180.0 / pi_; // sdh_knuckle_joint
-			velocities_[1] = velocities->data[5] * 180.0 / pi_; // sdh_finger22_joint
-			velocities_[2] = velocities->data[6] * 180.0 / pi_; // sdh_finger23_joint
-			velocities_[3] = velocities->data[1] * 180.0 / pi_; // sdh_thumb2_joint
-			velocities_[4] = velocities->data[2] * 180.0 / pi_; // sdh_thumb3_joint
-			velocities_[5] = velocities->data[3] * 180.0 / pi_; // sdh_finger12_joint
-			velocities_[6] = velocities->data[4] * 180.0 / pi_; // sdh_finger13_joint
-
-			hasNewGoal_ = true;
-		}
-
-		/*!
-		* \brief Executes the service callback for init.
-		*
-		* Connects to the hardware and initialized it.
-		* \param req Service request
-		* \param res Service response
-		*/
-		bool srvCallback_Init(std_srvs::Trigger::Request &req,
-							std_srvs::Trigger::Response &res )
-		{
-
-			if (isInitialized_ == false)
-			{
-				//Init Hand connection
-
-				try
-				{
-					if(sdhdevicetype_.compare("RS232")==0)
-					{
-						sdh_->OpenRS232( sdhdevicenum_, 115200, 1, sdhdevicestring_.c_str());
-						ROS_INFO("Initialized RS232 for SDH");
-						isInitialized_ = true;
-					}
-					if(sdhdevicetype_.compare("PCAN")==0)
-					{
-						ROS_INFO("Starting initializing PEAKCAN");
-						sdh_->OpenCAN_PEAK(baudrate_, timeout_, id_read_, id_write_, sdhdevicestring_.c_str());
-						ROS_INFO("Initialized PEAK CAN for SDH");
-						isInitialized_ = true;
-					}
-					if(sdhdevicetype_.compare("ESD")==0)
-					{
-						ROS_INFO("Starting initializing ESD");
-						if(strcmp(sdhdevicestring_.c_str(), "/dev/can0") == 0)
-						{
-							ROS_INFO("Initializing ESD on device %s",sdhdevicestring_.c_str());
-							sdh_->OpenCAN_ESD(0, baudrate_, timeout_, id_read_, id_write_ );
-						}
-						else if(strcmp(sdhdevicestring_.c_str(), "/dev/can1") == 0)
-						{
-							ROS_INFO("Initializin ESD on device %s",sdhdevicestring_.c_str());
-							sdh_->OpenCAN_ESD(1, baudrate_, timeout_, id_read_, id_write_ );
-						}
-						else
-						{
-							ROS_ERROR("Currently only support for /dev/can0 and /dev/can1");
-							res.success = false;
-							res.message = "Currently only support for /dev/can0 and /dev/can1";
-							return true;
-						}
-						ROS_INFO("Initialized ESDCAN for SDH");
-						isInitialized_ = true;
-					}
-				}
-				catch (SDH::cSDHLibraryException* e)
-				{
-					ROS_ERROR("An exception was caught: %s", e->what());
-					res.success = false;
-					res.message = e->what();
-					delete e;
-					return true;
-				}
-
-				//Init tactile data
-				if(!dsadevicestring_.empty())  {
-					try
-					{
-						dsa_ = new SDH::cDSA(0, dsadevicenum_, dsadevicestring_.c_str());
-						//dsa_->SetFramerate( 0, true, false );
-						dsa_->SetFramerate( 1, true );
-						ROS_INFO("Initialized RS232 for DSA Tactile Sensors on device %s",dsadevicestring_.c_str());
-						// ROS_INFO("Set sensitivity to 1.0");
-						// for(int i=0; i<6; i++)
-						// 	dsa_->SetMatrixSensitivity(i, 1.0);
-						isDSAInitialized_ = true;
-					}
-					catch (SDH::cSDHLibraryException* e)
-					{
-						isDSAInitialized_ = false;
-						ROS_ERROR("An exception was caught: %s", e->what());
-						res.success = false;
-						res.message = e->what();
-						delete e;
-						return true;
-					}
-				}
-				if(!switchOperationMode(operationMode_)){
-					res.success = false;
-					res.message = "Could not set operation mode to '" + operationMode_ + "'";
-					return true;
-				}
-			}
-			else
-			{
-				ROS_WARN("...sdh already initialized...");
-				res.success = true;
-				res.message = "sdh already initialized";
-			}
-
-			res.success = true;
-			return true;
-		}
-
-		/*!
-		* \brief Executes the service callback for stop.
-		*
-		* Stops all hardware movements.
-		* \param req Service request
-		* \param res Service response
-		*/
-		bool srvCallback_Stop(std_srvs::Trigger::Request &req,
-							std_srvs::Trigger::Response &res )
-		{
-			ROS_INFO("Stopping sdh");
-
-			// stopping all arm movements
-			try
-			{
-				sdh_->Stop();
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-			}
-
-		ROS_INFO("Stopping sdh succesfull");
-		res.success = true;
-		return true;
-	}
-
-	/*!
-	* \brief Executes the service callback for recover.
-	*
-	* Recovers the hardware after an emergency stop.
-	* \param req Service request
-	* \param res Service response
-	*/
-	bool srvCallback_Recover(std_srvs::Trigger::Request &req,
-							std_srvs::Trigger::Response &res )
-	{
-		ROS_WARN("Service recover not implemented yet");
-		res.success = true;
-		res.message = "Service recover not implemented yet";
-		return true;
-	}
-
-	/*!
-	* \brief Executes the service callback for set_operation_mode.
-	*
-	* Changes the operation mode.
-	* \param req Service request
-	* \param res Service response
-	*/
-	bool srvCallback_SetOperationMode(cob_srvs::SetString::Request &req,
-									cob_srvs::SetString::Response &res )
-	{
-		hasNewGoal_ = false;
-		sdh_->Stop();
-		ROS_INFO("Set operation mode to [%s]", req.data.c_str());
-		operationMode_ = req.data;
-		res.success = true;
-		if( operationMode_ == "position"){
-			sdh_->SetController(SDH::cSDH::eCT_POSE);
-		}else if( operationMode_ == "velocity"){
-			try{
-				sdh_->SetController(SDH::cSDH::eCT_VELOCITY);
-				sdh_->SetAxisEnable(sdh_->All, 1.0);
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-			}
-		}else{
-			ROS_ERROR_STREAM("Operation mode '" << req.data << "'  not supported");
-		}
-		return true;
-	}
-
-	/*!
-	* \brief Main routine to update sdh.
-	*
-	* Sends target to hardware and reads out current configuration.
-	*/
-	void updateSdh()
-	{
-		ROS_DEBUG("updateJointState");
-		if (isInitialized_ == true)
-		{
-			if (hasNewGoal_ == true)
-			{
-				// stop sdh first when new goal arrived
-				try
-				{
-					sdh_->Stop();
-				}
-				catch (SDH::cSDHLibraryException* e)
-				{
-					ROS_ERROR("An exception was caught: %s", e->what());
-					delete e;
-				}
-
-				if (operationMode_ == "position")
-				{
-					ROS_DEBUG("moving sdh in position mode");
-
-					try
-					{
-						sdh_->SetAxisTargetAngle( axes_, targetAngles_ );
-						sdh_->MoveHand(false);
-					}
-					catch (SDH::cSDHLibraryException* e)
-					{
-						ROS_ERROR("An exception was caught: %s", e->what());
-						delete e;
-					}
-				}
-				else if (operationMode_ == "velocity")
-				{
-					ROS_DEBUG("moving sdh in velocity mode");
-					try
-					{
-						sdh_->SetAxisTargetVelocity(axes_,velocities_);
-						// ROS_DEBUG_STREAM("velocities: " << velocities_[0] << " "<< velocities_[1] << " "<< velocities_[2] << " "<< velocities_[3] << " "<< velocities_[4] << " "<< velocities_[5] << " "<< velocities_[6]);
-					}
-					catch (SDH::cSDHLibraryException* e)
-					{
-						ROS_ERROR("An exception was caught: %s", e->what());
-						delete e;
-					}
-				}
-				else if (operationMode_ == "effort")
-				{
-					ROS_DEBUG("moving sdh in effort mode");
-					//sdh_->MoveVel(goal->trajectory.points[0].velocities);
-					ROS_WARN("Moving in effort mode currently disabled");
-				}
-				else
-				{
-					ROS_ERROR("sdh neither in position nor in velocity nor in effort mode. OperationMode = [%s]", operationMode_.c_str());
-				}
-
-				hasNewGoal_ = false;
-			}
-
-	 		// read and publish joint angles and velocities
-			std::vector<double> actualAngles;
-			try
-			{
-				actualAngles = sdh_->GetAxisActualAngle( axes_ );
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-			}
-			std::vector<double> actualVelocities;
-			try
-			{
-				actualVelocities = sdh_->GetAxisActualVelocity( axes_ );
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-			}
-
-			ROS_DEBUG("received %d angles from sdh",(int)actualAngles.size());
-
-			ros::Time time = ros::Time::now();
-
-			// create joint_state message
-			sensor_msgs::JointState msg;
-			msg.header.stamp = time;
-			msg.name.resize(DOF_);
-			msg.position.resize(DOF_);
-			msg.velocity.resize(DOF_);
-			msg.effort.resize(DOF_);
-			// set joint names and map them to angles
-			msg.name = joint_names_;
-			//['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
-			// pos
-			msg.position[0] = actualAngles[0]*pi_/180.0; // sdh_knuckle_joint
-			msg.position[1] = actualAngles[3]*pi_/180.0; // sdh_thumb_2_joint
-			msg.position[2] = actualAngles[4]*pi_/180.0; // sdh_thumb_3_joint
-			msg.position[3] = actualAngles[5]*pi_/180.0; // sdh_finger_12_joint
-			msg.position[4] = actualAngles[6]*pi_/180.0; // sdh_finger_13_joint
-			msg.position[5] = actualAngles[1]*pi_/180.0; // sdh_finger_22_joint
-			msg.position[6] = actualAngles[2]*pi_/180.0; // sdh_finger_23_joint
-			// vel
-			msg.velocity[0] = actualVelocities[0]*pi_/180.0; // sdh_knuckle_joint
-			msg.velocity[1] = actualVelocities[3]*pi_/180.0; // sdh_thumb_2_joint
-			msg.velocity[2] = actualVelocities[4]*pi_/180.0; // sdh_thumb_3_joint
-			msg.velocity[3] = actualVelocities[5]*pi_/180.0; // sdh_finger_12_joint
-			msg.velocity[4] = actualVelocities[6]*pi_/180.0; // sdh_finger_13_joint
-			msg.velocity[5] = actualVelocities[1]*pi_/180.0; // sdh_finger_22_joint
-			msg.velocity[6] = actualVelocities[2]*pi_/180.0; // sdh_finger_23_joint
-			// publish message
-			topicPub_JointState_.publish(msg);
-
-
-			// because the robot_state_publisher doen't know about the mimic joint, we have to publish the coupled joint separately
-			sensor_msgs::JointState  mimicjointmsg;
-			mimicjointmsg.header.stamp = time;
-			mimicjointmsg.name.resize(1);
-			mimicjointmsg.position.resize(1);
-			mimicjointmsg.velocity.resize(1);
-			mimicjointmsg.name[0] = "sdh_finger_21_joint";
-			mimicjointmsg.position[0] = msg.position[0]; // sdh_knuckle_joint = sdh_finger_21_joint
-			mimicjointmsg.velocity[0] = msg.velocity[0]; // sdh_knuckle_joint = sdh_finger_21_joint
-			topicPub_JointState_.publish(mimicjointmsg);
-
-
-			// publish controller state message
-			control_msgs::JointTrajectoryControllerState controllermsg;
-			controllermsg.header.stamp = time;
-			controllermsg.joint_names.resize(DOF_);
-			controllermsg.desired.positions.resize(DOF_);
-			controllermsg.desired.velocities.resize(DOF_);
-			controllermsg.actual.positions.resize(DOF_);
-			controllermsg.actual.velocities.resize(DOF_);
-			controllermsg.error.positions.resize(DOF_);
-			controllermsg.error.velocities.resize(DOF_);
-			// set joint names and map them to angles
-			controllermsg.joint_names = joint_names_;
-			//['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
-			// desired pos
-			if (targetAngles_.size() != 0)
-			{
-				controllermsg.desired.positions[0] = targetAngles_[0]*pi_/180.0; // sdh_knuckle_joint
-				controllermsg.desired.positions[1] = targetAngles_[3]*pi_/180.0; // sdh_thumb_2_joint
-				controllermsg.desired.positions[2] = targetAngles_[4]*pi_/180.0; // sdh_thumb_3_joint
-				controllermsg.desired.positions[3] = targetAngles_[5]*pi_/180.0; // sdh_finger_12_joint
-				controllermsg.desired.positions[4] = targetAngles_[6]*pi_/180.0; // sdh_finger_13_joint
-				controllermsg.desired.positions[5] = targetAngles_[1]*pi_/180.0; // sdh_finger_22_joint
-				controllermsg.desired.positions[6] = targetAngles_[2]*pi_/180.0; // sdh_finger_23_joint
-			}
-			// desired vel
-				// they are all zero
-			// actual pos
-			controllermsg.actual.positions = msg.position;
-			// actual vel
-			controllermsg.actual.velocities = msg.velocity;
-			// error, calculated out of desired and actual values
-			for (int i = 0; i<DOF_; i++ )
-			{
-				controllermsg.error.positions[i] = controllermsg.desired.positions[i] - controllermsg.actual.positions[i];
-				controllermsg.error.velocities[i] = controllermsg.desired.velocities[i] - controllermsg.actual.velocities[i];
-			}
-			// publish controller message
-			topicPub_ControllerState_.publish(controllermsg);
-
-			// read sdh status
-			state_ = sdh_->GetAxisActualState(axes_);
-		}
-		else
-		{
-			ROS_DEBUG("sdh not initialized");
-		}
-		// publishing diagnotic messages
-	    diagnostic_msgs::DiagnosticArray diagnostics;
-	    diagnostics.status.resize(1);
-	    // set data to diagnostics
-	    if(isError_)
-	    {
-	      diagnostics.status[0].level = 2;
-	      diagnostics.status[0].name = "schunk_powercube_chain";
-	      diagnostics.status[0].message = "one or more drives are in Error mode";
-	    }
-	    else
-	    {
-	      if (isInitialized_)
-	      {
-	        diagnostics.status[0].level = 0;
-	        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
-	        if(isDSAInitialized_)
-	        	diagnostics.status[0].message = "sdh with tactile sensing initialized and running";
-	        else
-	        	diagnostics.status[0].message = "sdh initialized and running, tactile sensors not connected";
-	      }
-	      else
-	      {
-	        diagnostics.status[0].level = 1;
-	        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
-	        diagnostics.status[0].message = "sdh not initialized";
-	      }
-	    }
-	    // publish diagnostic message
-	    topicPub_Diagnostics_.publish(diagnostics);
-
-	}
-
-	/*!
-	* \brief Main routine to update dsa.
-	*
-	* Reads out current values.
-	*/
-	void updateDsa()
-	{
-                static const int dsa_reorder[6] = { 2 ,3, 4, 5, 0 , 1 }; // t1,t2,f11,f12,f21,f22
-		ROS_DEBUG("updateTactileData");
-
-		if(isDSAInitialized_)
-		{
-			// read tactile data
-			for(int i=0; i<7; i++)
-			{
-				try
-				{
-					//dsa_->SetFramerate( 0, true, true );
-					dsa_->UpdateFrame();
-				}
-				catch (SDH::cSDHLibraryException* e)
-				{
-					ROS_ERROR("An exception was caught: %s", e->what());
-					delete e;
-				}
-			}
-
-			schunk_sdh::TactileSensor msg;
-			msg.header.stamp = ros::Time::now();
-			int m, x, y;
-			msg.tactile_matrix.resize(dsa_->GetSensorInfo().nb_matrices);
-			for ( int i = 0; i < dsa_->GetSensorInfo().nb_matrices; i++ )
-			{
-				m = dsa_reorder[i];
-				schunk_sdh::TactileMatrix &tm = msg.tactile_matrix[i];
-				tm.matrix_id = i;
-				tm.cells_x = dsa_->GetMatrixInfo( m ).cells_x;
-				tm.cells_y = dsa_->GetMatrixInfo( m ).cells_y;
-				tm.tactile_array.resize(tm.cells_x * tm.cells_y);
-				for ( y = 0; y < tm.cells_y; y++ )
-				{
-					for ( x = 0; x < tm.cells_x; x++ )
-						tm.tactile_array[tm.cells_x*y + x] = dsa_->GetTexel( m, x, y );
-				}
-			}
-			//publish matrix
-			topicPub_TactileSensor_.publish(msg);
-		}
-	}
-}; //SdhNode
+public:
+  /// create a handle for this node, initialize node
+  ros::NodeHandle nh_;
+private:
+  // declaration of topics to publish
+  ros::Publisher topicPub_JointState_;
+  ros::Publisher topicPub_ControllerState_;
+  ros::Publisher topicPub_TactileSensor_;
+  ros::Publisher topicPub_Diagnostics_;
+
+  // topic subscribers
+  ros::Subscriber subSetVelocitiesRaw_;
+
+  // service servers
+  ros::ServiceServer srvServer_Init_;
+  ros::ServiceServer srvServer_Stop_;
+  ros::ServiceServer srvServer_Recover_;
+  ros::ServiceServer srvServer_SetOperationMode_;
+
+  // actionlib server
+  actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> as_;
+  std::string action_name_;
+
+  // service clients
+  //--
+
+  // other variables
+  SDH::cSDH *sdh_;
+  SDH::cDSA *dsa_;
+  std::vector<SDH::cSDH::eAxisState> state_;
+
+  std::string sdhdevicetype_;
+  std::string sdhdevicestring_;
+  int sdhdevicenum_;
+  std::string dsadevicestring_;
+  int dsadevicenum_;
+  int baudrate_, id_read_, id_write_;
+  double timeout_;
+
+  bool isInitialized_;
+  bool isDSAInitialized_;
+  bool isError_;
+  int DOF_;
+  double pi_;
+
+  trajectory_msgs::JointTrajectory traj_;
+
+  std::vector<std::string> joint_names_;
+  std::vector<int> axes_;
+  std::vector<double> targetAngles_; // in degrees
+  std::vector<double> velocities_; // in rad/s
+  bool hasNewGoal_;
+  std::string operationMode_;
+
+public:
+  /*!
+   * \brief Constructor for SdhNode class
+   *
+   * \param name Name for the actionlib server
+   */
+  SdhNode(std::string name) :
+      as_(nh_, name, boost::bind(&SdhNode::executeCB, this, _1), true), action_name_(name)
+  {
+    pi_ = 3.1415926;
+
+    nh_ = ros::NodeHandle("~");
+    isError_ = false;
+    // diagnostics
+    topicPub_Diagnostics_ = nh_.advertise<diagnostic_msgs::DiagnosticArray>("/diagnostics", 1);
+  }
+
+  /*!
+   * \brief Destructor for SdhNode class
+   */
+  ~SdhNode()
+  {
+    if (isDSAInitialized_)
+      dsa_->Close();
+    if (isInitialized_)
+      sdh_->Close();
+    delete sdh_;
+  }
+
+  /*!
+   * \brief Initializes node to get parameters, subscribe and publish to topics.
+   */
+  bool init()
+  {
+    // initialize member variables
+    isInitialized_ = false;
+    isDSAInitialized_ = false;
+    hasNewGoal_ = false;
+
+    // implementation of topics to publish
+    topicPub_JointState_ = nh_.advertise<sensor_msgs::JointState>("joint_states", 1);
+    topicPub_ControllerState_ = nh_.advertise<control_msgs::JointTrajectoryControllerState>(
+        "joint_trajectory_controller/state", 1);
+    topicPub_TactileSensor_ = nh_.advertise<schunk_sdh::TactileSensor>("tactile_data", 1);
+
+    // pointer to sdh
+    sdh_ = new SDH::cSDH(false, false, 0); //(_use_radians=false, bool _use_fahrenheit=false, int _debug_level=0)
+
+    // implementation of service servers
+    srvServer_Init_ = nh_.advertiseService("init", &SdhNode::srvCallback_Init, this);
+    srvServer_Stop_ = nh_.advertiseService("stop", &SdhNode::srvCallback_Stop, this);
+    srvServer_Recover_ = nh_.advertiseService("recover", &SdhNode::srvCallback_Init, this); //HACK: There is no recover implemented yet, so we execute a init
+    srvServer_SetOperationMode_ = nh_.advertiseService("set_operation_mode", &SdhNode::srvCallback_SetOperationMode,
+                                                       this);
+
+    subSetVelocitiesRaw_ = nh_.subscribe("joint_group_velocity_controller/command", 1,
+                                         &SdhNode::topicCallback_setVelocitiesRaw, this);
+
+    // getting hardware parameters from parameter server
+    nh_.param("sdhdevicetype", sdhdevicetype_, std::string("PCAN"));
+    nh_.param("sdhdevicestring", sdhdevicestring_, std::string("/dev/pcan0"));
+    nh_.param("sdhdevicenum", sdhdevicenum_, 0);
+
+    nh_.param("dsadevicestring", dsadevicestring_, std::string(""));
+    nh_.param("dsadevicenum", dsadevicenum_, 0);
+
+    nh_.param("baudrate", baudrate_, 1000000);
+    nh_.param("timeout", timeout_, (double)0.04);
+    nh_.param("id_read", id_read_, 43);
+    nh_.param("id_write", id_write_, 42);
+
+    // get joint_names from parameter server
+    ROS_INFO("getting joint_names from parameter server");
+    XmlRpc::XmlRpcValue joint_names_param;
+    if (nh_.hasParam("joint_names"))
+    {
+      nh_.getParam("joint_names", joint_names_param);
+    }
+    else
+    {
+      ROS_ERROR("Parameter joint_names not set, shutting down node...");
+      nh_.shutdown();
+      return false;
+    }
+    DOF_ = joint_names_param.size();
+    joint_names_.resize(DOF_);
+    for (int i = 0; i < DOF_; i++)
+    {
+      joint_names_[i] = (std::string)joint_names_param[i];
+    }
+    std::cout << "joint_names = " << joint_names_param << std::endl;
+
+    // define axes to send to sdh
+    axes_.resize(DOF_);
+    velocities_.resize(DOF_);
+    for (int i = 0; i < DOF_; i++)
+    {
+      axes_[i] = i;
+    }
+    ROS_INFO("DOF = %d", DOF_);
+
+    state_.resize(axes_.size());
+
+    nh_.param("OperationMode", operationMode_, std::string("position"));
+    return true;
+  }
+  /*!
+   * \brief Switches operation mode if possible
+   *
+   * \param mode new mode
+   */
+  bool switchOperationMode(const std::string &mode)
+  {
+    hasNewGoal_ = false;
+    sdh_->Stop();
+
+    try
+    {
+      if (mode == "position")
+      {
+        sdh_->SetController(SDH::cSDH::eCT_POSE);
+      }
+      else if (mode == "velocity")
+      {
+        sdh_->SetController(SDH::cSDH::eCT_VELOCITY);
+      }
+      else
+      {
+        ROS_ERROR_STREAM("Operation mode '" << mode << "'  not supported");
+        return false;
+      }
+      sdh_->SetAxisEnable(sdh_->All, 1.0); // TODO: check if necessary
+    }
+    catch (SDH::cSDHLibraryException* e)
+    {
+      ROS_ERROR("An exception was caught: %s", e->what());
+      delete e;
+      return false;
+    }
+
+    operationMode_ = mode;
+    return true;
+
+  }
+
+  /*!
+   * \brief Executes the callback from the actionlib
+   *
+   * Set the current goal to aborted after receiving a new goal and write new goal to a member variable. Wait for the goal to finish and set actionlib status to succeeded.
+   * \param goal JointTrajectoryGoal
+   */
+  void executeCB(const control_msgs::FollowJointTrajectoryGoalConstPtr &goal)
+  {
+    ROS_INFO("sdh: executeCB");
+    if (operationMode_ != "position")
+    {
+      ROS_ERROR("%s: Rejected, sdh not in position mode", action_name_.c_str());
+      as_.setAborted();
+      return;
+    }
+    if (!isInitialized_)
+    {
+      ROS_ERROR("%s: Rejected, sdh not initialized", action_name_.c_str());
+      as_.setAborted();
+      return;
+    }
+
+    if (goal->trajectory.points.empty() || goal->trajectory.points[0].positions.size() != size_t(DOF_))
+    {
+      ROS_ERROR("%s: Rejected, malformed FollowJointTrajectoryGoal", action_name_.c_str());
+      as_.setAborted();
+      return;
+    }
+    while (hasNewGoal_ == true)
+      usleep(10000);
+
+    std::map<std::string, int> dict;
+    for (int idx = 0; idx < goal->trajectory.joint_names.size(); idx++)
+    {
+      dict[goal->trajectory.joint_names[idx]] = idx;
+    }
+
+    targetAngles_.resize(DOF_);
+    targetAngles_[0] = goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]] * 180.0 / pi_; // sdh_knuckle_joint
+    targetAngles_[1] = goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]] * 180.0 / pi_; // sdh_finger22_joint
+    targetAngles_[2] = goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]] * 180.0 / pi_; // sdh_finger23_joint
+    targetAngles_[3] = goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]] * 180.0 / pi_; // sdh_thumb2_joint
+    targetAngles_[4] = goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]] * 180.0 / pi_; // sdh_thumb3_joint
+    targetAngles_[5] = goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]] * 180.0 / pi_; // sdh_finger12_joint
+    targetAngles_[6] = goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]] * 180.0 / pi_; // sdh_finger13_joint
+    ROS_INFO(
+        "received position goal: [['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']] = [%f,%f,%f,%f,%f,%f,%f]",
+        goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]]);
+
+    hasNewGoal_ = true;
+
+    usleep(500000); // needed sleep until sdh starts to change status from idle to moving
+
+    bool finished = false;
+    while (finished == false)
+    {
+      if (as_.isNewGoalAvailable())
+      {
+        ROS_WARN("%s: Aborted", action_name_.c_str());
+        as_.setAborted();
+        return;
+      }
+      for (unsigned int i = 0; i < state_.size(); i++)
+      {
+        ROS_DEBUG("state[%d] = %d", i, state_[i]);
+        if (state_[i] == 0)
+        {
+          finished = true;
+        }
+        else
+        {
+          finished = false;
+        }
+      }
+      usleep(10000);
+      //feedback_ =
+      //as_.send feedback_
+    }
+
+    // set the action state to succeeded
+    ROS_INFO("%s: Succeeded", action_name_.c_str());
+    //result_.result.data = "succesfully received new goal";
+    //result_.success = 1;
+    //as_.setSucceeded(result_);
+    as_.setSucceeded();
+  }
+
+  void topicCallback_setVelocitiesRaw(const std_msgs::Float64MultiArrayPtr& velocities)
+  {
+    if (!isInitialized_)
+    {
+      ROS_ERROR("%s: Rejected, sdh not initialized", action_name_.c_str());
+      return;
+    }
+    if (velocities->data.size() != velocities_.size())
+    {
+      ROS_ERROR("Velocity array dimension mismatch");
+      return;
+    }
+    if (operationMode_ != "velocity")
+    {
+      ROS_ERROR("%s: Rejected, sdh not in velocity mode", action_name_.c_str());
+      return;
+    }
+
+    // TODO: write proper lock!
+    while (hasNewGoal_ == true)
+      usleep(10000);
+
+    velocities_[0] = velocities->data[0] * 180.0 / pi_; // sdh_knuckle_joint
+    velocities_[1] = velocities->data[5] * 180.0 / pi_; // sdh_finger22_joint
+    velocities_[2] = velocities->data[6] * 180.0 / pi_; // sdh_finger23_joint
+    velocities_[3] = velocities->data[1] * 180.0 / pi_; // sdh_thumb2_joint
+    velocities_[4] = velocities->data[2] * 180.0 / pi_; // sdh_thumb3_joint
+    velocities_[5] = velocities->data[3] * 180.0 / pi_; // sdh_finger12_joint
+    velocities_[6] = velocities->data[4] * 180.0 / pi_; // sdh_finger13_joint
+
+    hasNewGoal_ = true;
+  }
+
+  /*!
+   * \brief Executes the service callback for init.
+   *
+   * Connects to the hardware and initialized it.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_Init(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
+  {
+
+    if (isInitialized_ == false)
+    {
+      //Init Hand connection
+
+      try
+      {
+        if (sdhdevicetype_.compare("RS232") == 0)
+        {
+          sdh_->OpenRS232(sdhdevicenum_, 115200, 1, sdhdevicestring_.c_str());
+          ROS_INFO("Initialized RS232 for SDH");
+          isInitialized_ = true;
+        }
+        if (sdhdevicetype_.compare("PCAN") == 0)
+        {
+          ROS_INFO("Starting initializing PEAKCAN");
+          sdh_->OpenCAN_PEAK(baudrate_, timeout_, id_read_, id_write_, sdhdevicestring_.c_str());
+          ROS_INFO("Initialized PEAK CAN for SDH");
+          isInitialized_ = true;
+        }
+        if (sdhdevicetype_.compare("ESD") == 0)
+        {
+          ROS_INFO("Starting initializing ESD");
+          if (strcmp(sdhdevicestring_.c_str(), "/dev/can0") == 0)
+          {
+            ROS_INFO("Initializing ESD on device %s", sdhdevicestring_.c_str());
+            sdh_->OpenCAN_ESD(0, baudrate_, timeout_, id_read_, id_write_);
+          }
+          else if (strcmp(sdhdevicestring_.c_str(), "/dev/can1") == 0)
+          {
+            ROS_INFO("Initializin ESD on device %s", sdhdevicestring_.c_str());
+            sdh_->OpenCAN_ESD(1, baudrate_, timeout_, id_read_, id_write_);
+          }
+          else
+          {
+            ROS_ERROR("Currently only support for /dev/can0 and /dev/can1");
+            res.success = false;
+            res.message = "Currently only support for /dev/can0 and /dev/can1";
+            return true;
+          }
+          ROS_INFO("Initialized ESDCAN for SDH");
+          isInitialized_ = true;
+        }
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        res.success = false;
+        res.message = e->what();
+        delete e;
+        return true;
+      }
+
+      //Init tactile data
+      if (!dsadevicestring_.empty())
+      {
+        try
+        {
+          dsa_ = new SDH::cDSA(0, dsadevicenum_, dsadevicestring_.c_str());
+          //dsa_->SetFramerate( 0, true, false );
+          dsa_->SetFramerate(1, true);
+          ROS_INFO("Initialized RS232 for DSA Tactile Sensors on device %s", dsadevicestring_.c_str());
+          // ROS_INFO("Set sensitivity to 1.0");
+          // for(int i=0; i<6; i++)
+          // 	dsa_->SetMatrixSensitivity(i, 1.0);
+          isDSAInitialized_ = true;
+        }
+        catch (SDH::cSDHLibraryException* e)
+        {
+          isDSAInitialized_ = false;
+          ROS_ERROR("An exception was caught: %s", e->what());
+          res.success = false;
+          res.message = e->what();
+          delete e;
+          return true;
+        }
+      }
+      if (!switchOperationMode(operationMode_))
+      {
+        res.success = false;
+        res.message = "Could not set operation mode to '" + operationMode_ + "'";
+        return true;
+      }
+    }
+    else
+    {
+      ROS_WARN("...sdh already initialized...");
+      res.success = true;
+      res.message = "sdh already initialized";
+    }
+
+    res.success = true;
+    return true;
+  }
+
+  /*!
+   * \brief Executes the service callback for stop.
+   *
+   * Stops all hardware movements.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_Stop(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
+  {
+    ROS_INFO("Stopping sdh");
+
+    // stopping all arm movements
+    try
+    {
+      sdh_->Stop();
+    }
+    catch (SDH::cSDHLibraryException* e)
+    {
+      ROS_ERROR("An exception was caught: %s", e->what());
+      delete e;
+    }
+
+    ROS_INFO("Stopping sdh succesfull");
+    res.success = true;
+    return true;
+  }
+
+  /*!
+   * \brief Executes the service callback for recover.
+   *
+   * Recovers the hardware after an emergency stop.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_Recover(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
+  {
+    ROS_WARN("Service recover not implemented yet");
+    res.success = true;
+    res.message = "Service recover not implemented yet";
+    return true;
+  }
+
+  /*!
+   * \brief Executes the service callback for set_operation_mode.
+   *
+   * Changes the operation mode.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_SetOperationMode(cob_srvs::SetString::Request &req, cob_srvs::SetString::Response &res)
+  {
+    hasNewGoal_ = false;
+    sdh_->Stop();
+    ROS_INFO("Set operation mode to [%s]", req.data.c_str());
+    operationMode_ = req.data;
+    res.success = true;
+    if (operationMode_ == "position")
+    {
+      sdh_->SetController(SDH::cSDH::eCT_POSE);
+    }
+    else if (operationMode_ == "velocity")
+    {
+      try
+      {
+        sdh_->SetController(SDH::cSDH::eCT_VELOCITY);
+        sdh_->SetAxisEnable(sdh_->All, 1.0);
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        delete e;
+      }
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Operation mode '" << req.data << "'  not supported");
+    }
+    return true;
+  }
+
+  /*!
+   * \brief Main routine to update sdh.
+   *
+   * Sends target to hardware and reads out current configuration.
+   */
+  void updateSdh()
+  {
+    ROS_DEBUG("updateJointState");
+    if (isInitialized_ == true)
+    {
+      if (hasNewGoal_ == true)
+      {
+        // stop sdh first when new goal arrived
+        try
+        {
+          sdh_->Stop();
+        }
+        catch (SDH::cSDHLibraryException* e)
+        {
+          ROS_ERROR("An exception was caught: %s", e->what());
+          delete e;
+        }
+
+        if (operationMode_ == "position")
+        {
+          ROS_DEBUG("moving sdh in position mode");
+
+          try
+          {
+            sdh_->SetAxisTargetAngle(axes_, targetAngles_);
+            sdh_->MoveHand(false);
+          }
+          catch (SDH::cSDHLibraryException* e)
+          {
+            ROS_ERROR("An exception was caught: %s", e->what());
+            delete e;
+          }
+        }
+        else if (operationMode_ == "velocity")
+        {
+          ROS_DEBUG("moving sdh in velocity mode");
+          try
+          {
+            sdh_->SetAxisTargetVelocity(axes_, velocities_);
+            // ROS_DEBUG_STREAM("velocities: " << velocities_[0] << " "<< velocities_[1] << " "<< velocities_[2] << " "<< velocities_[3] << " "<< velocities_[4] << " "<< velocities_[5] << " "<< velocities_[6]);
+          }
+          catch (SDH::cSDHLibraryException* e)
+          {
+            ROS_ERROR("An exception was caught: %s", e->what());
+            delete e;
+          }
+        }
+        else if (operationMode_ == "effort")
+        {
+          ROS_DEBUG("moving sdh in effort mode");
+          //sdh_->MoveVel(goal->trajectory.points[0].velocities);
+          ROS_WARN("Moving in effort mode currently disabled");
+        }
+        else
+        {
+          ROS_ERROR("sdh neither in position nor in velocity nor in effort mode. OperationMode = [%s]",
+                    operationMode_.c_str());
+        }
+
+        hasNewGoal_ = false;
+      }
+
+      // read and publish joint angles and velocities
+      std::vector<double> actualAngles;
+      try
+      {
+        actualAngles = sdh_->GetAxisActualAngle(axes_);
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        delete e;
+      }
+      std::vector<double> actualVelocities;
+      try
+      {
+        actualVelocities = sdh_->GetAxisActualVelocity(axes_);
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        delete e;
+      }
+
+      ROS_DEBUG("received %d angles from sdh", (int )actualAngles.size());
+
+      ros::Time time = ros::Time::now();
+
+      // create joint_state message
+      sensor_msgs::JointState msg;
+      msg.header.stamp = time;
+      msg.name.resize(DOF_);
+      msg.position.resize(DOF_);
+      msg.velocity.resize(DOF_);
+      msg.effort.resize(DOF_);
+      // set joint names and map them to angles
+      msg.name = joint_names_;
+      //['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
+      // pos
+      msg.position[0] = actualAngles[0] * pi_ / 180.0; // sdh_knuckle_joint
+      msg.position[1] = actualAngles[3] * pi_ / 180.0; // sdh_thumb_2_joint
+      msg.position[2] = actualAngles[4] * pi_ / 180.0; // sdh_thumb_3_joint
+      msg.position[3] = actualAngles[5] * pi_ / 180.0; // sdh_finger_12_joint
+      msg.position[4] = actualAngles[6] * pi_ / 180.0; // sdh_finger_13_joint
+      msg.position[5] = actualAngles[1] * pi_ / 180.0; // sdh_finger_22_joint
+      msg.position[6] = actualAngles[2] * pi_ / 180.0; // sdh_finger_23_joint
+      // vel
+      msg.velocity[0] = actualVelocities[0] * pi_ / 180.0; // sdh_knuckle_joint
+      msg.velocity[1] = actualVelocities[3] * pi_ / 180.0; // sdh_thumb_2_joint
+      msg.velocity[2] = actualVelocities[4] * pi_ / 180.0; // sdh_thumb_3_joint
+      msg.velocity[3] = actualVelocities[5] * pi_ / 180.0; // sdh_finger_12_joint
+      msg.velocity[4] = actualVelocities[6] * pi_ / 180.0; // sdh_finger_13_joint
+      msg.velocity[5] = actualVelocities[1] * pi_ / 180.0; // sdh_finger_22_joint
+      msg.velocity[6] = actualVelocities[2] * pi_ / 180.0; // sdh_finger_23_joint
+      // publish message
+      topicPub_JointState_.publish(msg);
+
+      // because the robot_state_publisher doen't know about the mimic joint, we have to publish the coupled joint separately
+      sensor_msgs::JointState mimicjointmsg;
+      mimicjointmsg.header.stamp = time;
+      mimicjointmsg.name.resize(1);
+      mimicjointmsg.position.resize(1);
+      mimicjointmsg.velocity.resize(1);
+      mimicjointmsg.name[0] = "sdh_finger_21_joint";
+      mimicjointmsg.position[0] = msg.position[0]; // sdh_knuckle_joint = sdh_finger_21_joint
+      mimicjointmsg.velocity[0] = msg.velocity[0]; // sdh_knuckle_joint = sdh_finger_21_joint
+      topicPub_JointState_.publish(mimicjointmsg);
+
+      // publish controller state message
+      control_msgs::JointTrajectoryControllerState controllermsg;
+      controllermsg.header.stamp = time;
+      controllermsg.joint_names.resize(DOF_);
+      controllermsg.desired.positions.resize(DOF_);
+      controllermsg.desired.velocities.resize(DOF_);
+      controllermsg.actual.positions.resize(DOF_);
+      controllermsg.actual.velocities.resize(DOF_);
+      controllermsg.error.positions.resize(DOF_);
+      controllermsg.error.velocities.resize(DOF_);
+      // set joint names and map them to angles
+      controllermsg.joint_names = joint_names_;
+      //['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
+      // desired pos
+      if (targetAngles_.size() != 0)
+      {
+        controllermsg.desired.positions[0] = targetAngles_[0] * pi_ / 180.0; // sdh_knuckle_joint
+        controllermsg.desired.positions[1] = targetAngles_[3] * pi_ / 180.0; // sdh_thumb_2_joint
+        controllermsg.desired.positions[2] = targetAngles_[4] * pi_ / 180.0; // sdh_thumb_3_joint
+        controllermsg.desired.positions[3] = targetAngles_[5] * pi_ / 180.0; // sdh_finger_12_joint
+        controllermsg.desired.positions[4] = targetAngles_[6] * pi_ / 180.0; // sdh_finger_13_joint
+        controllermsg.desired.positions[5] = targetAngles_[1] * pi_ / 180.0; // sdh_finger_22_joint
+        controllermsg.desired.positions[6] = targetAngles_[2] * pi_ / 180.0; // sdh_finger_23_joint
+      }
+      // desired vel
+      // they are all zero
+      // actual pos
+      controllermsg.actual.positions = msg.position;
+      // actual vel
+      controllermsg.actual.velocities = msg.velocity;
+      // error, calculated out of desired and actual values
+      for (int i = 0; i < DOF_; i++)
+      {
+        controllermsg.error.positions[i] = controllermsg.desired.positions[i] - controllermsg.actual.positions[i];
+        controllermsg.error.velocities[i] = controllermsg.desired.velocities[i] - controllermsg.actual.velocities[i];
+      }
+      // publish controller message
+      topicPub_ControllerState_.publish(controllermsg);
+
+      // read sdh status
+      state_ = sdh_->GetAxisActualState(axes_);
+    }
+    else
+    {
+      ROS_DEBUG("sdh not initialized");
+    }
+    // publishing diagnotic messages
+    diagnostic_msgs::DiagnosticArray diagnostics;
+    diagnostics.status.resize(1);
+    // set data to diagnostics
+    if (isError_)
+    {
+      diagnostics.status[0].level = 2;
+      diagnostics.status[0].name = "schunk_powercube_chain";
+      diagnostics.status[0].message = "one or more drives are in Error mode";
+    }
+    else
+    {
+      if (isInitialized_)
+      {
+        diagnostics.status[0].level = 0;
+        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
+        if (isDSAInitialized_)
+          diagnostics.status[0].message = "sdh with tactile sensing initialized and running";
+        else
+          diagnostics.status[0].message = "sdh initialized and running, tactile sensors not connected";
+      }
+      else
+      {
+        diagnostics.status[0].level = 1;
+        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
+        diagnostics.status[0].message = "sdh not initialized";
+      }
+    }
+    // publish diagnostic message
+    topicPub_Diagnostics_.publish(diagnostics);
+
+  }
+
+  /*!
+   * \brief Main routine to update dsa.
+   *
+   * Reads out current values.
+   */
+  void updateDsa()
+  {
+    static const int dsa_reorder[6] = {2, 3, 4, 5, 0, 1}; // t1,t2,f11,f12,f21,f22
+    ROS_DEBUG("updateTactileData");
+
+    if (isDSAInitialized_)
+    {
+      // read tactile data
+      for (int i = 0; i < 7; i++)
+      {
+        try
+        {
+          //dsa_->SetFramerate( 0, true, true );
+          dsa_->UpdateFrame();
+        }
+        catch (SDH::cSDHLibraryException* e)
+        {
+          ROS_ERROR("An exception was caught: %s", e->what());
+          delete e;
+        }
+      }
+
+      schunk_sdh::TactileSensor msg;
+      msg.header.stamp = ros::Time::now();
+      int m, x, y;
+      msg.tactile_matrix.resize(dsa_->GetSensorInfo().nb_matrices);
+      for (int i = 0; i < dsa_->GetSensorInfo().nb_matrices; i++)
+      {
+        m = dsa_reorder[i];
+        schunk_sdh::TactileMatrix &tm = msg.tactile_matrix[i];
+        tm.matrix_id = i;
+        tm.cells_x = dsa_->GetMatrixInfo(m).cells_x;
+        tm.cells_y = dsa_->GetMatrixInfo(m).cells_y;
+        tm.tactile_array.resize(tm.cells_x * tm.cells_y);
+        for (y = 0; y < tm.cells_y; y++)
+        {
+          for (x = 0; x < tm.cells_x; x++)
+            tm.tactile_array[tm.cells_x * y + x] = dsa_->GetTexel(m, x, y);
+        }
+      }
+      //publish matrix
+      topicPub_TactileSensor_.publish(msg);
+    }
+  }
+};
+//SdhNode
 
 /*!
-* \brief Main loop of ROS node.
-*
-* Running with a specific frequency defined by loop_rate.
-*/
+ * \brief Main loop of ROS node.
+ *
+ * Running with a specific frequency defined by loop_rate.
+ */
 int main(int argc, char** argv)
 {
-	// initialize ROS, spezify name of node
-	ros::init(argc, argv, "schunk_sdh");
+  // initialize ROS, spezify name of node
+  ros::init(argc, argv, "schunk_sdh");
 
-	//SdhNode sdh_node(ros::this_node::getName() + "/joint_trajectory_action");
-	SdhNode sdh_node(ros::this_node::getName() + "/follow_joint_trajectory");
-	if (!sdh_node.init()) return 0;
+  //SdhNode sdh_node(ros::this_node::getName() + "/joint_trajectory_action");
+  SdhNode sdh_node(ros::this_node::getName() + "/follow_joint_trajectory");
+  if (!sdh_node.init())
+    return 0;
 
-	ROS_INFO("...sdh node running...");
+  ROS_INFO("...sdh node running...");
 
-	double frequency;
-	if (sdh_node.nh_.hasParam("frequency"))
-	{
-		sdh_node.nh_.getParam("frequency", frequency);
-	}
-	else
-	{
-		frequency = 5; //Hz
-		ROS_WARN("Parameter frequency not available, setting to default value: %f Hz", frequency);
-	}
+  double frequency;
+  if (sdh_node.nh_.hasParam("frequency"))
+  {
+    sdh_node.nh_.getParam("frequency", frequency);
+  }
+  else
+  {
+    frequency = 5; //Hz
+    ROS_WARN("Parameter frequency not available, setting to default value: %f Hz", frequency);
+  }
 
-	//sleep(1);
-	ros::Rate loop_rate(frequency); // Hz
-	while(sdh_node.nh_.ok())
-	{
-		// publish JointState
-		sdh_node.updateSdh();
+  //sleep(1);
+  ros::Rate loop_rate(frequency); // Hz
+  while (sdh_node.nh_.ok())
+  {
+    // publish JointState
+    sdh_node.updateSdh();
 
-		// publish TactileData
-		sdh_node.updateDsa();
+    // publish TactileData
+    sdh_node.updateDsa();
 
-		// sleep and waiting for messages, callbacks
-		ros::spinOnce();
-		loop_rate.sleep();
-	}
+    // sleep and waiting for messages, callbacks
+    ros::spinOnce();
+    loop_rate.sleep();
+  }
 
-	return 0;
+  return 0;
 }
 

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -57,10 +57,13 @@
  *
  ****************************************************************/
 
-//##################
-//#### includes ####
+// ##################
+// #### includes ####
 // standard includes
 #include <unistd.h>
+#include <map>
+#include <string>
+#include <vector>
 
 // ROS includes
 #include <ros/ros.h>
@@ -118,7 +121,7 @@ private:
   std::string action_name_;
 
   // service clients
-  //--
+  // --
 
   // other variables
   SDH::cSDH *sdh_;
@@ -143,8 +146,8 @@ private:
 
   std::vector<std::string> joint_names_;
   std::vector<int> axes_;
-  std::vector<double> targetAngles_; // in degrees
-  std::vector<double> velocities_; // in rad/s
+  std::vector<double> targetAngles_;  // in degrees
+  std::vector<double> velocities_;  // in rad/s
   bool hasNewGoal_;
   std::string operationMode_;
 
@@ -194,12 +197,12 @@ public:
     topicPub_TactileSensor_ = nh_.advertise<schunk_sdh::TactileSensor>("tactile_data", 1);
 
     // pointer to sdh
-    sdh_ = new SDH::cSDH(false, false, 0); //(_use_radians=false, bool _use_fahrenheit=false, int _debug_level=0)
+    sdh_ = new SDH::cSDH(false, false, 0);  // (_use_radians=false, bool _use_fahrenheit=false, int _debug_level=0)
 
     // implementation of service servers
     srvServer_Init_ = nh_.advertiseService("init", &SdhNode::srvCallback_Init, this);
     srvServer_Stop_ = nh_.advertiseService("stop", &SdhNode::srvCallback_Stop, this);
-    srvServer_Recover_ = nh_.advertiseService("recover", &SdhNode::srvCallback_Init, this); //HACK: There is no recover implemented yet, so we execute a init
+    srvServer_Recover_ = nh_.advertiseService("recover", &SdhNode::srvCallback_Init, this);  // HACK: There is no recover implemented yet, so we execute a init
     srvServer_SetOperationMode_ = nh_.advertiseService("set_operation_mode", &SdhNode::srvCallback_SetOperationMode,
                                                        this);
 
@@ -215,7 +218,7 @@ public:
     nh_.param("dsadevicenum", dsadevicenum_, 0);
 
     nh_.param("baudrate", baudrate_, 1000000);
-    nh_.param("timeout", timeout_, (double)0.04);
+    nh_.param("timeout", timeout_, static_cast<double>(0.04));
     nh_.param("id_read", id_read_, 43);
     nh_.param("id_write", id_write_, 42);
 
@@ -279,7 +282,7 @@ public:
         ROS_ERROR_STREAM("Operation mode '" << mode << "'  not supported");
         return false;
       }
-      sdh_->SetAxisEnable(sdh_->All, 1.0); // TODO: check if necessary
+      sdh_->SetAxisEnable(sdh_->All, 1.0);  // TODO: check if necessary
     }
     catch (SDH::cSDHLibraryException* e)
     {
@@ -290,7 +293,6 @@ public:
 
     operationMode_ = mode;
     return true;
-
   }
 
   /*!
@@ -331,13 +333,13 @@ public:
     }
 
     targetAngles_.resize(DOF_);
-    targetAngles_[0] = goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]] * 180.0 / pi_; // sdh_knuckle_joint
-    targetAngles_[1] = goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]] * 180.0 / pi_; // sdh_finger22_joint
-    targetAngles_[2] = goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]] * 180.0 / pi_; // sdh_finger23_joint
-    targetAngles_[3] = goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]] * 180.0 / pi_; // sdh_thumb2_joint
-    targetAngles_[4] = goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]] * 180.0 / pi_; // sdh_thumb3_joint
-    targetAngles_[5] = goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]] * 180.0 / pi_; // sdh_finger12_joint
-    targetAngles_[6] = goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]] * 180.0 / pi_; // sdh_finger13_joint
+    targetAngles_[0] = goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]] * 180.0 / pi_;  // sdh_knuckle_joint
+    targetAngles_[1] = goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]] * 180.0 / pi_;  // sdh_finger22_joint
+    targetAngles_[2] = goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]] * 180.0 / pi_;  // sdh_finger23_joint
+    targetAngles_[3] = goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]] * 180.0 / pi_;  // sdh_thumb2_joint
+    targetAngles_[4] = goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]] * 180.0 / pi_;  // sdh_thumb3_joint
+    targetAngles_[5] = goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]] * 180.0 / pi_;  // sdh_finger12_joint
+    targetAngles_[6] = goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]] * 180.0 / pi_;  // sdh_finger13_joint
     ROS_INFO(
         "received position goal: [['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']] = [%f,%f,%f,%f,%f,%f,%f]",
         goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]],
@@ -350,7 +352,7 @@ public:
 
     hasNewGoal_ = true;
 
-    usleep(500000); // needed sleep until sdh starts to change status from idle to moving
+    usleep(500000);  // needed sleep until sdh starts to change status from idle to moving
 
     bool finished = false;
     while (finished == false)
@@ -374,15 +376,15 @@ public:
         }
       }
       usleep(10000);
-      //feedback_ =
-      //as_.send feedback_
+      // feedback_ =
+      // as_.send feedback_
     }
 
     // set the action state to succeeded
     ROS_INFO("%s: Succeeded", action_name_.c_str());
-    //result_.result.data = "succesfully received new goal";
-    //result_.success = 1;
-    //as_.setSucceeded(result_);
+    // result_.result.data = "succesfully received new goal";
+    // result_.success = 1;
+    // as_.setSucceeded(result_);
     as_.setSucceeded();
   }
 
@@ -408,13 +410,13 @@ public:
     while (hasNewGoal_ == true)
       usleep(10000);
 
-    velocities_[0] = velocities->data[0] * 180.0 / pi_; // sdh_knuckle_joint
-    velocities_[1] = velocities->data[5] * 180.0 / pi_; // sdh_finger22_joint
-    velocities_[2] = velocities->data[6] * 180.0 / pi_; // sdh_finger23_joint
-    velocities_[3] = velocities->data[1] * 180.0 / pi_; // sdh_thumb2_joint
-    velocities_[4] = velocities->data[2] * 180.0 / pi_; // sdh_thumb3_joint
-    velocities_[5] = velocities->data[3] * 180.0 / pi_; // sdh_finger12_joint
-    velocities_[6] = velocities->data[4] * 180.0 / pi_; // sdh_finger13_joint
+    velocities_[0] = velocities->data[0] * 180.0 / pi_;  // sdh_knuckle_joint
+    velocities_[1] = velocities->data[5] * 180.0 / pi_;  // sdh_finger22_joint
+    velocities_[2] = velocities->data[6] * 180.0 / pi_;  // sdh_finger23_joint
+    velocities_[3] = velocities->data[1] * 180.0 / pi_;  // sdh_thumb2_joint
+    velocities_[4] = velocities->data[2] * 180.0 / pi_;  // sdh_thumb3_joint
+    velocities_[5] = velocities->data[3] * 180.0 / pi_;  // sdh_finger12_joint
+    velocities_[6] = velocities->data[4] * 180.0 / pi_;  // sdh_finger13_joint
 
     hasNewGoal_ = true;
   }
@@ -428,10 +430,9 @@ public:
    */
   bool srvCallback_Init(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
   {
-
     if (isInitialized_ == false)
     {
-      //Init Hand connection
+      // Init Hand connection
 
       try
       {
@@ -481,13 +482,13 @@ public:
         return true;
       }
 
-      //Init tactile data
+      // Init tactile data
       if (!dsadevicestring_.empty())
       {
         try
         {
           dsa_ = new SDH::cDSA(0, dsadevicenum_, dsadevicestring_.c_str());
-          //dsa_->SetFramerate( 0, true, false );
+          // dsa_->SetFramerate( 0, true, false );
           dsa_->SetFramerate(1, true);
           ROS_INFO("Initialized RS232 for DSA Tactile Sensors on device %s", dsadevicestring_.c_str());
           // ROS_INFO("Set sensitivity to 1.0");
@@ -658,7 +659,7 @@ public:
         else if (operationMode_ == "effort")
         {
           ROS_DEBUG("moving sdh in effort mode");
-          //sdh_->MoveVel(goal->trajectory.points[0].velocities);
+          // sdh_->MoveVel(goal->trajectory.points[0].velocities);
           ROS_WARN("Moving in effort mode currently disabled");
         }
         else
@@ -692,7 +693,7 @@ public:
         delete e;
       }
 
-      ROS_DEBUG("received %d angles from sdh", (int )actualAngles.size());
+      ROS_DEBUG("received %d angles from sdh", static_cast<int>(actualAngles.size()));
 
       ros::Time time = ros::Time::now();
 
@@ -705,23 +706,23 @@ public:
       msg.effort.resize(DOF_);
       // set joint names and map them to angles
       msg.name = joint_names_;
-      //['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
+      // ['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
       // pos
-      msg.position[0] = actualAngles[0] * pi_ / 180.0; // sdh_knuckle_joint
-      msg.position[1] = actualAngles[3] * pi_ / 180.0; // sdh_thumb_2_joint
-      msg.position[2] = actualAngles[4] * pi_ / 180.0; // sdh_thumb_3_joint
-      msg.position[3] = actualAngles[5] * pi_ / 180.0; // sdh_finger_12_joint
-      msg.position[4] = actualAngles[6] * pi_ / 180.0; // sdh_finger_13_joint
-      msg.position[5] = actualAngles[1] * pi_ / 180.0; // sdh_finger_22_joint
-      msg.position[6] = actualAngles[2] * pi_ / 180.0; // sdh_finger_23_joint
+      msg.position[0] = actualAngles[0] * pi_ / 180.0;  // sdh_knuckle_joint
+      msg.position[1] = actualAngles[3] * pi_ / 180.0;  // sdh_thumb_2_joint
+      msg.position[2] = actualAngles[4] * pi_ / 180.0;  // sdh_thumb_3_joint
+      msg.position[3] = actualAngles[5] * pi_ / 180.0;  // sdh_finger_12_joint
+      msg.position[4] = actualAngles[6] * pi_ / 180.0;  // sdh_finger_13_joint
+      msg.position[5] = actualAngles[1] * pi_ / 180.0;  // sdh_finger_22_joint
+      msg.position[6] = actualAngles[2] * pi_ / 180.0;  // sdh_finger_23_joint
       // vel
-      msg.velocity[0] = actualVelocities[0] * pi_ / 180.0; // sdh_knuckle_joint
-      msg.velocity[1] = actualVelocities[3] * pi_ / 180.0; // sdh_thumb_2_joint
-      msg.velocity[2] = actualVelocities[4] * pi_ / 180.0; // sdh_thumb_3_joint
-      msg.velocity[3] = actualVelocities[5] * pi_ / 180.0; // sdh_finger_12_joint
-      msg.velocity[4] = actualVelocities[6] * pi_ / 180.0; // sdh_finger_13_joint
-      msg.velocity[5] = actualVelocities[1] * pi_ / 180.0; // sdh_finger_22_joint
-      msg.velocity[6] = actualVelocities[2] * pi_ / 180.0; // sdh_finger_23_joint
+      msg.velocity[0] = actualVelocities[0] * pi_ / 180.0;  // sdh_knuckle_joint
+      msg.velocity[1] = actualVelocities[3] * pi_ / 180.0;  // sdh_thumb_2_joint
+      msg.velocity[2] = actualVelocities[4] * pi_ / 180.0;  // sdh_thumb_3_joint
+      msg.velocity[3] = actualVelocities[5] * pi_ / 180.0;  // sdh_finger_12_joint
+      msg.velocity[4] = actualVelocities[6] * pi_ / 180.0;  // sdh_finger_13_joint
+      msg.velocity[5] = actualVelocities[1] * pi_ / 180.0;  // sdh_finger_22_joint
+      msg.velocity[6] = actualVelocities[2] * pi_ / 180.0;  // sdh_finger_23_joint
       // publish message
       topicPub_JointState_.publish(msg);
 
@@ -732,8 +733,8 @@ public:
       mimicjointmsg.position.resize(1);
       mimicjointmsg.velocity.resize(1);
       mimicjointmsg.name[0] = "sdh_finger_21_joint";
-      mimicjointmsg.position[0] = msg.position[0]; // sdh_knuckle_joint = sdh_finger_21_joint
-      mimicjointmsg.velocity[0] = msg.velocity[0]; // sdh_knuckle_joint = sdh_finger_21_joint
+      mimicjointmsg.position[0] = msg.position[0];  // sdh_knuckle_joint = sdh_finger_21_joint
+      mimicjointmsg.velocity[0] = msg.velocity[0];  // sdh_knuckle_joint = sdh_finger_21_joint
       topicPub_JointState_.publish(mimicjointmsg);
 
       // publish controller state message
@@ -748,17 +749,17 @@ public:
       controllermsg.error.velocities.resize(DOF_);
       // set joint names and map them to angles
       controllermsg.joint_names = joint_names_;
-      //['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
+      // ['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
       // desired pos
       if (targetAngles_.size() != 0)
       {
-        controllermsg.desired.positions[0] = targetAngles_[0] * pi_ / 180.0; // sdh_knuckle_joint
-        controllermsg.desired.positions[1] = targetAngles_[3] * pi_ / 180.0; // sdh_thumb_2_joint
-        controllermsg.desired.positions[2] = targetAngles_[4] * pi_ / 180.0; // sdh_thumb_3_joint
-        controllermsg.desired.positions[3] = targetAngles_[5] * pi_ / 180.0; // sdh_finger_12_joint
-        controllermsg.desired.positions[4] = targetAngles_[6] * pi_ / 180.0; // sdh_finger_13_joint
-        controllermsg.desired.positions[5] = targetAngles_[1] * pi_ / 180.0; // sdh_finger_22_joint
-        controllermsg.desired.positions[6] = targetAngles_[2] * pi_ / 180.0; // sdh_finger_23_joint
+        controllermsg.desired.positions[0] = targetAngles_[0] * pi_ / 180.0;  // sdh_knuckle_joint
+        controllermsg.desired.positions[1] = targetAngles_[3] * pi_ / 180.0;  // sdh_thumb_2_joint
+        controllermsg.desired.positions[2] = targetAngles_[4] * pi_ / 180.0;  // sdh_thumb_3_joint
+        controllermsg.desired.positions[3] = targetAngles_[5] * pi_ / 180.0;  // sdh_finger_12_joint
+        controllermsg.desired.positions[4] = targetAngles_[6] * pi_ / 180.0;  // sdh_finger_13_joint
+        controllermsg.desired.positions[5] = targetAngles_[1] * pi_ / 180.0;  // sdh_finger_22_joint
+        controllermsg.desired.positions[6] = targetAngles_[2] * pi_ / 180.0;  // sdh_finger_23_joint
       }
       // desired vel
       // they are all zero
@@ -797,7 +798,7 @@ public:
       if (isInitialized_)
       {
         diagnostics.status[0].level = 0;
-        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
+        diagnostics.status[0].name = nh_.getNamespace();  // "schunk_powercube_chain";
         if (isDSAInitialized_)
           diagnostics.status[0].message = "sdh with tactile sensing initialized and running";
         else
@@ -806,13 +807,12 @@ public:
       else
       {
         diagnostics.status[0].level = 1;
-        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
+        diagnostics.status[0].name = nh_.getNamespace();  // "schunk_powercube_chain";
         diagnostics.status[0].message = "sdh not initialized";
       }
     }
     // publish diagnostic message
     topicPub_Diagnostics_.publish(diagnostics);
-
   }
 
   /*!
@@ -822,7 +822,7 @@ public:
    */
   void updateDsa()
   {
-    static const int dsa_reorder[6] = {2, 3, 4, 5, 0, 1}; // t1,t2,f11,f12,f21,f22
+    static const int dsa_reorder[6] = {2, 3, 4, 5, 0, 1};  // t1,t2,f11,f12,f21,f22
     ROS_DEBUG("updateTactileData");
 
     if (isDSAInitialized_)
@@ -832,7 +832,7 @@ public:
       {
         try
         {
-          //dsa_->SetFramerate( 0, true, true );
+          // dsa_->SetFramerate( 0, true, true );
           dsa_->UpdateFrame();
         }
         catch (SDH::cSDHLibraryException* e)
@@ -860,12 +860,12 @@ public:
             tm.tactile_array[tm.cells_x * y + x] = dsa_->GetTexel(m, x, y);
         }
       }
-      //publish matrix
+      // publish matrix
       topicPub_TactileSensor_.publish(msg);
     }
   }
 };
-//SdhNode
+// SdhNode
 
 /*!
  * \brief Main loop of ROS node.
@@ -877,7 +877,7 @@ int main(int argc, char** argv)
   // initialize ROS, spezify name of node
   ros::init(argc, argv, "schunk_sdh");
 
-  //SdhNode sdh_node(ros::this_node::getName() + "/joint_trajectory_action");
+  // SdhNode sdh_node(ros::this_node::getName() + "/joint_trajectory_action");
   SdhNode sdh_node(ros::this_node::getName() + "/follow_joint_trajectory");
   if (!sdh_node.init())
     return 0;
@@ -891,12 +891,12 @@ int main(int argc, char** argv)
   }
   else
   {
-    frequency = 5; //Hz
+    frequency = 5;  // Hz
     ROS_WARN("Parameter frequency not available, setting to default value: %f Hz", frequency);
   }
 
-  //sleep(1);
-  ros::Rate loop_rate(frequency); // Hz
+  // sleep(1);
+  ros::Rate loop_rate(frequency);  // Hz
   while (sdh_node.nh_.ok())
   {
     // publish JointState

--- a/schunk_sdh/ros/src/sdh_only.cpp
+++ b/schunk_sdh/ros/src/sdh_only.cpp
@@ -59,7 +59,6 @@
 
 //##################
 //#### includes ####
-
 // standard includes
 #include <unistd.h>
 
@@ -86,704 +85,728 @@
 #include <schunk_sdh/sdh.h>
 
 /*!
-* \brief Implementation of ROS node for sdh.
-*
-* Offers actionlib and direct command interface.
-*/
+ * \brief Implementation of ROS node for sdh.
+ *
+ * Offers actionlib and direct command interface.
+ */
 class SdhNode
 {
-	public:
-		/// create a handle for this node, initialize node
-		ros::NodeHandle nh_;
-		ros::NodeHandle nh_private_;
+public:
+  /// create a handle for this node, initialize node
+  ros::NodeHandle nh_;
+  ros::NodeHandle nh_private_;
 
-	private:
-		// declaration of topics to publish
-		ros::Publisher topicPub_JointState_;
-		ros::Publisher topicPub_ControllerState_;
-		ros::Publisher topicPub_Diagnostics_;
+private:
+  // declaration of topics to publish
+  ros::Publisher topicPub_JointState_;
+  ros::Publisher topicPub_ControllerState_;
+  ros::Publisher topicPub_Diagnostics_;
 
-		// topic subscribers
-		ros::Subscriber subSetVelocitiesRaw_;
+  // topic subscribers
+  ros::Subscriber subSetVelocitiesRaw_;
 
-		// service servers
-		ros::ServiceServer srvServer_Init_;
-		ros::ServiceServer srvServer_Stop_;
-		ros::ServiceServer srvServer_Recover_;
-		ros::ServiceServer srvServer_SetOperationMode_;
+  // service servers
+  ros::ServiceServer srvServer_Init_;
+  ros::ServiceServer srvServer_Stop_;
+  ros::ServiceServer srvServer_Recover_;
+  ros::ServiceServer srvServer_SetOperationMode_;
 
-		// actionlib server
-		actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> as_;
-		std::string action_name_;
+  // actionlib server
+  actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> as_;
+  std::string action_name_;
 
-		// service clients
-		//--
+  // service clients
+  //--
 
-		// other variables
-		SDH::cSDH *sdh_;
-		std::vector<SDH::cSDH::eAxisState> state_;
+  // other variables
+  SDH::cSDH *sdh_;
+  std::vector<SDH::cSDH::eAxisState> state_;
 
-		std::string sdhdevicetype_;
-		std::string sdhdevicestring_;
-		int sdhdevicenum_;
-		int baudrate_, id_read_, id_write_;
-		double timeout_;
+  std::string sdhdevicetype_;
+  std::string sdhdevicestring_;
+  int sdhdevicenum_;
+  int baudrate_, id_read_, id_write_;
+  double timeout_;
 
-		bool isInitialized_;
-		bool isError_;
-		int DOF_;
-		double pi_;
+  bool isInitialized_;
+  bool isError_;
+  int DOF_;
+  double pi_;
 
-		trajectory_msgs::JointTrajectory traj_;
+  trajectory_msgs::JointTrajectory traj_;
 
-		std::vector<std::string> joint_names_;
-		std::vector<int> axes_;
-		std::vector<double> targetAngles_; // in degrees
-		std::vector<double> velocities_; // in rad/s
-		bool hasNewGoal_;
-		std::string operationMode_;
+  std::vector<std::string> joint_names_;
+  std::vector<int> axes_;
+  std::vector<double> targetAngles_; // in degrees
+  std::vector<double> velocities_; // in rad/s
+  bool hasNewGoal_;
+  std::string operationMode_;
 
-	public:
-		/*!
-		* \brief Constructor for SdhNode class
-		*
-		* \param name Name for the actionlib server
-		*/
-		SdhNode():
-			as_(nh_, "joint_trajectory_controller/follow_joint_trajectory", boost::bind(&SdhNode::executeCB, this, _1),true),
-			action_name_("follow_joint_trajectory")
-		{
-			nh_private_ = ros::NodeHandle ("~");
-			pi_ = 3.1415926;
-			isError_ = false;
-		}
+public:
+  /*!
+   * \brief Constructor for SdhNode class
+   *
+   * \param name Name for the actionlib server
+   */
+  SdhNode() :
+      as_(nh_, "joint_trajectory_controller/follow_joint_trajectory", boost::bind(&SdhNode::executeCB, this, _1), true), action_name_(
+          "follow_joint_trajectory")
+  {
+    nh_private_ = ros::NodeHandle("~");
+    pi_ = 3.1415926;
+    isError_ = false;
+  }
 
-		/*!
-		* \brief Destructor for SdhNode class
-		*/
-		~SdhNode()
-		{
-			if(isInitialized_)
-				sdh_->Close();
-			delete sdh_;
-		}
+  /*!
+   * \brief Destructor for SdhNode class
+   */
+  ~SdhNode()
+  {
+    if (isInitialized_)
+      sdh_->Close();
+    delete sdh_;
+  }
 
+  /*!
+   * \brief Initializes node to get parameters, subscribe and publish to topics.
+   */
+  bool init()
+  {
+    // initialize member variables
+    isInitialized_ = false;
+    hasNewGoal_ = false;
 
-		/*!
-		* \brief Initializes node to get parameters, subscribe and publish to topics.
-		*/
-		bool init()
-		{
-			// initialize member variables
-			isInitialized_ = false;
-			hasNewGoal_ = false;
+    // implementation of topics to publish
+    topicPub_JointState_ = nh_.advertise<sensor_msgs::JointState>("joint_states", 1);
+    topicPub_ControllerState_ = nh_.advertise<control_msgs::JointTrajectoryControllerState>(
+        "joint_trajectory_controller/state", 1);
+    topicPub_Diagnostics_ = nh_.advertise<diagnostic_msgs::DiagnosticArray>("diagnostics", 1);
 
-			// implementation of topics to publish
-			topicPub_JointState_ = nh_.advertise<sensor_msgs::JointState>("joint_states", 1);
-			topicPub_ControllerState_ = nh_.advertise<control_msgs::JointTrajectoryControllerState>("joint_trajectory_controller/state", 1);
-			topicPub_Diagnostics_ = nh_.advertise<diagnostic_msgs::DiagnosticArray>("diagnostics", 1);
+    // pointer to sdh
+    sdh_ = new SDH::cSDH(false, false, 0); //(_use_radians=false, bool _use_fahrenheit=false, int _debug_level=0)
 
-			// pointer to sdh
-			sdh_ = new SDH::cSDH(false, false, 0); //(_use_radians=false, bool _use_fahrenheit=false, int _debug_level=0)
+    // implementation of service servers
+    srvServer_Init_ = nh_.advertiseService("driver/init", &SdhNode::srvCallback_Init, this);
+    srvServer_Stop_ = nh_.advertiseService("driver/stop", &SdhNode::srvCallback_Stop, this);
+    srvServer_Recover_ = nh_.advertiseService("driver/recover", &SdhNode::srvCallback_Init, this); //HACK: There is no recover implemented yet, so we execute a init
+    srvServer_SetOperationMode_ = nh_.advertiseService("driver/set_operation_mode",
+                                                       &SdhNode::srvCallback_SetOperationMode, this);
 
-			// implementation of service servers
-			srvServer_Init_ = nh_.advertiseService("driver/init", &SdhNode::srvCallback_Init, this);
-			srvServer_Stop_ = nh_.advertiseService("driver/stop", &SdhNode::srvCallback_Stop, this);
-			srvServer_Recover_ = nh_.advertiseService("driver/recover", &SdhNode::srvCallback_Init, this); //HACK: There is no recover implemented yet, so we execute a init
-			srvServer_SetOperationMode_ = nh_.advertiseService("driver/set_operation_mode", &SdhNode::srvCallback_SetOperationMode, this);
+    subSetVelocitiesRaw_ = nh_.subscribe("joint_group_velocity_controller/command", 1,
+                                         &SdhNode::topicCallback_setVelocitiesRaw, this);
 
-			subSetVelocitiesRaw_ = nh_.subscribe("joint_group_velocity_controller/command", 1, &SdhNode::topicCallback_setVelocitiesRaw, this);
+    // getting hardware parameters from parameter server
+    nh_private_.param("sdhdevicetype", sdhdevicetype_, std::string("PCAN"));
+    nh_private_.param("sdhdevicestring", sdhdevicestring_, std::string("/dev/pcan0"));
+    nh_private_.param("sdhdevicenum", sdhdevicenum_, 0);
 
-			// getting hardware parameters from parameter server
-			nh_private_.param("sdhdevicetype", sdhdevicetype_, std::string("PCAN"));
-			nh_private_.param("sdhdevicestring", sdhdevicestring_, std::string("/dev/pcan0"));
-			nh_private_.param("sdhdevicenum", sdhdevicenum_, 0);
+    nh_private_.param("baudrate", baudrate_, 1000000);
+    nh_private_.param("timeout", timeout_, (double)0.04);
+    nh_private_.param("id_read", id_read_, 43);
+    nh_private_.param("id_write", id_write_, 42);
 
-			nh_private_.param("baudrate", baudrate_, 1000000);
-			nh_private_.param("timeout", timeout_, (double)0.04);
-			nh_private_.param("id_read", id_read_, 43);
-			nh_private_.param("id_write", id_write_, 42);
+    // get joint_names from parameter server
+    ROS_INFO("getting joint_names from parameter server");
+    XmlRpc::XmlRpcValue joint_names_param;
+    if (nh_private_.hasParam("joint_names"))
+    {
+      nh_private_.getParam("joint_names", joint_names_param);
+    }
+    else
+    {
+      ROS_ERROR("Parameter 'joint_names' not set, shutting down node...");
+      nh_.shutdown();
+      return false;
+    }
+    DOF_ = joint_names_param.size();
+    joint_names_.resize(DOF_);
+    for (int i = 0; i < DOF_; i++)
+    {
+      joint_names_[i] = (std::string)joint_names_param[i];
+    }
+    std::cout << "joint_names = " << joint_names_param << std::endl;
 
-			// get joint_names from parameter server
-			ROS_INFO("getting joint_names from parameter server");
-			XmlRpc::XmlRpcValue joint_names_param;
-			if (nh_private_.hasParam("joint_names"))
-			{
-				nh_private_.getParam("joint_names", joint_names_param);
-			}
-			else
-			{
-				ROS_ERROR("Parameter 'joint_names' not set, shutting down node...");
-				nh_.shutdown();
-				return false;
-			}
-			DOF_ = joint_names_param.size();
-			joint_names_.resize(DOF_);
-			for (int i = 0; i<DOF_; i++ )
-			{
-				joint_names_[i] = (std::string)joint_names_param[i];
-			}
-			std::cout << "joint_names = " << joint_names_param << std::endl;
+    // define axes to send to sdh
+    axes_.resize(DOF_);
+    velocities_.resize(DOF_);
+    for (int i = 0; i < DOF_; i++)
+    {
+      axes_[i] = i;
+    }
+    ROS_INFO("DOF = %d", DOF_);
 
-			// define axes to send to sdh
-			axes_.resize(DOF_);
-			velocities_.resize(DOF_);
-			for(int i=0; i<DOF_; i++)
-			{
-				axes_[i] = i;
-			}
-			ROS_INFO("DOF = %d",DOF_);
+    state_.resize(axes_.size());
 
-			state_.resize(axes_.size());
+    nh_private_.param("OperationMode", operationMode_, std::string("position"));
+    return true;
+  }
+  /*!
+   * \brief Switches operation mode if possible
+   *
+   * \param mode new mode
+   */
+  bool switchOperationMode(const std::string &mode)
+  {
+    hasNewGoal_ = false;
+    sdh_->Stop();
 
-			nh_private_.param("OperationMode", operationMode_, std::string("position"));
-			return true;
-		}
-		/*!
-		* \brief Switches operation mode if possible
-		*
-		* \param mode new mode
-		*/
-		bool switchOperationMode(const std::string &mode){
-			hasNewGoal_ = false;
-			sdh_->Stop();
+    try
+    {
+      if (mode == "position")
+      {
+        sdh_->SetController(SDH::cSDH::eCT_POSE);
+      }
+      else if (mode == "velocity")
+      {
+        sdh_->SetController(SDH::cSDH::eCT_VELOCITY);
+      }
+      else
+      {
+        ROS_ERROR_STREAM("Operation mode '" << mode << "'  not supported");
+        return false;
+      }
+      sdh_->SetAxisEnable(sdh_->All, 1.0); // TODO: check if necessary
+    }
+    catch (SDH::cSDHLibraryException* e)
+    {
+      ROS_ERROR("An exception was caught: %s", e->what());
+      delete e;
+      return false;
+    }
 
-			try{
-				if(mode == "position"){
-					sdh_->SetController(SDH::cSDH::eCT_POSE);
-				}else if(mode == "velocity"){
-					sdh_->SetController(SDH::cSDH::eCT_VELOCITY);
-				}else{
-					ROS_ERROR_STREAM("Operation mode '" << mode << "'  not supported");
-					return false;
-				}
-				sdh_->SetAxisEnable(sdh_->All, 1.0); // TODO: check if necessary
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-				return false;
-			}
+    operationMode_ = mode;
+    return true;
 
-			operationMode_ = mode;
-			return true;
+  }
 
-		}
+  /*!
+   * \brief Executes the callback from the actionlib
+   *
+   * Set the current goal to aborted after receiving a new goal and write new goal to a member variable. Wait for the goal to finish and set actionlib status to succeeded.
+   * \param goal JointTrajectoryGoal
+   */
+  void executeCB(const control_msgs::FollowJointTrajectoryGoalConstPtr &goal)
+  {
+    ROS_INFO("sdh: executeCB");
+    if (operationMode_ != "position")
+    {
+      ROS_ERROR("%s: Rejected, sdh not in position mode", action_name_.c_str());
+      as_.setAborted();
+      return;
+    }
+    if (!isInitialized_)
+    {
+      ROS_ERROR("%s: Rejected, sdh not initialized", action_name_.c_str());
+      as_.setAborted();
+      return;
+    }
 
-		/*!
-		* \brief Executes the callback from the actionlib
-		*
-		* Set the current goal to aborted after receiving a new goal and write new goal to a member variable. Wait for the goal to finish and set actionlib status to succeeded.
-		* \param goal JointTrajectoryGoal
-		*/
-		void executeCB(const control_msgs::FollowJointTrajectoryGoalConstPtr &goal)
-		{
-			ROS_INFO("sdh: executeCB");
-			if (operationMode_ != "position")
-			{
-				ROS_ERROR("%s: Rejected, sdh not in position mode", action_name_.c_str());
-				as_.setAborted();
-				return;
-			}
-			if (!isInitialized_)
-			{
-				ROS_ERROR("%s: Rejected, sdh not initialized", action_name_.c_str());
-				as_.setAborted();
-				return;
-			}
+    if (goal->trajectory.points.empty() || goal->trajectory.points[0].positions.size() != size_t(DOF_))
+    {
+      ROS_ERROR("%s: Rejected, malformed FollowJointTrajectoryGoal", action_name_.c_str());
+      as_.setAborted();
+      return;
+    }
+    while (hasNewGoal_ == true)
+      usleep(10000);
 
-			if (goal->trajectory.points.empty() || goal->trajectory.points[0].positions.size() != size_t(DOF_))
-			{
-				ROS_ERROR("%s: Rejected, malformed FollowJointTrajectoryGoal", action_name_.c_str());
-				as_.setAborted();
-				return;
-			}
-			while (hasNewGoal_ == true ) usleep(10000);
+    std::map<std::string, int> dict;
+    for (int idx = 0; idx < goal->trajectory.joint_names.size(); idx++)
+    {
+      dict[goal->trajectory.joint_names[idx]] = idx;
+    }
 
-			std::map<std::string,int> dict;
-			for (int idx=0; idx<goal->trajectory.joint_names.size(); idx++)
-			{
-				dict[goal->trajectory.joint_names[idx]] = idx;
-			}
+    targetAngles_.resize(DOF_);
+    targetAngles_[0] = goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]] * 180.0 / pi_; // sdh_knuckle_joint
+    targetAngles_[1] = goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]] * 180.0 / pi_; // sdh_finger22_joint
+    targetAngles_[2] = goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]] * 180.0 / pi_; // sdh_finger23_joint
+    targetAngles_[3] = goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]] * 180.0 / pi_; // sdh_thumb2_joint
+    targetAngles_[4] = goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]] * 180.0 / pi_; // sdh_thumb3_joint
+    targetAngles_[5] = goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]] * 180.0 / pi_; // sdh_finger12_joint
+    targetAngles_[6] = goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]] * 180.0 / pi_; // sdh_finger13_joint
+    ROS_INFO(
+        "received position goal: [['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']] = [%f,%f,%f,%f,%f,%f,%f]",
+        goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]],
+        goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]]);
 
-			targetAngles_.resize(DOF_);
-			targetAngles_[0] = goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]]*180.0/pi_; // sdh_knuckle_joint
-			targetAngles_[1] = goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]]*180.0/pi_; // sdh_finger22_joint
-			targetAngles_[2] = goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]]*180.0/pi_; // sdh_finger23_joint
-			targetAngles_[3] = goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]]*180.0/pi_; // sdh_thumb2_joint
-			targetAngles_[4] = goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]]*180.0/pi_; // sdh_thumb3_joint
-			targetAngles_[5] = goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]]*180.0/pi_; // sdh_finger12_joint
-			targetAngles_[6] = goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]]*180.0/pi_; // sdh_finger13_joint
-			ROS_INFO("received position goal: [['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']] = [%f,%f,%f,%f,%f,%f,%f]",goal->trajectory.points[0].positions[dict["sdh_knuckle_joint"]],goal->trajectory.points[0].positions[dict["sdh_thumb_2_joint"]],goal->trajectory.points[0].positions[dict["sdh_thumb_3_joint"]],goal->trajectory.points[0].positions[dict["sdh_finger_12_joint"]],goal->trajectory.points[0].positions[dict["sdh_finger_13_joint"]],goal->trajectory.points[0].positions[dict["sdh_finger_22_joint"]],goal->trajectory.points[0].positions[dict["sdh_finger_23_joint"]]);
+    hasNewGoal_ = true;
 
-			hasNewGoal_ = true;
+    usleep(500000); // needed sleep until sdh starts to change status from idle to moving
 
-			usleep(500000); // needed sleep until sdh starts to change status from idle to moving
+    bool finished = false;
+    while (finished == false)
+    {
+      if (as_.isNewGoalAvailable())
+      {
+        ROS_WARN("%s: Aborted", action_name_.c_str());
+        as_.setAborted();
+        return;
+      }
+      for (unsigned int i = 0; i < state_.size(); i++)
+      {
+        ROS_DEBUG("state[%d] = %d", i, state_[i]);
+        if (state_[i] == 0)
+        {
+          finished = true;
+        }
+        else
+        {
+          finished = false;
+        }
+      }
+      usleep(10000);
+    }
 
-			bool finished = false;
-			while(finished == false)
-			{
-				if (as_.isNewGoalAvailable())
-				{
-					ROS_WARN("%s: Aborted", action_name_.c_str());
-					as_.setAborted();
-					return;
-				}
-				for ( unsigned int i = 0; i < state_.size(); i++ )
-		 		{
-		 			ROS_DEBUG("state[%d] = %d",i,state_[i]);
-		 			if (state_[i] == 0)
-		 			{
-		 				finished = true;
-		 			}
-		 			else
-		 			{
-		 				finished = false;
-		 			}
-		 		}
-		 		usleep(10000);
-			}
+    // set the action state to succeeded
+    ROS_INFO("%s: Succeeded", action_name_.c_str());
+    as_.setSucceeded();
+  }
 
-			// set the action state to succeeded
-			ROS_INFO("%s: Succeeded", action_name_.c_str());
-			as_.setSucceeded();
-		}
+  void topicCallback_setVelocitiesRaw(const std_msgs::Float64MultiArrayPtr& velocities)
+  {
+    if (!isInitialized_)
+    {
+      ROS_ERROR("%s: Rejected, sdh not initialized", action_name_.c_str());
+      return;
+    }
+    if (velocities->data.size() != velocities_.size())
+    {
+      ROS_ERROR("Velocity array dimension mismatch");
+      return;
+    }
+    if (operationMode_ != "velocity")
+    {
+      ROS_ERROR("%s: Rejected, sdh not in velocity mode", action_name_.c_str());
+      return;
+    }
 
-		void topicCallback_setVelocitiesRaw(const std_msgs::Float64MultiArrayPtr& velocities)
-		{
-			if (!isInitialized_)
-			{
-				ROS_ERROR("%s: Rejected, sdh not initialized", action_name_.c_str());
-				return;
-			}
-			if(velocities->data.size() != velocities_.size()){
-				ROS_ERROR("Velocity array dimension mismatch");
-				return;
-			}
-			if (operationMode_ != "velocity")
-			{
-				ROS_ERROR("%s: Rejected, sdh not in velocity mode", action_name_.c_str());
-				return;
-			}
+    // TODO: write proper lock!
+    while (hasNewGoal_ == true)
+      usleep(10000);
 
-			// TODO: write proper lock!
-			while (hasNewGoal_ == true ) usleep(10000);
+    velocities_[0] = velocities->data[0] * 180.0 / pi_; // sdh_knuckle_joint
+    velocities_[1] = velocities->data[5] * 180.0 / pi_; // sdh_finger22_joint
+    velocities_[2] = velocities->data[6] * 180.0 / pi_; // sdh_finger23_joint
+    velocities_[3] = velocities->data[1] * 180.0 / pi_; // sdh_thumb2_joint
+    velocities_[4] = velocities->data[2] * 180.0 / pi_; // sdh_thumb3_joint
+    velocities_[5] = velocities->data[3] * 180.0 / pi_; // sdh_finger12_joint
+    velocities_[6] = velocities->data[4] * 180.0 / pi_; // sdh_finger13_joint
 
-			velocities_[0] = velocities->data[0] * 180.0 / pi_; // sdh_knuckle_joint
-			velocities_[1] = velocities->data[5] * 180.0 / pi_; // sdh_finger22_joint
-			velocities_[2] = velocities->data[6] * 180.0 / pi_; // sdh_finger23_joint
-			velocities_[3] = velocities->data[1] * 180.0 / pi_; // sdh_thumb2_joint
-			velocities_[4] = velocities->data[2] * 180.0 / pi_; // sdh_thumb3_joint
-			velocities_[5] = velocities->data[3] * 180.0 / pi_; // sdh_finger12_joint
-			velocities_[6] = velocities->data[4] * 180.0 / pi_; // sdh_finger13_joint
+    hasNewGoal_ = true;
+  }
 
-			hasNewGoal_ = true;
-		}
+  /*!
+   * \brief Executes the service callback for init.
+   *
+   * Connects to the hardware and initialized it.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_Init(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
+  {
 
-		/*!
-		* \brief Executes the service callback for init.
-		*
-		* Connects to the hardware and initialized it.
-		* \param req Service request
-		* \param res Service response
-		*/
-		bool srvCallback_Init(std_srvs::Trigger::Request &req,
-							std_srvs::Trigger::Response &res )
-		{
+    if (isInitialized_ == false)
+    {
+      //Init Hand connection
 
-			if (isInitialized_ == false)
-			{
-				//Init Hand connection
+      try
+      {
+        if (sdhdevicetype_.compare("RS232") == 0)
+        {
+          sdh_->OpenRS232(sdhdevicenum_, 115200, 1, sdhdevicestring_.c_str());
+          ROS_INFO("Initialized RS232 for SDH");
+          isInitialized_ = true;
+        }
+        if (sdhdevicetype_.compare("PCAN") == 0)
+        {
+          ROS_INFO("Starting initializing PEAKCAN");
+          sdh_->OpenCAN_PEAK(baudrate_, timeout_, id_read_, id_write_, sdhdevicestring_.c_str());
+          ROS_INFO("Initialized PEAK CAN for SDH");
+          isInitialized_ = true;
+        }
+        if (sdhdevicetype_.compare("ESD") == 0)
+        {
+          ROS_INFO("Starting initializing ESD");
+          if (strcmp(sdhdevicestring_.c_str(), "/dev/can0") == 0)
+          {
+            ROS_INFO("Initializing ESD on device %s", sdhdevicestring_.c_str());
+            sdh_->OpenCAN_ESD(0, baudrate_, timeout_, id_read_, id_write_);
+          }
+          else if (strcmp(sdhdevicestring_.c_str(), "/dev/can1") == 0)
+          {
+            ROS_INFO("Initializin ESD on device %s", sdhdevicestring_.c_str());
+            sdh_->OpenCAN_ESD(1, baudrate_, timeout_, id_read_, id_write_);
+          }
+          else
+          {
+            ROS_ERROR("Currently only support for /dev/can0 and /dev/can1");
+            res.success = false;
+            res.message = "Currently only support for /dev/can0 and /dev/can1";
+            return true;
+          }
+          ROS_INFO("Initialized ESDCAN for SDH");
+          isInitialized_ = true;
+        }
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        res.success = false;
+        res.message = e->what();
+        delete e;
+        return true;
+      }
+      if (!switchOperationMode(operationMode_))
+      {
+        res.success = false;
+        res.message = "Could not set operation mode to '" + operationMode_ + "'";
+        return true;
+      }
+    }
+    else
+    {
+      ROS_WARN("...sdh already initialized...");
+      res.success = true;
+      res.message = "sdh already initialized";
+    }
 
-				try
-				{
-					if(sdhdevicetype_.compare("RS232")==0)
-					{
-						sdh_->OpenRS232( sdhdevicenum_, 115200, 1, sdhdevicestring_.c_str());
-						ROS_INFO("Initialized RS232 for SDH");
-						isInitialized_ = true;
-					}
-					if(sdhdevicetype_.compare("PCAN")==0)
-					{
-						ROS_INFO("Starting initializing PEAKCAN");
-						sdh_->OpenCAN_PEAK(baudrate_, timeout_, id_read_, id_write_, sdhdevicestring_.c_str());
-						ROS_INFO("Initialized PEAK CAN for SDH");
-						isInitialized_ = true;
-					}
-					if(sdhdevicetype_.compare("ESD")==0)
-					{
-						ROS_INFO("Starting initializing ESD");
-						if(strcmp(sdhdevicestring_.c_str(), "/dev/can0") == 0)
-						{
-							ROS_INFO("Initializing ESD on device %s",sdhdevicestring_.c_str());
-							sdh_->OpenCAN_ESD(0, baudrate_, timeout_, id_read_, id_write_ );
-						}
-						else if(strcmp(sdhdevicestring_.c_str(), "/dev/can1") == 0)
-						{
-							ROS_INFO("Initializin ESD on device %s",sdhdevicestring_.c_str());
-							sdh_->OpenCAN_ESD(1, baudrate_, timeout_, id_read_, id_write_ );
-						}
-						else
-						{
-							ROS_ERROR("Currently only support for /dev/can0 and /dev/can1");
-							res.success = false;
-							res.message = "Currently only support for /dev/can0 and /dev/can1";
-							return true;
-						}
-						ROS_INFO("Initialized ESDCAN for SDH");
-						isInitialized_ = true;
-					}
-				}
-				catch (SDH::cSDHLibraryException* e)
-				{
-					ROS_ERROR("An exception was caught: %s", e->what());
-					res.success = false;
-					res.message = e->what();
-					delete e;
-					return true;
-				}
-				if(!switchOperationMode(operationMode_)){
-					res.success = false;
-					res.message = "Could not set operation mode to '" + operationMode_ + "'";
-					return true;
-				}
-			}
-			else
-			{
-				ROS_WARN("...sdh already initialized...");
-				res.success = true;
-				res.message = "sdh already initialized";
-			}
+    res.success = true;
+    return true;
+  }
 
-			res.success = true;
-			return true;
-		}
+  /*!
+   * \brief Executes the service callback for stop.
+   *
+   * Stops all hardware movements.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_Stop(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
+  {
+    ROS_INFO("Stopping sdh");
 
-		/*!
-		* \brief Executes the service callback for stop.
-		*
-		* Stops all hardware movements.
-		* \param req Service request
-		* \param res Service response
-		*/
-		bool srvCallback_Stop(std_srvs::Trigger::Request &req,
-							std_srvs::Trigger::Response &res )
-		{
-			ROS_INFO("Stopping sdh");
+    // stopping all arm movements
+    try
+    {
+      sdh_->Stop();
+    }
+    catch (SDH::cSDHLibraryException* e)
+    {
+      ROS_ERROR("An exception was caught: %s", e->what());
+      delete e;
+    }
 
-			// stopping all arm movements
-			try
-			{
-				sdh_->Stop();
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-			}
+    ROS_INFO("Stopping sdh succesfull");
+    res.success = true;
+    return true;
+  }
 
-		ROS_INFO("Stopping sdh succesfull");
-		res.success = true;
-		return true;
-	}
+  /*!
+   * \brief Executes the service callback for recover.
+   *
+   * Recovers the hardware after an emergency stop.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_Recover(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
+  {
+    ROS_WARN("Service recover not implemented yet");
+    res.success = true;
+    res.message = "Service recover not implemented yet";
+    return true;
+  }
 
-	/*!
-	* \brief Executes the service callback for recover.
-	*
-	* Recovers the hardware after an emergency stop.
-	* \param req Service request
-	* \param res Service response
-	*/
-	bool srvCallback_Recover(std_srvs::Trigger::Request &req,
-							std_srvs::Trigger::Response &res )
-	{
-		ROS_WARN("Service recover not implemented yet");
-		res.success = true;
-		res.message = "Service recover not implemented yet";
-		return true;
-	}
+  /*!
+   * \brief Executes the service callback for set_operation_mode.
+   *
+   * Changes the operation mode.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_SetOperationMode(cob_srvs::SetString::Request &req, cob_srvs::SetString::Response &res)
+  {
+    hasNewGoal_ = false;
+    sdh_->Stop();
+    res.success = switchOperationMode(req.data);
+    if (operationMode_ == "position")
+    {
+      sdh_->SetController(SDH::cSDH::eCT_POSE);
+    }
+    else if (operationMode_ == "velocity")
+    {
+      try
+      {
+        sdh_->SetController(SDH::cSDH::eCT_VELOCITY);
+        sdh_->SetAxisEnable(sdh_->All, 1.0);
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        delete e;
+      }
+    }
+    else
+    {
+      ROS_ERROR_STREAM("Operation mode '" << req.data << "'  not supported");
+    }
+    return true;
+  }
 
-	/*!
-	* \brief Executes the service callback for set_operation_mode.
-	*
-	* Changes the operation mode.
-	* \param req Service request
-	* \param res Service response
-	*/
-	bool srvCallback_SetOperationMode(cob_srvs::SetString::Request &req,
-									cob_srvs::SetString::Response &res )
-	{
-		hasNewGoal_ = false;
-		sdh_->Stop();
-		res.success = switchOperationMode(req.data);
-		if( operationMode_ == "position"){
-			sdh_->SetController(SDH::cSDH::eCT_POSE);
-		}else if( operationMode_ == "velocity"){
-			try{
-				sdh_->SetController(SDH::cSDH::eCT_VELOCITY);
-				sdh_->SetAxisEnable(sdh_->All, 1.0);
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-			}
-		}else{
-			ROS_ERROR_STREAM("Operation mode '" << req.data << "'  not supported");
-		}
-		return true;
-	}
+  /*!
+   * \brief Main routine to update sdh.
+   *
+   * Sends target to hardware and reads out current configuration.
+   */
+  void updateSdh()
+  {
+    ROS_DEBUG("updateJointState");
+    if (isInitialized_ == true)
+    {
+      if (hasNewGoal_ == true)
+      {
+        // stop sdh first when new goal arrived
+        try
+        {
+          sdh_->Stop();
+        }
+        catch (SDH::cSDHLibraryException* e)
+        {
+          ROS_ERROR("An exception was caught: %s", e->what());
+          delete e;
+        }
 
-	/*!
-	* \brief Main routine to update sdh.
-	*
-	* Sends target to hardware and reads out current configuration.
-	*/
-	void updateSdh()
-	{
-		ROS_DEBUG("updateJointState");
-		if (isInitialized_ == true)
-		{
-			if (hasNewGoal_ == true)
-			{
-				// stop sdh first when new goal arrived
-				try
-				{
-					sdh_->Stop();
-				}
-				catch (SDH::cSDHLibraryException* e)
-				{
-					ROS_ERROR("An exception was caught: %s", e->what());
-					delete e;
-				}
+        if (operationMode_ == "position")
+        {
+          ROS_DEBUG("moving sdh in position mode");
 
-				if (operationMode_ == "position")
-				{
-					ROS_DEBUG("moving sdh in position mode");
+          try
+          {
+            sdh_->SetAxisTargetAngle(axes_, targetAngles_);
+            sdh_->MoveHand(false);
+          }
+          catch (SDH::cSDHLibraryException* e)
+          {
+            ROS_ERROR("An exception was caught: %s", e->what());
+            delete e;
+          }
+        }
+        else if (operationMode_ == "velocity")
+        {
+          ROS_DEBUG("moving sdh in velocity mode");
+          try
+          {
+            sdh_->SetAxisTargetVelocity(axes_, velocities_);
+            // ROS_DEBUG_STREAM("velocities: " << velocities_[0] << " "<< velocities_[1] << " "<< velocities_[2] << " "<< velocities_[3] << " "<< velocities_[4] << " "<< velocities_[5] << " "<< velocities_[6]);
+          }
+          catch (SDH::cSDHLibraryException* e)
+          {
+            ROS_ERROR("An exception was caught: %s", e->what());
+            delete e;
+          }
+        }
+        else if (operationMode_ == "effort")
+        {
+          ROS_DEBUG("moving sdh in effort mode");
+          //sdh_->MoveVel(goal->trajectory.points[0].velocities);
+          ROS_WARN("Moving in effort mode currently disabled");
+        }
+        else
+        {
+          ROS_ERROR("sdh neither in position nor in velocity nor in effort mode. OperationMode = [%s]",
+                    operationMode_.c_str());
+        }
 
-					try
-					{
-						sdh_->SetAxisTargetAngle( axes_, targetAngles_ );
-						sdh_->MoveHand(false);
-					}
-					catch (SDH::cSDHLibraryException* e)
-					{
-						ROS_ERROR("An exception was caught: %s", e->what());
-						delete e;
-					}
-				}
-				else if (operationMode_ == "velocity")
-				{
-					ROS_DEBUG("moving sdh in velocity mode");
-					try
-					{
-						sdh_->SetAxisTargetVelocity(axes_,velocities_);
-						// ROS_DEBUG_STREAM("velocities: " << velocities_[0] << " "<< velocities_[1] << " "<< velocities_[2] << " "<< velocities_[3] << " "<< velocities_[4] << " "<< velocities_[5] << " "<< velocities_[6]);
-					}
-					catch (SDH::cSDHLibraryException* e)
-					{
-						ROS_ERROR("An exception was caught: %s", e->what());
-						delete e;
-					}
-				}
-				else if (operationMode_ == "effort")
-				{
-					ROS_DEBUG("moving sdh in effort mode");
-					//sdh_->MoveVel(goal->trajectory.points[0].velocities);
-					ROS_WARN("Moving in effort mode currently disabled");
-				}
-				else
-				{
-					ROS_ERROR("sdh neither in position nor in velocity nor in effort mode. OperationMode = [%s]", operationMode_.c_str());
-				}
+        hasNewGoal_ = false;
+      }
 
-				hasNewGoal_ = false;
-			}
+      // read and publish joint angles and velocities
+      std::vector<double> actualAngles;
+      try
+      {
+        actualAngles = sdh_->GetAxisActualAngle(axes_);
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        delete e;
+      }
+      std::vector<double> actualVelocities;
+      try
+      {
+        actualVelocities = sdh_->GetAxisActualVelocity(axes_);
+      }
+      catch (SDH::cSDHLibraryException* e)
+      {
+        ROS_ERROR("An exception was caught: %s", e->what());
+        delete e;
+      }
 
-	 		// read and publish joint angles and velocities
-			std::vector<double> actualAngles;
-			try
-			{
-				actualAngles = sdh_->GetAxisActualAngle( axes_ );
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-			}
-			std::vector<double> actualVelocities;
-			try
-			{
-				actualVelocities = sdh_->GetAxisActualVelocity( axes_ );
-			}
-			catch (SDH::cSDHLibraryException* e)
-			{
-				ROS_ERROR("An exception was caught: %s", e->what());
-				delete e;
-			}
+      ROS_DEBUG("received %d angles from sdh", (int )actualAngles.size());
 
-			ROS_DEBUG("received %d angles from sdh",(int)actualAngles.size());
+      ros::Time time = ros::Time::now();
 
-			ros::Time time = ros::Time::now();
+      // create joint_state message
+      sensor_msgs::JointState msg;
+      msg.header.stamp = time;
+      msg.name.resize(DOF_);
+      msg.position.resize(DOF_);
+      msg.velocity.resize(DOF_);
+      msg.effort.resize(DOF_);
+      // set joint names and map them to angles
+      msg.name = joint_names_;
+      //['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
+      // pos
+      msg.position[0] = actualAngles[0] * pi_ / 180.0; // sdh_knuckle_joint
+      msg.position[1] = actualAngles[3] * pi_ / 180.0; // sdh_thumb_2_joint
+      msg.position[2] = actualAngles[4] * pi_ / 180.0; // sdh_thumb_3_joint
+      msg.position[3] = actualAngles[5] * pi_ / 180.0; // sdh_finger_12_joint
+      msg.position[4] = actualAngles[6] * pi_ / 180.0; // sdh_finger_13_joint
+      msg.position[5] = actualAngles[1] * pi_ / 180.0; // sdh_finger_22_joint
+      msg.position[6] = actualAngles[2] * pi_ / 180.0; // sdh_finger_23_joint
+      // vel
+      msg.velocity[0] = actualVelocities[0] * pi_ / 180.0; // sdh_knuckle_joint
+      msg.velocity[1] = actualVelocities[3] * pi_ / 180.0; // sdh_thumb_2_joint
+      msg.velocity[2] = actualVelocities[4] * pi_ / 180.0; // sdh_thumb_3_joint
+      msg.velocity[3] = actualVelocities[5] * pi_ / 180.0; // sdh_finger_12_joint
+      msg.velocity[4] = actualVelocities[6] * pi_ / 180.0; // sdh_finger_13_joint
+      msg.velocity[5] = actualVelocities[1] * pi_ / 180.0; // sdh_finger_22_joint
+      msg.velocity[6] = actualVelocities[2] * pi_ / 180.0; // sdh_finger_23_joint
+      // publish message
+      topicPub_JointState_.publish(msg);
 
-			// create joint_state message
-			sensor_msgs::JointState msg;
-			msg.header.stamp = time;
-			msg.name.resize(DOF_);
-			msg.position.resize(DOF_);
-			msg.velocity.resize(DOF_);
-			msg.effort.resize(DOF_);
-			// set joint names and map them to angles
-			msg.name = joint_names_;
-			//['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
-			// pos
-			msg.position[0] = actualAngles[0]*pi_/180.0; // sdh_knuckle_joint
-			msg.position[1] = actualAngles[3]*pi_/180.0; // sdh_thumb_2_joint
-			msg.position[2] = actualAngles[4]*pi_/180.0; // sdh_thumb_3_joint
-			msg.position[3] = actualAngles[5]*pi_/180.0; // sdh_finger_12_joint
-			msg.position[4] = actualAngles[6]*pi_/180.0; // sdh_finger_13_joint
-			msg.position[5] = actualAngles[1]*pi_/180.0; // sdh_finger_22_joint
-			msg.position[6] = actualAngles[2]*pi_/180.0; // sdh_finger_23_joint
-			// vel
-			msg.velocity[0] = actualVelocities[0]*pi_/180.0; // sdh_knuckle_joint
-			msg.velocity[1] = actualVelocities[3]*pi_/180.0; // sdh_thumb_2_joint
-			msg.velocity[2] = actualVelocities[4]*pi_/180.0; // sdh_thumb_3_joint
-			msg.velocity[3] = actualVelocities[5]*pi_/180.0; // sdh_finger_12_joint
-			msg.velocity[4] = actualVelocities[6]*pi_/180.0; // sdh_finger_13_joint
-			msg.velocity[5] = actualVelocities[1]*pi_/180.0; // sdh_finger_22_joint
-			msg.velocity[6] = actualVelocities[2]*pi_/180.0; // sdh_finger_23_joint
-			// publish message
-			topicPub_JointState_.publish(msg);
+      // because the robot_state_publisher doen't know about the mimic joint, we have to publish the coupled joint separately
+      sensor_msgs::JointState mimicjointmsg;
+      mimicjointmsg.header.stamp = time;
+      mimicjointmsg.name.resize(1);
+      mimicjointmsg.position.resize(1);
+      mimicjointmsg.velocity.resize(1);
+      mimicjointmsg.name[0] = "sdh_finger_21_joint";
+      mimicjointmsg.position[0] = msg.position[0]; // sdh_knuckle_joint = sdh_finger_21_joint
+      mimicjointmsg.velocity[0] = msg.velocity[0]; // sdh_knuckle_joint = sdh_finger_21_joint
+      topicPub_JointState_.publish(mimicjointmsg);
 
+      // publish controller state message
+      control_msgs::JointTrajectoryControllerState controllermsg;
+      controllermsg.header.stamp = time;
+      controllermsg.joint_names.resize(DOF_);
+      controllermsg.desired.positions.resize(DOF_);
+      controllermsg.desired.velocities.resize(DOF_);
+      controllermsg.actual.positions.resize(DOF_);
+      controllermsg.actual.velocities.resize(DOF_);
+      controllermsg.error.positions.resize(DOF_);
+      controllermsg.error.velocities.resize(DOF_);
+      // set joint names and map them to angles
+      controllermsg.joint_names = joint_names_;
+      //['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
+      // desired pos
+      if (targetAngles_.size() != 0)
+      {
+        controllermsg.desired.positions[0] = targetAngles_[0] * pi_ / 180.0; // sdh_knuckle_joint
+        controllermsg.desired.positions[1] = targetAngles_[3] * pi_ / 180.0; // sdh_thumb_2_joint
+        controllermsg.desired.positions[2] = targetAngles_[4] * pi_ / 180.0; // sdh_thumb_3_joint
+        controllermsg.desired.positions[3] = targetAngles_[5] * pi_ / 180.0; // sdh_finger_12_joint
+        controllermsg.desired.positions[4] = targetAngles_[6] * pi_ / 180.0; // sdh_finger_13_joint
+        controllermsg.desired.positions[5] = targetAngles_[1] * pi_ / 180.0; // sdh_finger_22_joint
+        controllermsg.desired.positions[6] = targetAngles_[2] * pi_ / 180.0; // sdh_finger_23_joint
+      }
+      // desired vel
+      // they are all zero
+      // actual pos
+      controllermsg.actual.positions = msg.position;
+      // actual vel
+      controllermsg.actual.velocities = msg.velocity;
+      // error, calculated out of desired and actual values
+      for (int i = 0; i < DOF_; i++)
+      {
+        controllermsg.error.positions[i] = controllermsg.desired.positions[i] - controllermsg.actual.positions[i];
+        controllermsg.error.velocities[i] = controllermsg.desired.velocities[i] - controllermsg.actual.velocities[i];
+      }
+      // publish controller message
+      topicPub_ControllerState_.publish(controllermsg);
 
-			// because the robot_state_publisher doen't know about the mimic joint, we have to publish the coupled joint separately
-			sensor_msgs::JointState  mimicjointmsg;
-			mimicjointmsg.header.stamp = time;
-			mimicjointmsg.name.resize(1);
-			mimicjointmsg.position.resize(1);
-			mimicjointmsg.velocity.resize(1);
-			mimicjointmsg.name[0] = "sdh_finger_21_joint";
-			mimicjointmsg.position[0] = msg.position[0]; // sdh_knuckle_joint = sdh_finger_21_joint
-			mimicjointmsg.velocity[0] = msg.velocity[0]; // sdh_knuckle_joint = sdh_finger_21_joint
-			topicPub_JointState_.publish(mimicjointmsg);
+      // read sdh status
+      state_ = sdh_->GetAxisActualState(axes_);
+    }
+    else
+    {
+      ROS_DEBUG("sdh not initialized");
+    }
+    // publishing diagnotic messages
+    diagnostic_msgs::DiagnosticArray diagnostics;
+    diagnostics.status.resize(1);
+    // set data to diagnostics
+    if (isError_)
+    {
+      diagnostics.status[0].level = 2;
+      diagnostics.status[0].name = "schunk_powercube_chain";
+      diagnostics.status[0].message = "one or more drives are in Error mode";
+    }
+    else
+    {
+      if (isInitialized_)
+      {
+        diagnostics.status[0].level = 0;
+        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
+        diagnostics.status[0].message = "sdh initialized and running";
+      }
+      else
+      {
+        diagnostics.status[0].level = 1;
+        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
+        diagnostics.status[0].message = "sdh not initialized";
+      }
+    }
+    // publish diagnostic message
+    topicPub_Diagnostics_.publish(diagnostics);
 
-
-			// publish controller state message
-			control_msgs::JointTrajectoryControllerState controllermsg;
-			controllermsg.header.stamp = time;
-			controllermsg.joint_names.resize(DOF_);
-			controllermsg.desired.positions.resize(DOF_);
-			controllermsg.desired.velocities.resize(DOF_);
-			controllermsg.actual.positions.resize(DOF_);
-			controllermsg.actual.velocities.resize(DOF_);
-			controllermsg.error.positions.resize(DOF_);
-			controllermsg.error.velocities.resize(DOF_);
-			// set joint names and map them to angles
-			controllermsg.joint_names = joint_names_;
-			//['sdh_knuckle_joint', 'sdh_thumb_2_joint', 'sdh_thumb_3_joint', 'sdh_finger_12_joint', 'sdh_finger_13_joint', 'sdh_finger_22_joint', 'sdh_finger_23_joint']
-			// desired pos
-			if (targetAngles_.size() != 0)
-			{
-				controllermsg.desired.positions[0] = targetAngles_[0]*pi_/180.0; // sdh_knuckle_joint
-				controllermsg.desired.positions[1] = targetAngles_[3]*pi_/180.0; // sdh_thumb_2_joint
-				controllermsg.desired.positions[2] = targetAngles_[4]*pi_/180.0; // sdh_thumb_3_joint
-				controllermsg.desired.positions[3] = targetAngles_[5]*pi_/180.0; // sdh_finger_12_joint
-				controllermsg.desired.positions[4] = targetAngles_[6]*pi_/180.0; // sdh_finger_13_joint
-				controllermsg.desired.positions[5] = targetAngles_[1]*pi_/180.0; // sdh_finger_22_joint
-				controllermsg.desired.positions[6] = targetAngles_[2]*pi_/180.0; // sdh_finger_23_joint
-			}
-			// desired vel
-				// they are all zero
-			// actual pos
-			controllermsg.actual.positions = msg.position;
-			// actual vel
-			controllermsg.actual.velocities = msg.velocity;
-			// error, calculated out of desired and actual values
-			for (int i = 0; i<DOF_; i++ )
-			{
-				controllermsg.error.positions[i] = controllermsg.desired.positions[i] - controllermsg.actual.positions[i];
-				controllermsg.error.velocities[i] = controllermsg.desired.velocities[i] - controllermsg.actual.velocities[i];
-			}
-			// publish controller message
-			topicPub_ControllerState_.publish(controllermsg);
-
-			// read sdh status
-			state_ = sdh_->GetAxisActualState(axes_);
-		}
-		else
-		{
-			ROS_DEBUG("sdh not initialized");
-		}
-		// publishing diagnotic messages
-	    diagnostic_msgs::DiagnosticArray diagnostics;
-	    diagnostics.status.resize(1);
-	    // set data to diagnostics
-	    if(isError_)
-	    {
-	      diagnostics.status[0].level = 2;
-	      diagnostics.status[0].name = "schunk_powercube_chain";
-	      diagnostics.status[0].message = "one or more drives are in Error mode";
-	    }
-	    else
-	    {
-	      if (isInitialized_)
-	      {
-	        diagnostics.status[0].level = 0;
-	        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
-	        diagnostics.status[0].message = "sdh initialized and running";
-	      }
-	      else
-	      {
-	        diagnostics.status[0].level = 1;
-	        diagnostics.status[0].name = nh_.getNamespace(); //"schunk_powercube_chain";
-	        diagnostics.status[0].message = "sdh not initialized";
-	      }
-	    }
-	    // publish diagnostic message
-	    topicPub_Diagnostics_.publish(diagnostics);
-
-	}
-}; //SdhNode
+  }
+};
+//SdhNode
 
 /*!
-* \brief Main loop of ROS node.
-*
-* Running with a specific frequency defined by loop_rate.
-*/
+ * \brief Main loop of ROS node.
+ *
+ * Running with a specific frequency defined by loop_rate.
+ */
 int main(int argc, char** argv)
 {
-	// initialize ROS, spezify name of node
-	ros::init(argc, argv, "schunk_sdh");
+  // initialize ROS, spezify name of node
+  ros::init(argc, argv, "schunk_sdh");
 
-	SdhNode sdh_node;
-	if (!sdh_node.init()) return 0;
+  SdhNode sdh_node;
+  if (!sdh_node.init())
+    return 0;
 
-	ROS_INFO("...sdh node running...");
+  ROS_INFO("...sdh node running...");
 
-	double frequency;
-	if (sdh_node.nh_private_.hasParam("frequency"))
-	{
-		sdh_node.nh_private_.getParam("frequency", frequency);
-	}
-	else
-	{
-		frequency = 5; //Hz
-		ROS_WARN("Parameter frequency not available, setting to default value: %f Hz", frequency);
-	}
+  double frequency;
+  if (sdh_node.nh_private_.hasParam("frequency"))
+  {
+    sdh_node.nh_private_.getParam("frequency", frequency);
+  }
+  else
+  {
+    frequency = 5; //Hz
+    ROS_WARN("Parameter frequency not available, setting to default value: %f Hz", frequency);
+  }
 
-	//sleep(1);
-	ros::Rate loop_rate(frequency); // Hz
-	while(sdh_node.nh_.ok())
-	{
-		// publish JointState
-		sdh_node.updateSdh();
+  //sleep(1);
+  ros::Rate loop_rate(frequency); // Hz
+  while (sdh_node.nh_.ok())
+  {
+    // publish JointState
+    sdh_node.updateSdh();
 
-		// sleep and waiting for messages, callbacks
-		ros::spinOnce();
-		loop_rate.sleep();
-	}
+    // sleep and waiting for messages, callbacks
+    ros::spinOnce();
+    loop_rate.sleep();
+  }
 
-	return 0;
+  return 0;
 }
 


### PR DESCRIPTION
This PR does not include functional changes. It reformats the Schunk SDH package according to the roscpp style guide, via the Eclipse ROScpp linting/formatting style guide [2], [3]. 
This is a follow up to the initial question in https://github.com/ipa320/cob_common/issues/169, after I've found the guideline in [1] and applied it to the SDH package in this PR. The intention is to reformat the package according to the roscpp style, so that future contributions can be easily linted before making a PR (we have modifications that we'd like to contribute back that would have a lot of whitespace/formatting edits otherwise).

Looking forward to hearing your feedback on this - and also very happy to know if you already have an automated formatting in place for this package that I might have overlooked.

Thanks,
Wolfgang

Links:
[1] https://github.com/ipa320/setup/blob/master/coding_introduction/CodingIntroduction.md#ros-coding-styles
[2] http://wiki.ros.org/CppStyleGuide
[3] http://wiki.ros.org/IDEs#Auto_Formatting
