### PR TITLE
Calibration fix + warning elimination

### DIFF
--- a/schunk_powercube_chain/ros/src/schunk_powercube_chain.cpp
+++ b/schunk_powercube_chain/ros/src/schunk_powercube_chain.cpp
@@ -374,7 +374,10 @@ public:
     std::vector<double> Offsets(DOF);
     for (unsigned int i = 0; i < DOF; i++)
     {
-      Offsets[i] = model.getJoint(JointNames[i].c_str())->calibration->rising.get()[0];
+      if(model.getJoint(JointNames[i].c_str())->calibration == NULL)
+        Offsets[i] = 0.0;
+      else
+        Offsets[i] = model.getJoint(JointNames[i].c_str())->calibration->rising.get()[0];
     }
 
     /// Set parameters

--- a/schunk_sdh/ros/src/sdh_only.cpp
+++ b/schunk_sdh/ros/src/sdh_only.cpp
@@ -152,12 +152,14 @@ public:
    * \param name Name for the actionlib server
    */
   SdhNode() :
-      as_(nh_, "joint_trajectory_controller/follow_joint_trajectory", boost::bind(&SdhNode::executeCB, this, _1), true), action_name_(
+      as_(nh_, "joint_trajectory_controller/follow_joint_trajectory", boost::bind(&SdhNode::executeCB, this, _1), false), action_name_(
           "follow_joint_trajectory")
   {
     nh_private_ = ros::NodeHandle("~");
     pi_ = 3.1415926;
     isError_ = false;
+
+    as_.start();
   }
 
   /*!


### PR DESCRIPTION
Since the calibration tag has been removed from the URDFs, the node crashes when trying to read it. Therefore we added a check and set the default value to 0.0. This is necessary since the "offsets" are still used throughout the powercube chain code

The second commit gets rid of a race condition warning.
