### PR TITLE
Set longer timeout for PCan device

### DIFF
--- a/schunk_libm5api/src/Device/PCanDevice.cpp
+++ b/schunk_libm5api/src/Device/PCanDevice.cpp
@@ -563,7 +563,7 @@ int CPCanDevice::init(const char* acInitString)
 {
 	InitializeCriticalSection(&m_csDevice);
 	int iRetVal = 0;
-	m_uiTimeOut =6;
+	m_uiTimeOut = 100;
         m_iNoOfRetries = 10;
 	char* pcToken;
 	char acString[128];


### PR DESCRIPTION
I tested this with two devices with different baudrates (1M and 250K) and none of them is working with timeout 6. Number 100 is more reliable.
