### PR TITLE
Newer xacro fixes

### DIFF
--- a/schunk_description/urdf/common.xacro
+++ b/schunk_description/urdf/common.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <property name="M_PI" value="3.1415926535897931" />
+  <xacro:property name="M_PI" value="3.1415926535897931" />
 
   <!-- see https://secure.wikimedia.org/wikipedia/en/wiki/List_of_moment_of_inertia_tensors -->
   <xacro:macro name="sphere_inertial" params="radius mass *origin">
     <inertial>
       <mass value="${mass}" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <inertia ixx="${0.4 * mass * radius * radius}" ixy="0.0" ixz="0.0"
         iyy="${0.4 * mass * radius * radius}" iyz="0.0"
         izz="${0.4 * mass * radius * radius}" />
@@ -17,7 +17,7 @@
   <xacro:macro name="cylinder_inertial" params="radius length mass *origin">
     <inertial>
       <mass value="${mass}" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <inertia ixx="${0.0833333 * mass * (3 * radius * radius + length * length)}" ixy="0.0" ixz="0.0"
         iyy="${0.0833333 * mass * (3 * radius * radius + length * length)}" iyz="0.0"
         izz="${0.5 * mass * radius * radius}" />
@@ -27,7 +27,7 @@
   <xacro:macro name="box_inertial" params="x y z mass *origin">
     <inertial>
       <mass value="${mass}" />
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <inertia ixx="${0.0833333 * mass * (y*y + z*z)}" ixy="0.0" ixz="0.0"
         iyy="${0.0833333 * mass * (x*x + z*z)}" iyz="0.0"
         izz="${0.0833333 * mass * (x*x + y*y)}" />

--- a/schunk_description/urdf/lwa/lwa.urdf.xacro
+++ b/schunk_description/urdf/lwa/lwa.urdf.xacro
@@ -8,7 +8,7 @@
 
     <!-- joint between base_link and arm_0_link -->
     <joint name="${name}_base_joint" type="fixed" >
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${name}_base_link" />
     </joint>

--- a/schunk_description/urdf/lwa/lwa.urdf.xacro
+++ b/schunk_description/urdf/lwa/lwa.urdf.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/lwa/lwa.gazebo.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/lwa/lwa.transmission.xacro" />
 

--- a/schunk_description/urdf/lwa4d/lwa4d.urdf.xacro
+++ b/schunk_description/urdf/lwa4d/lwa4d.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <property name="safety_offset" value="0.02"/>
+  <xacro:property name="safety_offset" value="0.02"/>
 
   <xacro:include filename="$(find schunk_description)/urdf/lwa4d/lwa4d.gazebo.xacro"/>
   <xacro:include filename="$(find schunk_description)/urdf/lwa4d/lwa4d.transmission.xacro"/>
@@ -23,7 +23,7 @@
     <xacro:if value="${has_podest}">
       <!-- joint between base_link and lwa4p_extended_connector_link -->
       <joint name="${name}_podest_joint" type="fixed">
-        <insert_block name="origin" />
+        <xacro:insert_block name="origin" />
         <parent link="${parent}"/>
         <child link="${name}_podest_link"/>
       </joint>
@@ -53,7 +53,7 @@
     <xacro:unless value="${has_podest}">
       <!-- joint between base_link and lwa4p_extended_connector_link -->
       <joint name="${name}_base_joint" type="fixed">
-        <insert_block name="origin" />
+        <xacro:insert_block name="origin" />
         <parent link="${parent}"/>
         <child link="${name}_base_link"/>
       </joint>

--- a/schunk_description/urdf/lwa4d/lwa4d.urdf.xacro
+++ b/schunk_description/urdf/lwa4d/lwa4d.urdf.xacro
@@ -2,6 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="safety_offset" value="0.02"/>
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/lwa4d/lwa4d.gazebo.xacro"/>
   <xacro:include filename="$(find schunk_description)/urdf/lwa4d/lwa4d.transmission.xacro"/>
   

--- a/schunk_description/urdf/lwa4p/lwa4p.urdf.xacro
+++ b/schunk_description/urdf/lwa4p/lwa4p.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <property name="safety_offset" value="0.02"/>
+  <xacro:property name="safety_offset" value="0.02"/>
 
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p/lwa4p.gazebo.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p/lwa4p.transmission.xacro" />
@@ -10,7 +10,7 @@
     <xacro:if value="${has_podest}">
       <!-- joint between base_link and lwa4p_extended_connector_link -->
       <joint name="${name}_podest_joint" type="fixed">
-        <insert_block name="origin" />
+        <xacro:insert_block name="origin" />
         <parent link="${parent}"/>
         <child link="${name}_podest_link"/>
       </joint>
@@ -41,7 +41,7 @@
     <xacro:unless value="${has_podest}">
       <!-- joint between base_link and lwa4p_extended_connector_link -->
       <joint name="${name}_base_joint" type="fixed">
-        <insert_block name="origin" />
+        <xacro:insert_block name="origin" />
         <parent link="${parent}"/>
         <child link="${name}_base_link"/>
       </joint>

--- a/schunk_description/urdf/lwa4p/lwa4p.urdf.xacro
+++ b/schunk_description/urdf/lwa4p/lwa4p.urdf.xacro
@@ -2,6 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="safety_offset" value="0.02"/>
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p/lwa4p.gazebo.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p/lwa4p.transmission.xacro" />
 

--- a/schunk_description/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro
+++ b/schunk_description/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <property name="safety_offset" value="0.02"/>
+  <xacro:property name="safety_offset" value="0.02"/>
 
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p_extended/lwa4p_extended.gazebo.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p_extended/lwa4p_extended.transmission.xacro" />
@@ -10,7 +10,7 @@
     <xacro:if value="${has_podest}">
       <!-- joint between base_link and lwa4p_extended_connector_link -->
       <joint name="${name}_podest_joint" type="fixed">
-        <insert_block name="origin" />
+        <xacro:insert_block name="origin" />
         <parent link="${parent}"/>
         <child link="${name}_podest_link"/>
       </joint>
@@ -41,7 +41,7 @@
     <xacro:unless value="${has_podest}">
       <!-- joint between base_link and lwa4p_extended_connector_link -->
       <joint name="${name}_base_joint" type="fixed">
-        <insert_block name="origin" />
+        <xacro:insert_block name="origin" />
         <parent link="${parent}"/>
         <child link="${name}_base_link"/>
       </joint>

--- a/schunk_description/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro
+++ b/schunk_description/urdf/lwa4p_extended/lwa4p_extended.urdf.xacro
@@ -2,6 +2,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:property name="safety_offset" value="0.02"/>
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p_extended/lwa4p_extended.gazebo.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/lwa4p_extended/lwa4p_extended.transmission.xacro" />
 

--- a/schunk_description/urdf/lwa_extended/lwa_extended.urdf.xacro
+++ b/schunk_description/urdf/lwa_extended/lwa_extended.urdf.xacro
@@ -8,7 +8,7 @@
 
     <!-- joint between base_link and arm_0_link -->
     <joint name="${name}_0_joint" type="fixed" >
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${name}_0_link" />
     </joint>

--- a/schunk_description/urdf/pw70/pw70.urdf.xacro
+++ b/schunk_description/urdf/pw70/pw70.urdf.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/pw70/pw70.gazebo.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/pw70/pw70.transmission.xacro" />
 

--- a/schunk_description/urdf/sdh/sdh.urdf.xacro
+++ b/schunk_description/urdf/sdh/sdh.urdf.xacro
@@ -8,7 +8,7 @@
 
     <!-- joint between arm_7_link and sdh_palm_link -->
     <joint name="${name}_palm_joint" type="fixed" >
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <parent link="${parent}" />
       <child link="${name}_palm_link" />
     </joint>

--- a/schunk_description/urdf/sdh/sdh.urdf.xacro
+++ b/schunk_description/urdf/sdh/sdh.urdf.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/sdh/sdh.gazebo.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/sdh/sdh.transmission.xacro" />
 


### PR DESCRIPTION
This commits fix the `schunk_description` to newer `xacro` recommendations, removes warnings and fix the `unknown macro name: xacro:default_inertial` when explicitly running new `xacro`

Since the new `xacro` is available in _indigo_ and that the changes do not affect older `xacro`, this should be no problem to merge.
