### PR TITLE
Harmonize/Simplify urdfs

### DIFF
--- a/schunk_description/urdf/common.xacro
+++ b/schunk_description/urdf/common.xacro
@@ -42,4 +42,18 @@
     </inertial>
   </xacro:macro>
 
+  <xacro:macro name="default_transmission" params="jname">
+    <transmission name="${jname}_trans">
+      <type>transmission_interface/SimpleTransmission</type>
+      <joint name="${jname}_joint">
+        <hardwareInterface>PositionJointInterface</hardwareInterface>
+        <hardwareInterface>VelocityJointInterface</hardwareInterface>
+        <!--hardwareInterface>EffortJointInterface</hardwareInterface-->
+      </joint>
+      <actuator name="${jname}_motor">
+        <mechanicalReduction>1</mechanicalReduction>
+      </actuator>
+    </transmission>
+  </xacro:macro>
+
 </robot>

--- a/schunk_description/urdf/lwa/lwa.transmission.xacro
+++ b/schunk_description/urdf/lwa/lwa.transmission.xacro
@@ -1,84 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
+
   <xacro:macro name="schunk_lwa_transmission" params="name">
 
-    <transmission name="${name}_1_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_1_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_1_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_2_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_2_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_2_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_3_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_3_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_3_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_4_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_4_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_4_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_5_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_5_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_5_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_6_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_6_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_6_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_7_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_7_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_7_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
+    <xacro:default_transmission jname="${name}_1"/>
+    <xacro:default_transmission jname="${name}_2"/>
+    <xacro:default_transmission jname="${name}_3"/>
+    <xacro:default_transmission jname="${name}_4"/>
+    <xacro:default_transmission jname="${name}_5"/>
+    <xacro:default_transmission jname="${name}_6"/>
+    <xacro:default_transmission jname="${name}_7"/>
 
   </xacro:macro>
 

--- a/schunk_description/urdf/lwa4d/lwa4d.transmission.xacro
+++ b/schunk_description/urdf/lwa4d/lwa4d.transmission.xacro
@@ -1,28 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="schunk_lwa4d_SimpleTransmission" params="jname number">
-    <transmission name="${jname}_${number}_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${jname}_${number}_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${jname}_${number}_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-  </xacro:macro>
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
 
   <xacro:macro name="schunk_lwa4d_transmission" params="name">
 
-    <xacro:schunk_lwa4d_SimpleTransmission jname="${name}" number="1"></xacro:schunk_lwa4d_SimpleTransmission>
-    <xacro:schunk_lwa4d_SimpleTransmission jname="${name}" number="2"></xacro:schunk_lwa4d_SimpleTransmission>
-    <xacro:schunk_lwa4d_SimpleTransmission jname="${name}" number="3"></xacro:schunk_lwa4d_SimpleTransmission>
-    <xacro:schunk_lwa4d_SimpleTransmission jname="${name}" number="4"></xacro:schunk_lwa4d_SimpleTransmission>
-    <xacro:schunk_lwa4d_SimpleTransmission jname="${name}" number="5"></xacro:schunk_lwa4d_SimpleTransmission>
-    <xacro:schunk_lwa4d_SimpleTransmission jname="${name}" number="6"></xacro:schunk_lwa4d_SimpleTransmission>
-    <xacro:schunk_lwa4d_SimpleTransmission jname="${name}" number="7"></xacro:schunk_lwa4d_SimpleTransmission>
+    <xacro:default_transmission jname="${name}_1"/>
+    <xacro:default_transmission jname="${name}_2"/>
+    <xacro:default_transmission jname="${name}_3"/>
+    <xacro:default_transmission jname="${name}_4"/>
+    <xacro:default_transmission jname="${name}_5"/>
+    <xacro:default_transmission jname="${name}_6"/>
+    <xacro:default_transmission jname="${name}_7"/>
 
   </xacro:macro>
 

--- a/schunk_description/urdf/lwa4p/lwa4p.transmission.xacro
+++ b/schunk_description/urdf/lwa4p/lwa4p.transmission.xacro
@@ -1,73 +1,16 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
+
   <xacro:macro name="schunk_lwa4p_transmission" params="name">
 
-    <transmission name="${name}_1_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_1_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_1_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_2_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_2_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_2_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_3_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_3_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_3_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_4_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_4_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_4_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_5_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_5_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_5_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_6_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_6_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_6_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
+    <xacro:default_transmission jname="${name}_1"/>
+    <xacro:default_transmission jname="${name}_2"/>
+    <xacro:default_transmission jname="${name}_3"/>
+    <xacro:default_transmission jname="${name}_4"/>
+    <xacro:default_transmission jname="${name}_5"/>
+    <xacro:default_transmission jname="${name}_6"/>
 
   </xacro:macro>
 

--- a/schunk_description/urdf/lwa4p_extended/lwa4p_extended.transmission.xacro
+++ b/schunk_description/urdf/lwa4p_extended/lwa4p_extended.transmission.xacro
@@ -1,28 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="schunk_lwa4p_extended_SimpleTransmission" params="jname number">
-    <transmission name="${jname}_${number}_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${jname}_${number}_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${jname}_${number}_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-  </xacro:macro>
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
 
   <xacro:macro name="schunk_lwa4p_extended_transmission" params="name">
 
-    <xacro:schunk_lwa4p_extended_SimpleTransmission jname="${name}" number="1"></xacro:schunk_lwa4p_extended_SimpleTransmission>
-    <xacro:schunk_lwa4p_extended_SimpleTransmission jname="${name}" number="2"></xacro:schunk_lwa4p_extended_SimpleTransmission>
-    <xacro:schunk_lwa4p_extended_SimpleTransmission jname="${name}" number="3"></xacro:schunk_lwa4p_extended_SimpleTransmission>
-    <xacro:schunk_lwa4p_extended_SimpleTransmission jname="${name}" number="4"></xacro:schunk_lwa4p_extended_SimpleTransmission>
-    <xacro:schunk_lwa4p_extended_SimpleTransmission jname="${name}" number="5"></xacro:schunk_lwa4p_extended_SimpleTransmission>
-    <xacro:schunk_lwa4p_extended_SimpleTransmission jname="${name}" number="6"></xacro:schunk_lwa4p_extended_SimpleTransmission>
-    <xacro:schunk_lwa4p_extended_SimpleTransmission jname="${name}" number="7"></xacro:schunk_lwa4p_extended_SimpleTransmission>
+    <xacro:default_transmission jname="${name}_1"/>
+    <xacro:default_transmission jname="${name}_2"/>
+    <xacro:default_transmission jname="${name}_3"/>
+    <xacro:default_transmission jname="${name}_4"/>
+    <xacro:default_transmission jname="${name}_5"/>
+    <xacro:default_transmission jname="${name}_6"/>
+    <xacro:default_transmission jname="${name}_7"/>
 
   </xacro:macro>
 

--- a/schunk_description/urdf/lwa_extended/lwa_extended.transmission.xacro
+++ b/schunk_description/urdf/lwa_extended/lwa_extended.transmission.xacro
@@ -1,77 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
+
   <xacro:macro name="schunk_lwa_extended_transmission" params="name">
 
-    <transmission name="${name}_1_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_1_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_1_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_2_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_2_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_2_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_3_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_3_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_3_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_4_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_4_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_4_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_5_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_5_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_5_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_6_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_6_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_6_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_7_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_7_joint">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_7_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
+    <xacro:default_transmission jname="${name}_1"/>
+    <xacro:default_transmission jname="${name}_2"/>
+    <xacro:default_transmission jname="${name}_3"/>
+    <xacro:default_transmission jname="${name}_4"/>
+    <xacro:default_transmission jname="${name}_5"/>
+    <xacro:default_transmission jname="${name}_6"/>
+    <xacro:default_transmission jname="${name}_7"/>
 
   </xacro:macro>
 

--- a/schunk_description/urdf/pg70/pg70.transmission.xacro
+++ b/schunk_description/urdf/pg70/pg70.transmission.xacro
@@ -1,33 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
+
   <xacro:macro name="schunk_pg70_transmission" params="name">
 
-    <!-- finger1 -->
-    <transmission name="${name}_finger_left_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_finger_left_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_finger_left_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <!-- finger2 - mimic -->
-    <transmission name="${name}_finger_right_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_finger_right_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_finger_right_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
+    <xacro:default_transmission jname="${name}_finger_left"/>
+    <xacro:default_transmission jname="${name}_finger_right"/>
 
   </xacro:macro>
 

--- a/schunk_description/urdf/pg70/pg70.urdf.xacro
+++ b/schunk_description/urdf/pg70/pg70.urdf.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/pg70/pg70.gazebo.xacro" />
   <xacro:include filename="$(find schunk_description)/urdf/pg70/pg70.transmission.xacro" />
 
@@ -8,7 +9,7 @@
 
     <xacro:if value="${has_podest}">
       <joint name="${name}_podest_joint" type="fixed">
-        <insert_block name="origin" />
+        <xacro:insert_block name="origin" />
         <parent link="${parent}"/>
         <child link="${name}_podest_link"/>
       </joint>
@@ -38,7 +39,7 @@
 
     <xacro:unless value="${has_podest}">
       <joint name="${name}_palm_joint" type="fixed">
-        <insert_block name="origin" />
+        <xacro:insert_block name="origin" />
         <parent link="${parent}"/>
         <child link="${name}_palm_link" />
       </joint>

--- a/schunk_description/urdf/pw70/pw70.transmission.xacro
+++ b/schunk_description/urdf/pw70/pw70.transmission.xacro
@@ -1,33 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="schunk_pg70_transmission" params="name">
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
 
-    <!-- finger1 -->
-    <transmission name="${name}_pan_rotation">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_pan_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_pan_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
+  <xacro:macro name="schunk_pw70_transmission" params="name">
 
-    <!-- finger2 - mimic -->
-    <transmission name="${name}_tilt_rotation">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_tilt_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-        <hardwareInterface>VelocityJointInterface</hardwareInterface>
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_tilt_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
+    <xacro:default_transmission jname="${name}_pan"/>
+    <xacro:default_transmission jname="${name}_tilt"/>
 
   </xacro:macro>
 

--- a/schunk_description/urdf/pw70/pw70.urdf.xacro
+++ b/schunk_description/urdf/pw70/pw70.urdf.xacro
@@ -175,7 +175,6 @@
     <xacro:schunk_pw70_gazebo name="${name}" />
     <xacro:schunk_pw70_transmission name="${name}" />
 
-
   </xacro:macro>
 </robot>
 

--- a/schunk_description/urdf/sdh/sdh.gazebo.xacro
+++ b/schunk_description/urdf/sdh/sdh.gazebo.xacro
@@ -55,10 +55,6 @@
       <gravity>true</gravity>
       <self_collide>false</self_collide>
       <material>Schunk/LightGrey</material>
-      <!--mu1 value="500" />
-      <mu2 value="500" />
-      <kp value="1000000.0" />
-      <kd value="1.0" /-->
     </gazebo>
 
     <gazebo reference="${name}_finger_22_link">
@@ -138,14 +134,6 @@
         </plugin>
       </sensor>
     </gazebo>
-
-    <!--gazebo reference="${name}_finger_21_joint">
-      <stopKd value='1.0' />
-      <stopKp value='10000000' />
-      <fudgeFactor value='1.0' />
-      <provideFeedback value="true"/>
-    </gazebo-->
-
 
   </xacro:macro>
 

--- a/schunk_description/urdf/sdh/sdh.transmission.xacro
+++ b/schunk_description/urdf/sdh/sdh.transmission.xacro
@@ -1,90 +1,18 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+  <xacro:include filename="$(find schunk_description)/urdf/common.xacro" />
+
   <xacro:macro name="schunk_sdh_transmission" params="name">
 
-    <transmission name="${name}_finger_21_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_finger_21_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_finger_21_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_knuckle_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_knuckle_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_knuckle_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <!-- finger1 -->
-    <transmission name="${name}_finger_12_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_finger_12_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_finger_12_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_finger_13_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_finger_13_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_finger_13_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <!-- finger2 -->
-    <transmission name="${name}_finger_22_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_finger_22_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_finger_22_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_finger_23_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_finger_23_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_finger_23_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <!-- thumb -->
-    <transmission name="${name}_thumb_2_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_thumb_2_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_thumb_2_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
-
-    <transmission name="${name}_thumb_3_trans">
-      <type>transmission_interface/SimpleTransmission</type>
-      <joint name="${name}_thumb_3_joint">
-        <hardwareInterface>PositionJointInterface</hardwareInterface>
-      </joint>
-      <actuator name="${name}_thumb_3_motor">
-        <mechanicalReduction>1</mechanicalReduction>
-      </actuator>
-    </transmission>
+    <xacro:default_transmission jname="${name}_finger_21"/>
+    <xacro:default_transmission jname="${name}_knuckle"/>
+    <xacro:default_transmission jname="${name}_finger_12"/>
+    <xacro:default_transmission jname="${name}_finger_13"/>
+    <xacro:default_transmission jname="${name}_finger_22"/>
+    <xacro:default_transmission jname="${name}_finger_23"/>
+    <xacro:default_transmission jname="${name}_thumb_2"/>
+    <xacro:default_transmission jname="${name}_thumb_3"/>
 
   </xacro:macro>
 


### PR DESCRIPTION
This PR applies changes from #171 to components that were missed.

It also simplifies the transmission macros for all components by introducing a default_transmission which provides the standard interfaces Position (used for FollowJointTrajectory) and Velocity (used for TwistControl). As was required for #176.
This only affects simulation!