### PR TITLE
Services for disabling motors

### DIFF
--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -622,6 +622,7 @@ public:
    */
   bool srvCallback_EmergencyStop(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res) {
       try {
+        isInitialized_ = false;
         sdh_->EmergencyStop();
         sdh_->SetAxisEnable(sdh_->All, 0.0);
         sdh_->SetAxisMotorCurrent(sdh_->All, 0.0);
@@ -647,6 +648,7 @@ public:
    */
   bool srvCallback_Disconnect(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res) {
       try {
+        isInitialized_ = false;
         sdh_->Close();
       }
       catch(const SDH::cSDHErrorCommunication* e) {

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -561,21 +561,6 @@ public:
   }
 
   /*!
-   * \brief Executes the service callback for recover.
-   *
-   * Recovers the hardware after an emergency stop.
-   * \param req Service request
-   * \param res Service response
-   */
-  bool srvCallback_Recover(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res)
-  {
-    ROS_WARN("Service recover not implemented yet");
-    res.success = true;
-    res.message = "Service recover not implemented yet";
-    return true;
-  }
-
-  /*!
    * \brief Executes the service callback for set_operation_mode.
    *
    * Changes the operation mode.

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -642,23 +642,29 @@ public:
   /*!
    * \brief Executes the service callback for disconnect.
    *
-   * Disconnect from SDH and disable motors to prevent overheating.
+   * Disconnect from SDH and DSA and disable motors to prevent overheating.
    * \param req Service request
    * \param res Service response
    */
   bool srvCallback_Disconnect(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res) {
       try {
         isInitialized_ = false;
+        isDSAInitialized_ = false;
+
+        sdh_->SetAxisEnable(sdh_->All, 0.0);
+        sdh_->SetAxisMotorCurrent(sdh_->All, 0.0);
+
         sdh_->Close();
+        dsa_->Close();
       }
-      catch(const SDH::cSDHErrorCommunication* e) {
+      catch(const SDH::cSDHLibraryException* e) {
           ROS_ERROR("An exception was caught: %s", e->what());
           res.success = false;
           res.message = e->what();
           return false;
       }
 
-      ROS_INFO("Disconnected from sdh");
+      ROS_INFO("Disconnected");
       res.success = true;
       return true;
   }

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -117,6 +117,8 @@ private:
   ros::ServiceServer srvServer_Stop_;
   ros::ServiceServer srvServer_Recover_;
   ros::ServiceServer srvServer_SetOperationMode_;
+  ros::ServiceServer srvServer_EmergencyStop_;
+  ros::ServiceServer srvServer_Disconnect_;
 
   // actionlib server
   actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> as_;
@@ -210,6 +212,8 @@ public:
     srvServer_Recover_ = nh_.advertiseService("recover", &SdhNode::srvCallback_Init, this);  // HACK: There is no recover implemented yet, so we execute a init
     srvServer_SetOperationMode_ = nh_.advertiseService("set_operation_mode", &SdhNode::srvCallback_SetOperationMode,
                                                        this);
+    srvServer_EmergencyStop_ = nh_.advertiseService("emergency_stop", &SdhNode::srvCallback_EmergencyStop, this);
+    srvServer_Disconnect_ = nh_.advertiseService("disconnect", &SdhNode::srvCallback_Disconnect, this);
 
     subSetVelocitiesRaw_ = nh_.subscribe("joint_group_velocity_controller/command", 1,
                                          &SdhNode::topicCallback_setVelocitiesRaw, this);
@@ -607,6 +611,54 @@ public:
       ROS_ERROR_STREAM("Operation mode '" << req.data << "'  not supported");
     }
     return true;
+  }
+
+  /*!
+   * \brief Executes the service callback for emergency_stop.
+   *
+   * Performs an emergency stop.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_EmergencyStop(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res) {
+      try {
+        sdh_->EmergencyStop();
+        sdh_->SetAxisEnable(sdh_->All, 0.0);
+        sdh_->SetAxisMotorCurrent(sdh_->All, 0.0);
+      }
+      catch(const SDH::cSDHLibraryException* e) {
+          ROS_ERROR("An exception was caught: %s", e->what());
+          res.success = false;
+          res.message = e->what();
+          return false;
+      }
+
+      res.success = true;
+      res.message = "EMERGENCY stop";
+      return true;
+  }
+
+  /*!
+   * \brief Executes the service callback for disconnect.
+   *
+   * Disconnect from SDH and disable motors to prevent overheating.
+   * \param req Service request
+   * \param res Service response
+   */
+  bool srvCallback_Disconnect(std_srvs::Trigger::Request &req, std_srvs::Trigger::Response &res) {
+      try {
+        sdh_->Close();
+      }
+      catch(const SDH::cSDHErrorCommunication* e) {
+          ROS_ERROR("An exception was caught: %s", e->what());
+          res.success = false;
+          res.message = e->what();
+          return false;
+      }
+
+      ROS_INFO("Disconnected from sdh");
+      res.success = true;
+      return true;
   }
 
   /*!

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -631,7 +631,7 @@ public:
           ROS_ERROR("An exception was caught: %s", e->what());
           res.success = false;
           res.message = e->what();
-          return false;
+          return true;
       }
 
       res.success = true;
@@ -661,7 +661,7 @@ public:
           ROS_ERROR("An exception was caught: %s", e->what());
           res.success = false;
           res.message = e->what();
-          return false;
+          return true;
       }
 
       ROS_INFO("Disconnected");

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -213,7 +213,7 @@ public:
     srvServer_SetOperationMode_ = nh_.advertiseService("set_operation_mode", &SdhNode::srvCallback_SetOperationMode,
                                                        this);
     srvServer_EmergencyStop_ = nh_.advertiseService("emergency_stop", &SdhNode::srvCallback_EmergencyStop, this);
-    srvServer_Disconnect_ = nh_.advertiseService("disconnect", &SdhNode::srvCallback_Disconnect, this);
+    srvServer_Disconnect_ = nh_.advertiseService("shutdown", &SdhNode::srvCallback_Disconnect, this);
 
     subSetVelocitiesRaw_ = nh_.subscribe("joint_group_velocity_controller/command", 1,
                                          &SdhNode::topicCallback_setVelocitiesRaw, this);


### PR DESCRIPTION
Expose services `emergency_stop` and `disconnect`:
- `emergency_stop` uses `EmergencyStop()`
- `disconnect` uses `Close()` to shutdown the node and prevent overheating

After using these services, the node needs to be initialised again by the `init` service.

The procedure to prevent overheating during grasping would be:
(power on) > `init` > send joint trajectory > `disconnect` > (power off)