### PR TITLE
Publish temperatures for monitoring overheating

### DIFF
--- a/schunk_sdh/CMakeLists.txt
+++ b/schunk_sdh/CMakeLists.txt
@@ -12,6 +12,7 @@ add_message_files(
   DIRECTORY msg FILES
     TactileMatrix.msg
     TactileSensor.msg
+    TemperatureArray.msg
 )
 
 generate_messages(

--- a/schunk_sdh/CMakeLists.txt
+++ b/schunk_sdh/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(schunk_sdh)
 
+add_compile_options(-std=c++11)
+
 find_package(catkin REQUIRED COMPONENTS actionlib cob_srvs control_msgs diagnostic_msgs libntcan libpcan message_generation roscpp roslint sensor_msgs std_msgs std_srvs trajectory_msgs urdf)
 
 find_package(Boost REQUIRED)

--- a/schunk_sdh/msg/TemperatureArray.msg
+++ b/schunk_sdh/msg/TemperatureArray.msg
@@ -1,0 +1,4 @@
+Header header
+
+string[] name           # list of sensor name
+float64[] temperature   # list of temperature in degree Celcius (°C)


### PR DESCRIPTION
Publish all temperature readings as `TemperatureArray` on topic `temperature`. The names of the temperature sensors are currently hard coded in `temperature_names_` since there is no way to retrieve them from the API.

This PR depends on PR https://github.com/ipa320/schunk_modular_robotics/pull/192 and already includes its changes. I am happy to rebase this PR on `indigo_dev` if it should be merged first.