### PR TITLE
Motor power switch

### DIFF
--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -535,6 +535,7 @@ public:
     }
 
     res.success = true;
+    res.message = "SDH initialised";
     return true;
   }
 
@@ -562,6 +563,7 @@ public:
 
     ROS_INFO("Stopping sdh succesfull");
     res.success = true;
+    res.message = "stopped SDH";
     return true;
   }
 
@@ -579,6 +581,7 @@ public:
     ROS_INFO("Set operation mode to [%s]", req.data.c_str());
     operationMode_ = req.data;
     res.success = true;
+    res.message = "Set operation mode to "+req.data;
     if (operationMode_ == "position")
     {
       sdh_->SetController(SDH::cSDH::eCT_POSE);
@@ -656,6 +659,7 @@ public:
 
       ROS_INFO("Disconnected");
       res.success = true;
+      res.message = "disconnected from SDH";
       return true;
   }
 

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -455,14 +455,14 @@ public:
           ROS_INFO("Initialized RS232 for SDH");
           isInitialized_ = true;
         }
-        if (sdhdevicetype_.compare("PCAN") == 0)
+        else if (sdhdevicetype_.compare("PCAN") == 0)
         {
           ROS_INFO("Starting initializing PEAKCAN");
           sdh_->OpenCAN_PEAK(baudrate_, timeout_, id_read_, id_write_, sdhdevicestring_.c_str());
           ROS_INFO("Initialized PEAK CAN for SDH");
           isInitialized_ = true;
         }
-        if (sdhdevicetype_.compare("ESD") == 0)
+        else if (sdhdevicetype_.compare("ESD") == 0)
         {
           ROS_INFO("Starting initializing ESD");
           if (strcmp(sdhdevicestring_.c_str(), "/dev/can0") == 0)
@@ -484,6 +484,12 @@ public:
           }
           ROS_INFO("Initialized ESDCAN for SDH");
           isInitialized_ = true;
+        }
+        else
+        {
+            ROS_ERROR("Unknown SDH device type: %s", sdhdevicetype_.c_str());
+            res.success = false;
+            res.message = "Unknown SDH device type: " + sdhdevicetype_;
         }
       }
       catch (const SDH::cSDHLibraryException &e)

--- a/schunk_sdh/ros/src/sdh.cpp
+++ b/schunk_sdh/ros/src/sdh.cpp
@@ -298,10 +298,9 @@ public:
       }
       sdh_->SetAxisEnable(sdh_->All, 1.0);  // TODO: check if necessary
     }
-    catch (SDH::cSDHLibraryException* e)
+    catch (const SDH::cSDHLibraryException &e)
     {
-      ROS_ERROR("An exception was caught: %s", e->what());
-      delete e;
+      ROS_ERROR("An exception was caught: %s", e.what());
       return false;
     }
 
@@ -487,12 +486,11 @@ public:
           isInitialized_ = true;
         }
       }
-      catch (SDH::cSDHLibraryException* e)
+      catch (const SDH::cSDHLibraryException &e)
       {
-        ROS_ERROR("An exception was caught: %s", e->what());
+        ROS_ERROR("An exception was caught: %s", e.what());
         res.success = false;
-        res.message = e->what();
-        delete e;
+        res.message = e.what();
         return true;
       }
 
@@ -510,13 +508,12 @@ public:
           //  dsa_->SetMatrixSensitivity(i, 1.0);
           isDSAInitialized_ = true;
         }
-        catch (SDH::cSDHLibraryException* e)
+        catch (const SDH::cSDHLibraryException &e)
         {
           isDSAInitialized_ = false;
-          ROS_ERROR("An exception was caught: %s", e->what());
+          ROS_ERROR("An exception was caught: %s", e.what());
           res.success = false;
-          res.message = e->what();
-          delete e;
+          res.message = e.what();
           return true;
         }
       }
@@ -555,10 +552,9 @@ public:
     {
       sdh_->Stop();
     }
-    catch (SDH::cSDHLibraryException* e)
+    catch (const SDH::cSDHLibraryException &e)
     {
-      ROS_ERROR("An exception was caught: %s", e->what());
-      delete e;
+      ROS_ERROR("An exception was caught: %s", e.what());
     }
 
     ROS_INFO("Stopping sdh succesfull");
@@ -593,10 +589,9 @@ public:
         sdh_->SetController(SDH::cSDH::eCT_VELOCITY);
         sdh_->SetAxisEnable(sdh_->All, 1.0);
       }
-      catch (SDH::cSDHLibraryException* e)
+      catch (const SDH::cSDHLibraryException &e)
       {
-        ROS_ERROR("An exception was caught: %s", e->what());
-        delete e;
+        ROS_ERROR("An exception was caught: %s", e.what());
       }
     }
     else
@@ -620,10 +615,10 @@ public:
         sdh_->SetAxisEnable(sdh_->All, 0.0);
         sdh_->SetAxisMotorCurrent(sdh_->All, 0.0);
       }
-      catch(const SDH::cSDHLibraryException* e) {
-          ROS_ERROR("An exception was caught: %s", e->what());
+      catch(const SDH::cSDHLibraryException &e) {
+          ROS_ERROR("An exception was caught: %s", e.what());
           res.success = false;
-          res.message = e->what();
+          res.message = e.what();
           return true;
       }
 
@@ -650,10 +645,10 @@ public:
         sdh_->Close();
         dsa_->Close();
       }
-      catch(const SDH::cSDHLibraryException* e) {
-          ROS_ERROR("An exception was caught: %s", e->what());
+      catch(const SDH::cSDHLibraryException &e) {
+          ROS_ERROR("An exception was caught: %s", e.what());
           res.success = false;
-          res.message = e->what();
+          res.message = e.what();
           return true;
       }
 
@@ -673,10 +668,10 @@ public:
       sdh_->SetAxisEnable(sdh_->All, 1.0);
       sdh_->SetAxisMotorCurrent(sdh_->All, 0.5);
     }
-    catch (const SDH::cSDHLibraryException* e) {
-      ROS_ERROR("An exception was caught: %s", e->what());
+    catch (const SDH::cSDHLibraryException &e) {
+      ROS_ERROR("An exception was caught: %s", e.what());
       res.success = false;
-      res.message = e->what();
+      res.message = e.what();
       return true;
     }
     ROS_INFO("Motor power ON");
@@ -695,10 +690,10 @@ public:
       sdh_->SetAxisEnable(sdh_->All, 0.0);
       sdh_->SetAxisMotorCurrent(sdh_->All, 0.0);
     }
-    catch (const SDH::cSDHLibraryException* e) {
-      ROS_ERROR("An exception was caught: %s", e->what());
+    catch (const SDH::cSDHLibraryException &e) {
+      ROS_ERROR("An exception was caught: %s", e.what());
       res.success = false;
-      res.message = e->what();
+      res.message = e.what();
       return true;
     }
     ROS_INFO("Motor power OFF");
@@ -725,10 +720,9 @@ public:
         {
           sdh_->Stop();
         }
-        catch (SDH::cSDHLibraryException* e)
+        catch (const SDH::cSDHLibraryException &e)
         {
-          ROS_ERROR("An exception was caught: %s", e->what());
-          delete e;
+          ROS_ERROR("An exception was caught: %s", e.what());
         }
 
         if (operationMode_ == "position")
@@ -740,10 +734,9 @@ public:
             sdh_->SetAxisTargetAngle(axes_, targetAngles_);
             sdh_->MoveHand(false);
           }
-          catch (SDH::cSDHLibraryException* e)
+          catch (const SDH::cSDHLibraryException &e)
           {
-            ROS_ERROR("An exception was caught: %s", e->what());
-            delete e;
+            ROS_ERROR("An exception was caught: %s", e.what());
           }
         }
         else if (operationMode_ == "velocity")
@@ -754,10 +747,9 @@ public:
             sdh_->SetAxisTargetVelocity(axes_, velocities_);
             // ROS_DEBUG_STREAM("velocities: " << velocities_[0] << " "<< velocities_[1] << " "<< velocities_[2] << " "<< velocities_[3] << " "<< velocities_[4] << " "<< velocities_[5] << " "<< velocities_[6]);
           }
-          catch (SDH::cSDHLibraryException* e)
+          catch (const SDH::cSDHLibraryException &e)
           {
-            ROS_ERROR("An exception was caught: %s", e->what());
-            delete e;
+            ROS_ERROR("An exception was caught: %s", e.what());
           }
         }
         else if (operationMode_ == "effort")
@@ -781,20 +773,18 @@ public:
       {
         actualAngles = sdh_->GetAxisActualAngle(axes_);
       }
-      catch (SDH::cSDHLibraryException* e)
+      catch (const SDH::cSDHLibraryException &e)
       {
-        ROS_ERROR("An exception was caught: %s", e->what());
-        delete e;
+        ROS_ERROR("An exception was caught: %s", e.what());
       }
       std::vector<double> actualVelocities;
       try
       {
         actualVelocities = sdh_->GetAxisActualVelocity(axes_);
       }
-      catch (SDH::cSDHLibraryException* e)
+      catch (const SDH::cSDHLibraryException &e)
       {
-        ROS_ERROR("An exception was caught: %s", e->what());
-        delete e;
+        ROS_ERROR("An exception was caught: %s", e.what());
       }
 
       ROS_DEBUG("received %d angles from sdh", static_cast<int>(actualAngles.size()));
@@ -950,10 +940,9 @@ public:
           // dsa_->SetFramerate( 0, true, true );
           dsa_->UpdateFrame();
         }
-        catch (SDH::cSDHLibraryException* e)
+        catch (const SDH::cSDHLibraryException &e)
         {
-          ROS_ERROR("An exception was caught: %s", e->what());
-          delete e;
+          ROS_ERROR("An exception was caught: %s", e.what());
         }
       }
 


### PR DESCRIPTION
As extension to https://github.com/ipa320/schunk_modular_robotics/pull/192 and as proposed by @wxmerkt in https://github.com/ipab-slmc/schunk_modular_robotics/blob/forward-format_bitbucket/schunk_sdh/ros/src/sdh.cpp#L677-L699, I finally implemented the motor power on/off services that only power on/off the motors and keep the controller active for a faster on/off cycle.

There are additional minor changes to catch by reference (instead of pointer) and provide additional status messages for service calls.