### PR TITLE
fix PG+70 limits and simplify collision model

### DIFF
--- a/schunk_description/urdf/pg70/pg70.urdf.xacro
+++ b/schunk_description/urdf/pg70/pg70.urdf.xacro
@@ -57,8 +57,9 @@
         </geometry>
       </visual>
       <collision>
+        <origin xyz="0 0 ${0.040-0.5*0.0171}" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://schunk_description/meshes/pg70/pg70.stl" />
+          <box size="0.082 0.114 0.080" />
         </geometry>
       </collision>
     </link>
@@ -69,7 +70,7 @@
       <parent link="${name}_palm_link" />
       <child link="${name}_finger_left_link" />
       <axis xyz="0 1 0" />
-      <limit effort="10" lower="-0.001" upper="0.061" velocity="2.0"/>
+      <limit effort="10" lower="-0.001" upper="0.0301" velocity="0.041"/>
     </joint>
 
     <link name="${name}_finger_left_link">
@@ -103,7 +104,7 @@
       <child link="${name}_finger_right_link" />
       <axis xyz="0 -1 0" />
       <mimic joint="${name}_finger_left_joint" multiplier="1" offset="0"/>
-      <limit effort="10" lower="-0.001" upper="0.061" velocity="2.0"/>
+      <limit effort="10" lower="-0.001" upper="0.0301" velocity="0.041"/>
     </joint>
 
     <link name="${name}_finger_right_link">


### PR DESCRIPTION
The gripper fingers both can move 30mm according to the datasheet
to give a distance of 60mm between the fingers.
The _finger_palm_link can be easily simplified as a box geometry
for faster collision checking.

As driver we configured `ros_canopen` with
```yaml
nodes:
 plwa_gripper_finger_left_joint:
    id: 12
    # Scaling: The gripper pos is stated (over CAN) for both fingers, 
    # but is needed as pos for single finger in URDF-Modell.
    pos_to_device: "pos*1e6*2"
    pos_from_device: "obj6064*5e-7"
```