### PR TITLE
Deactivate definition of 'abs' function

### DIFF
--- a/schunk_libm5api/CMakeLists.txt
+++ b/schunk_libm5api/CMakeLists.txt
@@ -13,7 +13,7 @@ catkin_package(
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(m5api  src/Device/Device.cpp  src/Device/ProtocolDevice.cpp  src/Device/ESDDevice.cpp  src/Device/PCanDevice.cpp  src/Device/SocketCANDevice.cpp  src/Device/ProtocolMessage.cpp  src/Device/RS232Device.cpp  src/Util/Random.cpp  src/Util/Message.cpp src/Util/StopWatch.cpp  src/Util/IOFunctions.cpp  src/Util/Thread.cpp  src/M5apiw32/m5apiw32.cpp)
-set_target_properties(m5api PROPERTIES COMPILE_FLAGS "-D__LINUX__ -DUSE_PCAN -DUSE_ESD -DUSE_SOCKET_CAN")
+set_target_properties(m5api PROPERTIES COMPILE_FLAGS "-D__LINUX__ -DUSE_PCAN -DUSE_ESD -DUSE_SOCKET_CAN -DNO_ABS_FCT")
 target_link_libraries(m5api ${catkin_LIBRARIES})
 
 ### INSTALL ###


### PR DESCRIPTION
On Ubuntu 18.04 / ROS melodic I receive errors about the overloaded abs function:
```
Util/InlineFunctions.h:84:28: error: ‘long int abs(long int)’ conflicts with a previous declaration
 inline long abs(long iValue) 
[...]
Util/InlineFunctions.h:89:37: error: call of overloaded ‘abs(long int&)’ is ambiguous
  return static_cast<long>(abs(iValue));
[...]
Util/InlineFunctions.h:104:30: error: ‘float abs(float)’ conflicts with a previous declaration
 inline float abs(float fValue)
[...]
```

This PR uses the provided flag `NO_ABS_FCT` to deactivate the definitions of `abs` functions and hence tells the compiler to use `std::abs` instead.
Maybe we can also remove the definitions of `abs` completely since it is already defined in the C+ standard functions.
