### PR TITLE
remove visual representation of virtual SDH grasp and tip links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,12 @@ env:
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
     - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=file
     - ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
+    - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=file
+    - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
 matrix:
   allow_failures:
-    - env: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
-    - env: ROS_DISTRO=kinetic UPSTREAM_WORKSPACE=debian
+    - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=file
+    - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/schunk_description/urdf/sdh/sdh.urdf.xacro
+++ b/schunk_description/urdf/sdh/sdh.urdf.xacro
@@ -42,21 +42,7 @@
       <child link="${name}_grasp_link" />
     </joint>
 
-    <link name="${name}_grasp_link">
-      <xacro:default_inertial/>
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <box size="0.001 0.001 0.001" />
-        </geometry>
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <box size="0.001 0.001 0.001" />
-        </geometry>
-      </collision>
-    </link>
+    <link name="${name}_grasp_link" />
 
     <!-- tip link -->
     <joint name="${name}_tip_joint" type="fixed" >
@@ -65,21 +51,7 @@
       <child link="${name}_tip_link" />
     </joint>
 
-    <link name="${name}_tip_link">
-      <xacro:default_inertial/>
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <box size="0.001 0.001 0.001" />
-        </geometry>
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
-        <geometry>
-          <box size="0.001 0.001 0.001" />
-        </geometry>
-      </collision>
-    </link>
+    <link name="${name}_tip_link" />
 
     <!-- finger1 -->
     <!-- joint between sdh_palm_link and sdh_finger_11_link -->


### PR DESCRIPTION
The xacro files for the Schunk SDH define visuals for the virtual grasp and tip links (shown as red boxes):
![sdh_virtual_links](https://user-images.githubusercontent.com/8226248/46435370-1fd17f80-c74e-11e8-998f-cfa56d85b91b.png)

This PR removes all properties of these two virtual links/frames.