### PR TITLE
Use separately released SDHLibrary-CPP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "SDHLibrary-CPP"]
-	path = SDHLibrary-CPP
-	url = https://github.com/ipab-slmc/SDHLibrary-CPP.git
-	branch = master

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,1 +1,12 @@
-# empty
+- git:
+    uri: 'https://github.com/ipa320/cob_common.git'
+    local-name: cob_common
+    version: indigo_dev
+- git:
+    uri: 'https://github.com/ipa320/cob_extern.git'
+    local-name: cob_extern
+    version: indigo_dev
+- git:
+    uri: https://github.com/ipab-slmc/SDHLibrary-CPP.git
+    local-name: SDHLibrary-CPP
+    version: 0.2.10

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,8 +1,0 @@
-- git:
-    uri: 'https://github.com/ipa320/cob_common.git'
-    local-name: cob_common
-    version: indigo_dev
-- git:
-    uri: 'https://github.com/ipa320/cob_extern.git'
-    local-name: cob_extern
-    version: indigo_dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
     on_failure: always
 env:
   global:
-    - ROS_REPO=ros
+    - ROS_REPO=ros-testing
   matrix:
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file
     - ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: generic
 notifications:
   email:
@@ -17,8 +17,8 @@ env:
     - ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
 matrix:
   allow_failures:
-    - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=file
-    - env: ROS_DISTRO=melodic UPSTREAM_WORKSPACE=debian
+    - env: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=file
+    - env: ROS_DISTRO=indigo UPSTREAM_WORKSPACE=debian
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:


### PR DESCRIPTION
This PR removes the [`SDHLibrary-CPP`](https://github.com/ipab-slmc/SDHLibrary-CPP) as a submodule from the repo and depends on the [separately released](https://github.com/ipab-slmc/SDHLibrary-CPP-release) version of it. The main reason for this is to be able to release the library and the actual ROS node independently and prevent unnecessary version bumping of `SDHLibrary-CPP` whenever a new version of the ROS node gets released.

The CI now uses the shadow repo to test with unreleased dependencies. Since ROS `indigo` is EOL, there will be no further releases of packages upstream and it, therefore, has been set as an optional CI dependency. In preparation of a release, `melodic` is now a mandatory CI dependency.