### PR TITLE
remove dependency on linux headers

### DIFF
--- a/schunk_powercube_chain/package.xml
+++ b/schunk_powercube_chain/package.xml
@@ -22,7 +22,6 @@
   <depend>diagnostic_msgs</depend>
   <depend>libntcan</depend>
   <depend>libpcan</depend>
-  <depend>linux-headers-generic</depend>
   <depend>roscpp</depend>
   <depend>schunk_libm5api</depend>
   <depend>sensor_msgs</depend>


### PR DESCRIPTION
Similar to https://github.com/ipa320/cob_extern/pull/100, remove the dependency on the linux headers for `schunk_powercube_chain`.
I don't see any reference to the linux headers in the `schunk_powercube_chain` other than "Added linux-headers-generic as dependency" in https://github.com/ipa320/schunk_modular_robotics/blob/kinetic_dev/schunk_powercube_chain/CHANGELOG.rst#068-2016-10-10.

I really want to remove the old kernel and headers but keep the Schunk packages :-)