### PR TITLE
release 0.6.14

### DIFF
--- a/schunk_description/CHANGELOG.rst
+++ b/schunk_description/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog for package schunk_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.14 (2019-11-20)
+-------------------
+* Merge pull request `#217 <https://github.com/ipa320/schunk_modular_robotics/issues/217>`_ from crthilakraj/indigo_dev
+  Changed the origin of the left and right finger joints to avoid collision
+* changed the origin of the left and right finger joints to avoid collision
+* Merge pull request `#216 <https://github.com/ipa320/schunk_modular_robotics/issues/216>`_ from tobigs/indigo_dev
+  Gazebo segfault fix
+* Prepended PositionJointInterface and VelocityJointInterface with hardware_interface/ to prevent gazebo segfaults
+* Merge pull request `#215 <https://github.com/ipa320/schunk_modular_robotics/issues/215>`_ from ipa320/indigo_release_candidate
+  Indigo release candidate
+* Merge branch 'indigo_dev' into indigo_release_candidate
+* Merge branch 'indigo_dev' of github.com:ipa320/schunk_modular_robotics into indigo_release_candidate
+* Merge pull request `#199 <https://github.com/ipa320/schunk_modular_robotics/issues/199>`_ from ipa320/indigo_dev
+  Indigo dev
+* Contributors: Christian Rauch, Felix Messmer, Tobias Seidel, chikmagalore.thilak, fmessmer
+
 0.6.13 (2019-08-20)
 -------------------
 * Merge pull request `#213 <https://github.com/ipa320/schunk_modular_robotics/issues/213>`_ from PilzDE/remove-gazebo-depend

--- a/schunk_description/package.xml
+++ b/schunk_description/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>schunk_description</name>
-  <version>0.6.13</version>
+  <version>0.6.14</version>
   <description>This package contains the description (mechanical, kinematic, visual,
   etc.) of different schunk components. The files in this package are parsed and used by
   a variety of other components. Most users will not interact directly

--- a/schunk_libm5api/CHANGELOG.rst
+++ b/schunk_libm5api/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package schunk_libm5api
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.14 (2019-11-20)
+-------------------
+* Merge pull request `#215 <https://github.com/ipa320/schunk_modular_robotics/issues/215>`_ from ipa320/indigo_release_candidate
+  Indigo release candidate
+* Merge branch 'indigo_dev' into indigo_release_candidate
+* Merge branch 'indigo_dev' of github.com:ipa320/schunk_modular_robotics into indigo_release_candidate
+* Merge pull request `#199 <https://github.com/ipa320/schunk_modular_robotics/issues/199>`_ from ipa320/indigo_dev
+  Indigo dev
+* Contributors: Christian Rauch, Felix Messmer, fmessmer
+
 0.6.13 (2019-08-20)
 -------------------
 * Merge pull request `#207 <https://github.com/ipa320/schunk_modular_robotics/issues/207>`_ from christian-rauch/no_abs

--- a/schunk_libm5api/package.xml
+++ b/schunk_libm5api/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>schunk_libm5api</name>
-  <version>0.6.13</version>
+  <version>0.6.14</version>
   <description>This package wraps the libm5api to use it as a ros dependency. Original sources from http://www.schunk-modular-robotics.com/fileadmin/user_upload/software/schunk_libm5api_source.zip.</description>
 
   <license>Apache 2.0</license>

--- a/schunk_modular_robotics/CHANGELOG.rst
+++ b/schunk_modular_robotics/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package schunk_modular_robotics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.14 (2019-11-20)
+-------------------
+* Merge pull request `#215 <https://github.com/ipa320/schunk_modular_robotics/issues/215>`_ from ipa320/indigo_release_candidate
+  Indigo release candidate
+* Merge branch 'indigo_dev' into indigo_release_candidate
+* Merge branch 'indigo_dev' of github.com:ipa320/schunk_modular_robotics into indigo_release_candidate
+* Merge pull request `#199 <https://github.com/ipa320/schunk_modular_robotics/issues/199>`_ from ipa320/indigo_dev
+  Indigo dev
+* Contributors: Christian Rauch, Felix Messmer, fmessmer
+
 0.6.13 (2019-08-20)
 -------------------
 

--- a/schunk_modular_robotics/package.xml
+++ b/schunk_modular_robotics/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>schunk_modular_robotics</name>
-  <version>0.6.13</version>
+  <version>0.6.14</version>
   <description>This stack includes packages that provide access to the Schunk hardware through ROS messages, services and actions.</description>
 
   <license>Apache 2.0</license>

--- a/schunk_powercube_chain/CHANGELOG.rst
+++ b/schunk_powercube_chain/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog for package schunk_powercube_chain
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.14 (2019-11-20)
+-------------------
+* Merge pull request `#218 <https://github.com/ipa320/schunk_modular_robotics/issues/218>`_ from christian-rauch/rm_dep_linux_header
+  remove dependency on linux headers
+* remove dependency on linux headers
+* Merge pull request `#215 <https://github.com/ipa320/schunk_modular_robotics/issues/215>`_ from ipa320/indigo_release_candidate
+  Indigo release candidate
+* Merge branch 'indigo_dev' into indigo_release_candidate
+* Merge branch 'indigo_dev' of github.com:ipa320/schunk_modular_robotics into indigo_release_candidate
+* Merge pull request `#199 <https://github.com/ipa320/schunk_modular_robotics/issues/199>`_ from ipa320/indigo_dev
+  Indigo dev
+* Contributors: Christian Rauch, Felix Messmer, fmessmer
+
 0.6.13 (2019-08-20)
 -------------------
 

--- a/schunk_powercube_chain/package.xml
+++ b/schunk_powercube_chain/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>schunk_powercube_chain</name>
-  <version>0.6.13</version>
+  <version>0.6.14</version>
   <description>This packages provides a configurable driver of a chain
   of Schunk powercubes. The powercube chain is configured
   through parameters. Most users will not directly interact

--- a/schunk_sdh/CHANGELOG.rst
+++ b/schunk_sdh/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package schunk_sdh
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.14 (2019-11-20)
+-------------------
+* Merge pull request `#215 <https://github.com/ipa320/schunk_modular_robotics/issues/215>`_ from ipa320/indigo_release_candidate
+  Indigo release candidate
+* Merge branch 'indigo_dev' into indigo_release_candidate
+* Merge branch 'indigo_dev' of github.com:ipa320/schunk_modular_robotics into indigo_release_candidate
+* Merge pull request `#199 <https://github.com/ipa320/schunk_modular_robotics/issues/199>`_ from ipa320/indigo_dev
+  Indigo dev
+* Contributors: Christian Rauch, Felix Messmer, fmessmer
+
 0.6.13 (2019-08-20)
 -------------------
 * Merge pull request `#212 <https://github.com/ipa320/schunk_modular_robotics/issues/212>`_ from christian-rauch/sdhlib_source

--- a/schunk_sdh/package.xml
+++ b/schunk_sdh/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>schunk_sdh</name>
-  <version>0.6.13</version>
+  <version>0.6.14</version>
   <description>This package provides an interface for operating the schunk dexterous hand (SDH), including the tactile sensors.</description>
 
   <license>Apache 2.0</license>

--- a/schunk_simulated_tactile_sensors/CHANGELOG.rst
+++ b/schunk_simulated_tactile_sensors/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package schunk_simulated_tactile_sensors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.14 (2019-11-20)
+-------------------
+* Merge pull request `#215 <https://github.com/ipa320/schunk_modular_robotics/issues/215>`_ from ipa320/indigo_release_candidate
+  Indigo release candidate
+* Merge branch 'indigo_dev' into indigo_release_candidate
+* Merge branch 'indigo_dev' of github.com:ipa320/schunk_modular_robotics into indigo_release_candidate
+* Merge pull request `#199 <https://github.com/ipa320/schunk_modular_robotics/issues/199>`_ from ipa320/indigo_dev
+  Indigo dev
+* Contributors: Christian Rauch, Felix Messmer, fmessmer
+
 0.6.13 (2019-08-20)
 -------------------
 

--- a/schunk_simulated_tactile_sensors/package.xml
+++ b/schunk_simulated_tactile_sensors/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>schunk_simulated_tactile_sensors</name>
-  <version>0.6.13</version>
+  <version>0.6.14</version>
   <description>This package provides simulated tactile sensors for the Schunk Dextrous
      Hand (SDH) which is mounted on the Care-O-bot arm. The node subscribes to
      the Gazebo bumper topics of the SDH. It transforms the Gazebo feedback to


### PR DESCRIPTION
Prepare the release for 0.6.14 for `kinetic` and `melodic`.
This will use the release branch `kinetic_release_candidate` because of breaking changes with `indigo`: https://github.com/ipa320/schunk_modular_robotics/pull/216#issuecomment-547879073.